### PR TITLE
Release/node lambda otel lite 0.8.1

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2025-02-22
+
+### Fixed
+- Fixed API Gateway v2 event extraction to use `rawPath` as `http.route` when `routeKey` is `$default`
+- Aligned Python and Node.js implementations for consistent attribute extraction behavior
+
 ## [0.8.0] - 2025-02-21
 
 ### Breaking Changes

--- a/packages/node/lambda-otel-lite/__tests__/handler.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/handler.test.ts
@@ -196,7 +196,7 @@ describe('createTracedHandler', () => {
 
       // Verify the expected attributes
       expect(attributesSet.get('faas.trigger')).toBe('http');
-      expect(attributesSet.get('http.route')).toBe('$default');
+      expect(attributesSet.get('http.route')).toBe('/path/to/resource');
       expect(attributesSet.get('http.request.method')).toBe('POST');
       expect(attributesSet.get('url.path')).toBe('/path/to/resource');
       expect(attributesSet.get('url.scheme')).toBe('https');

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
This pull request includes updates to the `lambda-otel-lite` package to improve attribute extraction consistency and fix issues with API Gateway v2 event handling. The changes include updates to the `CHANGELOG.md`, `package.json`, and several extractor functions.

### Improvements and Fixes:

* [`packages/node/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR8-R13): Documented the changes for version 0.8.1, including the fix for API Gateway v2 event extraction and alignment of attribute extraction behavior between Python and Node.js implementations.
* [`packages/node/lambda-otel-lite/package.json`](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3): Updated the version from 0.8.0 to 0.8.1.

### Attribute Extraction Enhancements:

* [`packages/node/lambda-otel-lite/src/internal/telemetry/extractors.ts`](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L112-R113): Updated the `defaultExtractor` function to return Lambda context attributes and extract standard OpenTelemetry FaaS attributes. [[1]](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L112-R113) [[2]](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L136-L143)
* [`packages/node/lambda-otel-lite/src/internal/telemetry/extractors.ts`](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L162-L166): Enhanced the `apiGatewayV2Extractor` function to start with default attributes, handle `$default` route key, and set the span name based on the HTTP method and route. [[1]](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L162-L166) [[2]](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L181) [[3]](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L191-L225)
* [`packages/node/lambda-otel-lite/src/internal/telemetry/extractors.ts`](diffhunk://#diff-401343f6c8a4bc6edc7e206ceef24b2b4a5aac47e0b66f374e8d3b74f8ceca03L296-L298): Applied similar enhancements to the `apiGatewayV1Extractor` and `albExtractor` functions to start with default attributes.

### Test Updates:

* [`packages/node/lambda-otel-lite/__tests__/handler.test.ts`](diffhunk://#diff-43cf92b5a265106b35e58dfdd6b7702b4214917dfa6bea6ebe54575ccf561affL199-R199): Updated test expectations to reflect the changes in the `http.route` attribute value.