### PR TITLE
ci: add required permissions for GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-python-lambda-otel-lite.yml
+++ b/.github/workflows/publish-python-lambda-otel-lite.yml
@@ -13,6 +13,11 @@ on:
     paths:
       - 'packages/python/lambda_otel_lite/**'
 
+# Add permissions needed for the workflow
+permissions:
+  contents: write  # Needed for pushing tags
+  id-token: write # Needed for publishing to PyPI
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/publish-python-lambda-otel-lite.yml` file. The change adds necessary permissions for the workflow to function correctly.

Permissions added:

* `contents: write` - Needed for pushing tags
* `id-token: write` - Needed for publishing to PyPI