### PR TITLE
feat: update OTLP stdout Kinesis processor configuration and dependencies

### DIFF
--- a/experimental/otlp-stdout-kinesis-processor/extension/layer/Cargo.toml
+++ b/experimental/otlp-stdout-kinesis-processor/extension/layer/Cargo.toml
@@ -1,18 +1,15 @@
 [package]
-name = "otlp-stdout-kinesis-extension"
+name = "otlp-stdout-kinesis-extension-layer"
 version = "0.1.0"
 edition = "2021"
-authors = ["Alessandro Bologna <alessandro.bologna@gmail.com>"]
-license = "MIT"
-rust-version = "1.70"
+authors.workspace = true
+license.workspace = true
 description = "OpenTelemetry Lambda extension for sending otlp data to Kinesis"
 
-[workspace]
-
 [dependencies]
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
+tokio.workspace = true
+tracing.workspace = true
+aws-config.workspace = true
 aws-sdk-kinesis = { version = "1", default-features = false, features = ["rt-tokio"] }
 lambda-extension = { version = "0.11.0" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tracing = { version = "0.1", features = ["log"] }
 uuid = { version = "1.0", features = ["v4"] }

--- a/experimental/otlp-stdout-kinesis-processor/extension/layer/Makefile
+++ b/experimental/otlp-stdout-kinesis-processor/extension/layer/Makefile
@@ -2,8 +2,9 @@
 # This builds the extension for ARM64 architecture and copies it to the artifacts directory
 # The extension is used to capture and process Lambda telemetry events
 
+
 build-StdoutKinesisOTLPLayer:
 	@echo "Building Rust extension layer"
 	@cargo lambda build --release --extension --arm64
 	@echo "Copying extension layer to artifacts directory"
-	@cp -r target/lambda/extensions "$(ARTIFACTS_DIR)"
+	@cp "$(shell cargo metadata --format-version=1 | jq -r '.target_directory')/lambda/extensions/otlp-stdout-kinesis-extension-layer" "$(ARTIFACTS_DIR)"

--- a/experimental/otlp-stdout-kinesis-processor/extension/samconfig.toml
+++ b/experimental/otlp-stdout-kinesis-processor/extension/samconfig.toml
@@ -1,4 +1,7 @@
 version = 0.1
+[default.build.parameters]
+build_in_source = true
+
 [default.deploy.parameters]
 stack_name = "kinesis-extension"
 resolve_s3 = true

--- a/experimental/otlp-stdout-kinesis-processor/extension/template.yaml
+++ b/experimental/otlp-stdout-kinesis-processor/extension/template.yaml
@@ -8,6 +8,7 @@ Resources:
     Type: AWS::Serverless::LayerVersion
     Metadata:
       BuildMethod: makefile
+      BuildArchitecture: arm64
     Properties:
       LayerName: !Sub '${AWS::StackName}-rust-extension'
       ContentUri: layer/


### PR DESCRIPTION
This pull request includes several updates to the `otlp-stdout-kinesis-processor` extension to improve its configuration and build process. The most important changes include renaming the package, updating dependencies to use workspace settings, modifying the Makefile for better build output management, and adding build parameters to the SAM configuration.

Configuration and dependencies updates:

* [`experimental/otlp-stdout-kinesis-processor/extension/layer/Cargo.toml`](diffhunk://#diff-d86c962401bcfc47aa9f6750bf91d6c99221c0d19b74fa01c43201901eec75f4L2-L17): Renamed the package to `otlp-stdout-kinesis-extension-layer`, updated dependencies to use workspace settings for `authors`, `license`, `tokio`, `tracing`, and `aws-config`.

Build process improvements:

* [`experimental/otlp-stdout-kinesis-processor/extension/layer/Makefile`](diffhunk://#diff-198e63403d21b3698868873530e5ec747ecac1a6d8d29be3113d3de4f9c4c4b4R5-R10): Modified the build command to use `cargo metadata` for determining the target directory, ensuring the correct path for the extension layer.
* [`experimental/otlp-stdout-kinesis-processor/extension/samconfig.toml`](diffhunk://#diff-b4e53d1f567cd44af288a04f72a4f10160bf9c8be385f4b6d6c338940bbe6b90R2-R4): Added `build_in_source` parameter to the default build parameters to enable in-source builds.
* [`experimental/otlp-stdout-kinesis-processor/extension/template.yaml`](diffhunk://#diff-92530515a8c46464f25be4eba26330d9751fa6b5da131471cfd759ac00d65a59R11): Added `BuildArchitecture: arm64` to the `Resources` section to specify the architecture for the build process.