### PR TITLE
chore(otlp-stdout-span-exporter): bump version to 0.6.0

### DIFF
--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,17 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2024-01-17
+## [0.6.0] - 2025-02-09
+
+### Changed
+- Version bump to align with lambda-otel-utils and other packages
+
+## [0.1.2] - 2025-01-17
 
 ### Changed
 - Modified export implementation to perform work synchronously and return a resolved future, making the behavior more explicit
 
-## [0.1.1] - 2024-01-16
+## [0.1.1] - 2025-01-16
 
 ### Fixed
 - Fixed resource attributes not being properly set in the exporter by moving `set_resource` implementation into the `SpanExporter` trait implementation block 
 
-## [0.1.0] - 2024-01-15
+## [0.1.0] - 2025-01-15
 
 ### Added
 - Initial release of the otlp-stdout-span-exporter


### PR DESCRIPTION
This pull request updates the changelog for the `otlp-stdout-span-exporter` package. The most important change is the version bump to align with other related packages.

Changes to the changelog:

* [`packages/rust/otlp-stdout-span-exporter/CHANGELOG.md`](diffhunk://#diff-51c986c5bb8e2e0e9f9c5ecc6f5ac74d2f94a63485f77b241081dc12820081ffL8-R23): Updated the version to 0.6.0 and added a note about the version bump to align with `lambda-otel-utils` and other packages.