### PR TITLE
Release/node lambda otel lite 0.9.0

### DIFF
--- a/packages/node/lambda-otel-lite/.eslintrc.js
+++ b/packages/node/lambda-otel-lite/.eslintrc.js
@@ -8,40 +8,65 @@ module.exports = {
   ],
   overrides: [
     {
-      files: ['src/**/*.ts', '__tests__/**/*.ts'],
+      files: ['src/**/*.ts'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
-        project: ['./tsconfig.json', './tsconfig.test.json'],
+        project: ['./tsconfig.json'],
         tsconfigRootDir: __dirname,
         sourceType: 'module'
       },
       plugins: ['@typescript-eslint'],
       extends: [
         'eslint:recommended',
-        'plugin:@typescript-eslint/recommended'
+        'plugin:@typescript-eslint/recommended',
+        'prettier'
       ],
       env: {
-        'node': true,
-        'jest': true
+        'node': true
       },
       rules: {
-        // Essential TypeScript rules
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/no-unused-vars': ['error', { 
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_'
         }],
-
-        // Basic code style
         'semi': ['error', 'always'],
         'quotes': ['error', 'single'],
         'indent': ['error', 2, { 'SwitchCase': 1 }],
-
-        // Best practices
         'eqeqeq': ['error', 'always', { 'null': 'ignore' }],
         'no-console': ['warn', { allow: ['warn', 'error'] }],
         'curly': ['error', 'all']
+      }
+    },
+    {
+      files: ['__tests__/**/*.ts'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        project: ['./tsconfig.test.json'],
+        tsconfigRootDir: __dirname,
+        sourceType: 'module'
+      },
+      plugins: ['@typescript-eslint'],
+      extends: [
+        'eslint:recommended',
+        'plugin:@typescript-eslint/recommended',
+        'prettier'
+      ],
+      env: {
+        'node': true,
+        'jest': true
+      },
+      rules: {
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/no-unused-vars': ['error', { 
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_'
+        }],
+        'semi': ['error', 'always'],
+        'quotes': ['error', 'single'],
+        'indent': ['error', 2, { 'SwitchCase': 1 }]
       }
     },
     {
@@ -53,10 +78,17 @@ module.exports = {
         ecmaVersion: 2020,
         sourceType: 'module'
       },
+      extends: ['eslint:recommended', 'prettier'],
       rules: {
-        'indent': ['error', 2, { 'SwitchCase': 1 }],
+        'no-unused-vars': ['error', {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_'
+        }],
         'semi': ['error', 'always'],
         'quotes': ['error', 'single']
+      },
+      globals: {
+        'Promise': 'readonly'
       }
     }
   ]

--- a/packages/node/lambda-otel-lite/.prettierignore
+++ b/packages/node/lambda-otel-lite/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+coverage/
+node_modules/
+*.d.ts
+package-lock.json 

--- a/packages/node/lambda-otel-lite/.prettierrc.json
+++ b/packages/node/lambda-otel-lite/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+} 

--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-02-22
+
+### Breaking Changes
+- Simplified handler creation API by removing configuration object wrapper:
+  - Old: `createTracedHandler(name, completionHandler, { attributesExtractor })`
+  - New: `createTracedHandler(name, completionHandler, attributesExtractor)`
+- Removed `TracerConfig` interface as it's no longer needed
+
+### Changed
+- Updated examples to use the new direct extractor passing style
+- Improved alignment with Python and Rust implementations
+
 ## [0.8.2] - 2025-02-22
 
 ### Changed

--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `TracerConfig` interface as it's no longer needed
 
 ### Changed
+- Fixed `faas.max_memory` attribute to be in bytes instead of the raw MB value
+- Ensured all numeric attributes are set as numbers instead of strings:
+  - `lambda_otel_lite.lambda_span_processor.queue_size`
+  - `lambda_otel_lite.lambda_span_processor.batch_size`
+  - `lambda_otel_lite.otlp_stdout_span_exporter.compression_level`
+- Added Prettier for code formatting:
+  - Added `.prettierrc.json` configuration
+  - Added `.prettierignore` file
+  - Added format scripts to package.json
+  - Formatted all code according to style guide
 - Updated examples to use the new direct extractor passing style
 - Improved alignment with Python and Rust implementations
 

--- a/packages/node/lambda-otel-lite/PUBLISHING.md
+++ b/packages/node/lambda-otel-lite/PUBLISHING.md
@@ -27,6 +27,8 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 
 ## Code Quality
 - [ ] All tests pass (`npm test`)
+- [ ] Code is properly formatted (`npm run format`)
+- [ ] Format check passes (`npm run format:check`)
 - [ ] Linting passes (`npm run lint`)
 - [ ] TypeScript compilation succeeds (`npm run build`)
 - [ ] No debug code or console.logs (except in logger)
@@ -42,14 +44,16 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 ## Publishing Steps
 1. Update version in `package.json`
 2. Update `CHANGELOG.md`
-3. Run tests: `npm test`
-4. Run linting: `npm run lint`
-5. Clean build: `npm run clean && npm run build`
-6. Commit changes: `git commit -am "Release vX.Y.Z"`
-7. Create git tag: `git tag vX.Y.Z`
-8. Push changes: `git push && git push --tags`
-9. Publish to npm: `npm publish`
-10. Verify package on npm: https://www.npmjs.com/package/@dev7a/lambda-otel-lite
+3. Format code: `npm run format`
+4. Run format check: `npm run format:check`
+5. Run linting: `npm run lint`
+6. Run tests: `npm test`
+7. Clean build: `npm run clean && npm run build`
+8. Commit changes: `git commit -am "Release vX.Y.Z"`
+9. Create git tag: `git tag vX.Y.Z`
+10. Push changes: `git push && git push --tags`
+11. Publish to npm: `npm publish`
+12. Verify package on npm: https://www.npmjs.com/package/@dev7a/lambda-otel-lite
 
 ## Post-Publishing
 - [ ] Verify package installation works: `npm install @dev7a/lambda-otel-lite`

--- a/packages/node/lambda-otel-lite/README.md
+++ b/packages/node/lambda-otel-lite/README.md
@@ -7,11 +7,15 @@ By leveraging Lambda's execution lifecycle and providing multiple processing mod
 >[!IMPORTANT]
 >This package is highly experimental and should not be used in production. Contributions are welcome.
 
+## Requirements
+- Node.js >= 18.0.0
+
 ## Features
 
 - **Flexible Processing Modes**: Support for synchronous, asynchronous, and custom export strategies
 - **Automatic Resource Detection**: Automatic extraction of Lambda environment attributes
 - **Lambda Extension Integration**: Built-in extension for efficient telemetry export
+- **Efficient Memory Usage**: Queue-based buffering to prevent memory growth
 - **AWS Event Support**: Automatic extraction of attributes from common AWS event types (API Gateway v1/v2, ALB)
 - **Flexible Context Propagation**: Support for W3C Trace Context
 - **TypeScript Support**: Full TypeScript type definitions included
@@ -22,45 +26,80 @@ The package follows a modular architecture where each component has a specific r
 
 ```mermaid
 graph TD
-    A[core] --> B[processor]
+    A[telemetry] --> B[processor]
     A --> C[extension]
-    B <--> C
-    D[resource] --> A
+    B --> C
     E[extractors] --> F[handler]
     F --> B
     A --> F
+    H[resource attributes] --> B
+    A --> H
 ```
 
-- **Core**: Core initialization and configuration
+- `telemetry`: Core initialization and configuration
   - Main entry point via `initTelemetry`
   - Configures global tracer and span processors
   - Returns a `TelemetryCompletionHandler` for span lifecycle management
 
-- **Processor**: Lambda-optimized span processor
-  - Configurable queue size implementation
+- `processor`: Lambda-optimized span processor
+  - Queue-based implementation
   - Multiple processing modes
   - Coordinates with extension for async export
 
-- **Extension**: Lambda Extension implementation
+- `extension`: Lambda Extension implementation
   - Manages extension lifecycle and registration
   - Handles span export coordination
   - Implements graceful shutdown
 
-- **Resource**: Resource attribute management
-  - Automatic Lambda attribute detection
-  - Environment-based configuration
-  - Custom attribute support
-
-- **Extractors**: Event processing
-  - Built-in support for API Gateway (v1/v2) and ALB events
+- `extractors`: Event processing
+  - Built-in support for API Gateway and ALB events
   - Extensible interface for custom events
   - W3C Trace Context propagation
 
 ## Installation
 
-Add the package to your project:
 ```bash
+# Install the base package
 npm install --save @dev7a/lambda-otel-lite
+
+# Optional: For OTLP HTTP export support
+npm install --save @opentelemetry/exporter-trace-otlp-http
+```
+
+## Quick Start
+
+```typescript
+import { trace } from '@opentelemetry/api';
+import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
+import { apiGatewayV2Extractor } from '@dev7a/lambda-otel-lite/extractors';
+
+// Initialize telemetry once, outside the handler
+const { tracer, completionHandler } = initTelemetry();
+
+// Create traced handler with configuration
+const traced = createTracedHandler(
+    'my-handler',
+    completionHandler,
+    apiGatewayV2Extractor  // Optional: Use event-specific extractor
+);
+
+function processEvent(event: any) {
+    // Your business logic here
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: "Success" })
+    };
+}
+
+export const handler = traced(async (event, context) => {
+    // Access current span via OpenTelemetry API
+    const currentSpan = trace.getActiveSpan();
+    currentSpan?.setAttribute("custom", "value");
+    
+    // Your handler code here
+    const result = await processEvent(event);
+    return result;
+});
 ```
 
 ## Processing Modes
@@ -71,25 +110,30 @@ The package supports three processing modes for span export:
    - Direct, synchronous export in handler thread
    - Recommended for low-volume telemetry or when latency is not critical
    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=sync`
-   - Does not install a sigterm handler
 
 2. **Async Mode**:
    - Export via Lambda extension using AWS Lambda Extensions API
    - Spans are queued and exported after handler completion
+   - Uses event-based communication between handler and extension
+   - Registers specifically for Lambda INVOKE events
+   - Implements graceful shutdown with SIGTERM handling
+   - Error handling for:
+     - Event communication failures
+     - Export failures
+     - Extension registration issues
    - Best for production use with high telemetry volume
    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=async`
    - Requires extension initialization: `NODE_OPTIONS=--require @dev7a/lambda-otel-lite/extension`
-   - Install a sigterm handler to ensure spans are flushed on shutdown
 
 3. **Finalize Mode**:
-   - Leaves span export to the processor implementation
-   - Best for use with BatchSpanProcessor
+   - Registers extension with no events
+   - Maintains SIGTERM handler for graceful shutdown
+   - Ensures all spans are flushed during shutdown
+   - Compatible with BatchSpanProcessor for custom export strategies
+   - Best for specialized export requirements where you need full control
    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=finalize`
-   - Install a sigterm handler to ensure spans are flushed on shutdown
 
-## Processing Modes Architecture
-
-The async mode leverages Lambda's extension API to optimize perceived latency by deferring span export until after the response is sent to the user. The extension is loaded via Node.js's `--require` flag and uses an event-driven architecture:
+### Async Processing Mode Architecture
 
 ```mermaid
 sequenceDiagram
@@ -100,22 +144,17 @@ sequenceDiagram
     participant LambdaSpanProcessor
     participant OTLPStdoutSpanExporter
 
-    Note over Extension: Loaded via --require
+    Note over Extension: Initialization
     Extension->>Lambda Runtime: Register extension (POST /register)
-    alt Registration Success
-        Lambda Runtime-->>Extension: Extension ID
-        Extension->>Extension: Setup SIGTERM handler
-    else Registration Failure
-        Lambda Runtime-->>Extension: Error
-        Note over Extension: Log error and continue
-    end
-
+    Lambda Runtime-->>Extension: Extension ID
     Extension->>Lambda Runtime: Request next event (GET /next)
-    Lambda Runtime-->>Extension: INVOKE event
 
     Note over Handler: Function execution starts
     Handler->>LambdaSpanProcessor: Add spans during execution
+    Note over LambdaSpanProcessor: Spans stored in fixed-size queue
+
     Handler->>Event Emitter: Emit 'handlerComplete'
+    Note over Handler: Handler returns response
     
     Event Emitter->>Extension: Handle completion
     Extension->>LambdaSpanProcessor: Force flush spans
@@ -126,25 +165,49 @@ sequenceDiagram
     Lambda Runtime->>Extension: SHUTDOWN event
     Extension->>LambdaSpanProcessor: Force flush spans
     LambdaSpanProcessor->>OTLPStdoutSpanExporter: Export remaining spans
-    Extension->>Process: Exit(0)
 ```
 
-Key aspects of the implementation:
+The async mode leverages Lambda's extension API to optimize perceived latency by deferring span export until after the response is sent to the user. The extension is loaded via Node.js's `--require` flag and uses an event-driven architecture:
+
 1. The extension is loaded at startup via `--require` flag
 2. Uses Node.js's built-in `http` module for Lambda API communication
 3. Leverages event emitters for handler completion notification
 4. Single event loop handles both extension and handler code
 5. SIGTERM handler ensures graceful shutdown with span flushing
 
-## Configuration
-### Environment Variables
+## Environment Variables
 
-- `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE`: Processing mode (`sync`, `async`, or `finalize`)
+The package can be configured using the following environment variables:
+
+### Processing Configuration
+- `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE`: Controls span processing strategy
+  - `sync`: Direct export in handler thread (default)
+  - `async`: Deferred export via extension
+  - `finalize`: Custom export strategy
 - `LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE`: Maximum number of spans to queue (default: 2048)
-- `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE`: Maximum batch size for export (default: 512)
-- `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level for span export (default: 6)
-- `OTEL_SERVICE_NAME`: Service name (defaults to Lambda function name)
-- `OTEL_RESOURCE_ATTRIBUTES`: Additional resource attributes in key=value format
+- `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE`: Maximum number of spans to export in each batch (default: 512)
+
+### Resource Configuration
+- `OTEL_SERVICE_NAME`: Override the service name (defaults to function name)
+- `OTEL_RESOURCE_ATTRIBUTES`: Additional resource attributes in key=value,key2=value2 format
+
+### Export Configuration
+- `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: Gzip compression level for stdout exporter
+  - 0: No compression
+  - 1: Best speed
+  - 6: Good balance between size and speed (default)
+  - 9: Best compression
+
+### Logging
+- `AWS_LAMBDA_LOG_LEVEL` or `LOG_LEVEL`: Configure log level (debug, info, warn, error, none)
+
+### AWS Lambda Environment
+The following AWS Lambda environment variables are automatically used for resource attributes:
+- `AWS_REGION`: Region where function runs
+- `AWS_LAMBDA_FUNCTION_NAME`: Function name
+- `AWS_LAMBDA_FUNCTION_VERSION`: Function version
+- `AWS_LAMBDA_LOG_STREAM_NAME`: Log stream name
+- `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`: Function memory size
 
 ## Automatic Attributes extraction
 
@@ -187,59 +250,90 @@ The package adds several resource attributes under the `lambda_otel_lite` namesp
 
 These attributes are automatically added to the resource and can be used to understand the telemetry configuration in your observability backend.
 
-## Usage
+## Error Handling
 
-### Basic Usage
+The package provides automatic error tracking and span status updates based on handler behavior:
 
-The package provides a simple API for instrumenting AWS Lambda functions with OpenTelemetry:
-
+### HTTP Response Status
+If your handler returns a standard HTTP response object, the status code is automatically recorded:
 ```typescript
-import { trace } from '@opentelemetry/api';
-import { createTracedHandler, initTelemetry } from '@dev7a/lambda-otel-lite';
-import { apiGatewayV2Extractor } from '@dev7a/lambda-otel-lite/extractors';
+import { StatusCode } from '@opentelemetry/api';
 
-// Initialize telemetry with default configuration
-const { tracer, completionHandler } = initTelemetry();
-
-// Create a traced handler with a name and optional attribute extractor
-const traced = createTracedHandler(
-  'my-handler',
-  completionHandler,
-  apiGatewayV2Extractor  // Optional: pass extractor directly for automatic attribute extraction
-);
-
-// Use the traced handler to process Lambda events
-export const lambdaHandler = traced(async (event, context) => {
-  // Get current span if needed
-  const currentSpan = trace.getActiveSpan();
-  currentSpan?.setAttribute('custom.attribute', 'value');
-  
-  // Create a child span for a sub-operation
-  return tracer.startActiveSpan('process_request', async (span) => {
+export const handler = traced(async (event, context) => {
     try {
-      span.setAttribute('operation.type', 'process');
-      // ... do some work ...
-      return {
-        statusCode: 200,
-        body: JSON.stringify({ message: 'Hello World' })
-      };
-    } finally {
-      span.end();
+        const result = await processEvent(event);
+        return {
+            statusCode: 200,
+            body: JSON.stringify({ message: "Success" })
+        };
+    } catch (error) {
+        if (error instanceof ValidationError) {
+            // Return a 4xx response - this won't set the span status to ERROR
+            return {
+                statusCode: 400,
+                body: JSON.stringify({ error: error.message })
+            };
+        }
+        // Return a 5xx response - this will set the span status to ERROR
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ error: "Internal error" })
+        };
     }
-  });
 });
 ```
 
+Any response with status code >= 500 will automatically set the span status to ERROR.
+
+### Exception Handling
+While the package will automatically record uncaught exceptions, it's recommended to handle exceptions explicitly in your handler:
+
+```typescript
+import { trace, StatusCode } from '@opentelemetry/api';
+
+export const handler = traced(async (event, context) => {
+    try {
+        // Your code here
+        throw new Error("invalid input");
+    } catch (error) {
+        // Record the error and set appropriate status
+        const currentSpan = trace.getActiveSpan();
+        if (currentSpan) {
+            currentSpan.recordException(error as Error);
+            currentSpan.setStatus({
+                code: StatusCode.ERROR,
+                message: error instanceof Error ? error.message : String(error)
+            });
+        }
+        return {
+            statusCode: 400,
+            body: JSON.stringify({ error: String(error) })
+        };
+    }
+});
+```
+
+This gives you more control over:
+- Which exceptions to record
+- What status code to return
+- What error message to include
+- Whether to set the span status to ERROR
+
+Uncaught exceptions will still be recorded as a fallback, but this should be considered a last resort.
+
+## Advanced Usage
+
 ### Event Extractors
 
-The package provides built-in extractors for common AWS Lambda triggers. You can pass these directly to `createTracedHandler`:
+Built-in extractors for common Lambda triggers:
 
 ```typescript
 import { createTracedHandler, initTelemetry } from '@dev7a/lambda-otel-lite';
 import {
-  apiGatewayV1Extractor,
-  apiGatewayV2Extractor,
-  albExtractor
+    apiGatewayV1Extractor,  // API Gateway REST API
+    apiGatewayV2Extractor,  // API Gateway HTTP API
+    albExtractor,           // Application Load Balancer
+    defaultExtractor        // Basic Lambda attributes
 } from '@dev7a/lambda-otel-lite/extractors';
 
 // Initialize telemetry with default configuration
@@ -247,191 +341,180 @@ const { tracer, completionHandler } = initTelemetry();
 
 // Create handlers for different event types
 export const apiV2Handler = createTracedHandler(
-  'api-v2-handler',
-  completionHandler,
-  apiGatewayV2Extractor
+    'api-v2-handler',
+    completionHandler,
+    apiGatewayV2Extractor
 );
 
 export const apiV1Handler = createTracedHandler(
-  'api-v1-handler',
-  completionHandler,
-  apiGatewayV1Extractor
+    'api-v1-handler',
+    completionHandler,
+    apiGatewayV1Extractor
 );
 
 export const albHandler = createTracedHandler(
-  'alb-handler',
-  completionHandler,
-  albExtractor
+    'alb-handler',
+    completionHandler,
+    albExtractor
 );
+```
 
-// For custom event types, you can create your own extractor function
-const customExtractor = (event: unknown, context: LambdaContext) => ({
-  spanName: 'custom-operation',
-  attributes: {
-    'custom.attribute': 'value',
-    'event.type': 'custom'
-  },
-  trigger: 'custom'
+Custom extractors can be created by implementing the extractor interface:
+
+```typescript
+import { SpanAttributes, TriggerType } from '@dev7a/lambda-otel-lite/types';
+import type { Context as LambdaContext } from 'aws-lambda';
+
+const customExtractor = (event: unknown, context: LambdaContext): SpanAttributes => ({
+    trigger: TriggerType.OTHER,  // Or any custom string
+    attributes: {
+        'custom.attribute': 'value',
+        // ... other attributes
+    },
+    spanName: 'custom-operation',  // Optional
+    carrier: event?.headers,  // Optional: For context propagation
 });
 
 export const customHandler = createTracedHandler(
-  'custom-handler',
-  completionHandler,
-  customExtractor
+    'custom-handler',
+    completionHandler,
+    customExtractor
 );
 ```
 
-### Simple Usage Without Event Extraction
-
-If you don't need automatic attribute extraction, you can omit the extractor:
-
-```typescript
-import { createTracedHandler, initTelemetry } from '@dev7a/lambda-otel-lite';
-
-const { completionHandler } = initTelemetry();
-
-// Create a basic traced handler without event extraction
-export const handler = createTracedHandler(
-  'simple-handler',
-  completionHandler
-)(async (event, context) => {
-  // Your handler code here
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ message: 'Hello World' })
-  };
-});
-```
-
-The extractors handle header normalization consistently across implementations:
-- Headers are normalized to lowercase for case-insensitive lookup
-- The `Host` header is used for `server.address` in API Gateway v1
-- User agent is extracted from `requestContext` when available, falling back to headers
-
-### Custom Resource Attributes
+### Custom Resource
 
 You can provide custom resource attributes during initialization:
 
 ```typescript
-import { createTracedHandler, initTelemetry } from '@dev7a/lambda-otel-lite';
 import { Resource } from '@opentelemetry/resources';
+import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
 
 // Create a custom resource
 const resource = new Resource({
-  'service.version': '1.0.0',
-  'deployment.environment': 'production'
+    'service.version': '1.0.0',
+    'deployment.environment': 'production'
 });
 
 // Initialize with custom resource
 const { tracer, completionHandler } = initTelemetry({
-  resource
+    resource
 });
 
 // Create a traced handler as usual
 export const handler = createTracedHandler(
-  'custom-resource-handler',
-  completionHandler
+    'custom-resource-handler',
+    completionHandler
 )(async (event, context) => {
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ message: 'Hello World' })
-  };
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: 'Hello World' })
+    };
 });
 ```
 
 ### Custom Span Processor
 
-You can use custom span processors for special export needs:
+For advanced use cases, you can use custom span processors:
 
 ```typescript
-import { createTracedHandler, initTelemetry } from '@dev7a/lambda-otel-lite';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
 
-// Create a custom processor
-const processor = new BatchSpanProcessor(new ConsoleSpanExporter());
+// Create a custom processor with OTLP HTTP exporter
+const processor = new BatchSpanProcessor(
+    new OTLPTraceExporter({
+        url: 'https://your-otlp-endpoint/v1/traces'
+    })
+);
 
 // Initialize with custom processor
 const { tracer, completionHandler } = initTelemetry({
-  spanProcessors: [processor]
+    spanProcessors: [processor]
 });
 
 // Create a traced handler as usual
 export const handler = createTracedHandler(
-  'custom-processor-handler',
-  completionHandler
+    'custom-processor-handler',
+    completionHandler
 )(async (event, context) => {
-  return {
-    statusCode: 200,
-    body: JSON.stringify({ message: 'Hello World' })
-  };
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: 'Hello World' })
+    };
 });
 ```
 
-### Advanced Event Extractor Example
+## Local Development
 
-Here's a more complex example showing how to create an extractor for SQS events:
+### Building the Package
 
-```typescript
-import { SpanKind } from '@opentelemetry/api';
-import { createTracedHandler, initTelemetry, TriggerType } from '@dev7a/lambda-otel-lite';
-import type { LambdaContext } from '@dev7a/lambda-otel-lite';
+The package uses static versioning with version numbers defined in both `package.json` and `src/version.ts`. Version tags follow the format `node/lambda-otel-lite/vX.Y.Z` (e.g., `node/lambda-otel-lite/v0.8.0`).
 
-// Custom extractor for SQS events
-function sqsEventExtractor(event: any, context: LambdaContext) {
-  // Check if this is an SQS event
-  if (!event?.Records?.[0]?.eventSource?.includes('aws:sqs')) {
-    return {
-      trigger: TriggerType.Other,
-      kind: SpanKind.INTERNAL,
-      attributes: {}
-    };
-  }
+When building locally:
 
-  const record = event.Records[0];
-  
-  return {
-    trigger: TriggerType.PubSub,
-    kind: SpanKind.CONSUMER,
-    spanName: `process ${record.eventSourceARN.split(':').pop()}`,
-    // Extract trace context from message attributes if present
-    carrier: record.messageAttributes?.['traceparent']?.stringValue 
-      ? { traceparent: record.messageAttributes['traceparent'].stringValue }
-      : undefined,
-    attributes: {
-      'messaging.system': 'aws.sqs',
-      'messaging.destination': record.eventSourceARN,
-      'messaging.destination_kind': 'queue',
-      'messaging.operation': 'process',
-      'messaging.message_id': record.messageId,
-      'aws.sqs.message_group_id': record.attributes.MessageGroupId,
-      'aws.sqs.message_deduplication_id': record.attributes.MessageDeduplicationId,
-    }
-  };
-}
+```bash
+# Install dependencies
+npm install
 
-// Initialize telemetry
-const { tracer, completionHandler } = initTelemetry();
+# Build the package
+npm run build
 
-// Create handler with SQS extractor
-export const handler = createTracedHandler(
-  'sqs-handler',
-  completionHandler,
-  sqsEventExtractor
-)(async (event, context) => {
-  // Create a child span for message processing
-  return tracer.startActiveSpan('process_message', async (span) => {
-    try {
-      // Process SQS message
-      return {
-        statusCode: 200,
-        body: JSON.stringify({ message: 'Message processed' })
-      };
-    } finally {
-      span.end();
-    }
-  });
-});
+# Run tests
+npm test
+```
+
+### Installing for Development
+
+For development, install in link mode:
+
+```bash
+# Clone the repository
+git clone https://github.com/dev7a/lambda-otel-lite.git
+cd lambda-otel-lite
+
+# Install dependencies
+npm install
+
+# Build and link the package
+npm run build
+npm link
+
+# In your project directory
+npm link @dev7a/lambda-otel-lite
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+npm test
+
+# Run with coverage
+npm run test:coverage
+
+# Run specific test file
+npm test -- src/__tests__/handler.test.ts
+
+# Run tests in watch mode
+npm run test:watch
+```
+
+### Code Quality
+
+```bash
+# Format code
+npm run format
+
+# Run linter
+npm run lint
+
+# Run type checker
+npm run type-check
+
+# Run all checks
+npm run check
 ```
 
 ## License

--- a/packages/node/lambda-otel-lite/__tests__/LambdaSpanProcessor.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/LambdaSpanProcessor.test.ts
@@ -31,10 +31,10 @@ describe('LambdaSpanProcessor', () => {
       spanContext: () => ({
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
         spanId: '6e0c63257de34c92',
-        traceFlags: TraceFlags.NONE
-      })
+        traceFlags: TraceFlags.NONE,
+      }),
     };
-    
+
     processor.onStart(createSpan(), context.active());
     processor.onEnd(span);
     expect(exporter.exportCalledTimes).toBe(0);
@@ -78,11 +78,11 @@ describe('LambdaSpanProcessor', () => {
 
   it('should drop spans when maxQueueSize is reached', async () => {
     const processor = new LambdaSpanProcessor(exporter, { maxQueueSize: 1 });
-    
+
     // Add two spans - second one should be dropped
     const span1 = createTestSpan('span-1');
     const span2 = createTestSpan('span-2');
-    
+
     processor.onStart(createSpan(), context.active());
     processor.onEnd(span1);
     processor.onEnd(span2);
@@ -110,7 +110,7 @@ describe('LambdaSpanProcessor', () => {
 
   it('should not accept spans after shutdown', async () => {
     await processor.shutdown();
-    
+
     const span = createTestSpan();
     processor.onStart(createSpan(), context.active());
     processor.onEnd(span);
@@ -122,10 +122,10 @@ describe('LambdaSpanProcessor', () => {
     // Mock export failure
     const failingExporter = new TestSpanExporter();
     failingExporter.exportResult = { code: ExportResultCode.FAILED };
-    
+
     const processor = new LambdaSpanProcessor(failingExporter);
     const span = createTestSpan();
-    
+
     processor.onStart(createSpan(), context.active());
     processor.onEnd(span);
 
@@ -138,19 +138,21 @@ describe('LambdaSpanProcessor', () => {
   it('should handle concurrent span additions', async () => {
     const processor = new LambdaSpanProcessor(exporter, { maxQueueSize: 100 });
     const numSpans = 50;
-    
+
     // Simulate concurrent span additions
-    await Promise.all(Array.from({ length: numSpans }).map(async (_, i) => {
-      const span = createTestSpan(`span-${i}`);
-      processor.onStart(createSpan(), context.active());
-      processor.onEnd(span);
-    }));
+    await Promise.all(
+      Array.from({ length: numSpans }).map(async (_, i) => {
+        const span = createTestSpan(`span-${i}`);
+        processor.onStart(createSpan(), context.active());
+        processor.onEnd(span);
+      })
+    );
 
     await processor.forceFlush();
     expect(exporter.spans.length).toBe(numSpans);
-    
+
     // Verify span order is maintained
-    const spanNames = exporter.spans.map(s => s.name);
+    const spanNames = exporter.spans.map((s) => s.name);
     expect(spanNames).toEqual(Array.from({ length: numSpans }).map((_, i) => `span-${i}`));
   });
 
@@ -159,9 +161,9 @@ describe('LambdaSpanProcessor', () => {
     const testAttributes = {
       'test.key': 'test-value',
       'test.number': 123,
-      'test.bool': true
+      'test.bool': true,
     };
-    
+
     Object.entries(testAttributes).forEach(([key, value]) => {
       span.attributes[key] = value;
     });
@@ -173,4 +175,4 @@ describe('LambdaSpanProcessor', () => {
     expect(exporter.spans.length).toBe(1);
     expect(exporter.spans[0].attributes).toEqual(testAttributes);
   });
-}); 
+});

--- a/packages/node/lambda-otel-lite/__tests__/ProcessorMode.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/ProcessorMode.test.ts
@@ -74,7 +74,9 @@ describe('ProcessorMode', () => {
 
     it('should use provided default mode over global default', () => {
       envManager.setup({ TEST_MODE: undefined });
-      expect(processorModeFromEnv('TEST_MODE', ProcessorMode.Finalize)).toBe(ProcessorMode.Finalize);
+      expect(processorModeFromEnv('TEST_MODE', ProcessorMode.Finalize)).toBe(
+        ProcessorMode.Finalize
+      );
     });
 
     it('should handle non-string environment values', () => {
@@ -87,4 +89,4 @@ describe('ProcessorMode', () => {
       expect(processorModeFromEnv('TEST_MODE')).toBe(ProcessorMode.Sync);
     });
   });
-}); 
+});

--- a/packages/node/lambda-otel-lite/__tests__/handler.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/handler.test.ts
@@ -180,7 +180,7 @@ describe('createTracedHandler', () => {
       const traced = createTracedHandler(
         'test-handler',
         completionHandler,
-        { attributesExtractor: apiGatewayV2Extractor }
+        apiGatewayV2Extractor
       );
       
       const handler = traced(async (_event, _context) => 'success');
@@ -209,7 +209,7 @@ describe('createTracedHandler', () => {
       const traced = createTracedHandler(
         'test-handler',
         completionHandler,
-        { attributesExtractor: apiGatewayV1Extractor }
+        apiGatewayV1Extractor
       );
       
       const handler = traced(async (_event, _context) => 'success');
@@ -238,7 +238,7 @@ describe('createTracedHandler', () => {
       const traced = createTracedHandler(
         'test-handler',
         completionHandler,
-        { attributesExtractor: albExtractor }
+        albExtractor
       );
       
       const handler = traced(async (_event, _context) => 'success');

--- a/packages/node/lambda-otel-lite/__tests__/handler.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/handler.test.ts
@@ -1,20 +1,20 @@
 // Mock OpenTelemetry API
 const mockApi = {
   SpanKind: {
-    SERVER: 'SERVER'
+    SERVER: 'SERVER',
   },
   SpanStatusCode: {
     OK: 'OK',
-    ERROR: 'ERROR'
+    ERROR: 'ERROR',
   },
   ROOT_CONTEXT: {},
   trace: {
     getSpan: jest.fn(),
-    getTracer: jest.fn()
+    getTracer: jest.fn(),
   },
   propagation: {
-    extract: jest.fn().mockReturnValue({})
-  }
+    extract: jest.fn().mockReturnValue({}),
+  },
 };
 
 jest.doMock('@opentelemetry/api', () => mockApi);
@@ -34,14 +34,14 @@ jest.doMock('../src/internal/state', () => ({
   clearState: jest.fn(),
   state: {
     mode: null,
-    extensionInitialized: false
-  }
+    extensionInitialized: false,
+  },
 }));
 
 // Mock cold start functions
 jest.doMock('../src/internal/telemetry/init', () => ({
   isColdStart: jest.fn(),
-  setColdStart: jest.fn()
+  setColdStart: jest.fn(),
 }));
 
 // Import after mocks
@@ -50,7 +50,11 @@ import { jest } from '@jest/globals';
 import { createTracedHandler } from '../src/handler';
 import * as init from '../src/internal/telemetry/init';
 import { TelemetryCompletionHandler } from '../src/internal/telemetry/completion';
-import { apiGatewayV1Extractor, apiGatewayV2Extractor, albExtractor } from '../src/internal/telemetry/extractors';
+import {
+  apiGatewayV1Extractor,
+  apiGatewayV2Extractor,
+  albExtractor,
+} from '../src/internal/telemetry/extractors';
 import { describe, it, beforeEach, expect } from '@jest/globals';
 
 // Import fixtures
@@ -68,34 +72,36 @@ describe('createTracedHandler', () => {
   beforeEach(() => {
     // Reset all mocks
     jest.clearAllMocks();
-        
+
     // Create mock span
     mockSpan = {
       setAttribute: jest.fn(),
       setStatus: jest.fn(),
       end: jest.fn(),
       recordException: jest.fn(),
-      addEvent: jest.fn()
+      addEvent: jest.fn(),
     };
 
     // Create mock tracer
     tracer = {
-      startActiveSpan: jest.fn((name: string, options: any, context: any, fn: (span: any) => Promise<any>) => {
-        return fn(mockSpan);
-      })
+      startActiveSpan: jest.fn(
+        (name: string, options: any, context: any, fn: (span: any) => Promise<any>) => {
+          return fn(mockSpan);
+        }
+      ),
     };
 
     // Create mock span processor
     const _mockSpanProcessor = {
       onStart: jest.fn(),
-      onEnd: jest.fn()
+      onEnd: jest.fn(),
     };
 
     // Create mock completion handler
     completionHandler = {
       complete: jest.fn(),
       shutdown: jest.fn(),
-      getTracer: jest.fn().mockReturnValue(tracer)
+      getTracer: jest.fn().mockReturnValue(tracer),
     } as any;
 
     // Set up default event and context
@@ -106,7 +112,7 @@ describe('createTracedHandler', () => {
       functionName: 'test-function',
       functionVersion: '$LATEST',
       memoryLimitInMB: '128',
-      getRemainingTimeInMillis: () => 1000
+      getRemainingTimeInMillis: () => 1000,
     };
 
     // Mock cold start as true initially
@@ -118,11 +124,8 @@ describe('createTracedHandler', () => {
 
   describe('basic functionality', () => {
     it('should work with basic options', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => 'success');
       const result = await handler(defaultEvent, defaultContext);
 
@@ -134,11 +137,8 @@ describe('createTracedHandler', () => {
 
     it('should set default faas.trigger for non-HTTP events', async () => {
       const event = { type: 'custom' };
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => 'success');
       const result = await handler(event, defaultContext);
 
@@ -155,14 +155,11 @@ describe('createTracedHandler', () => {
         functionName: 'test-function',
         functionVersion: '$LATEST',
         memoryLimitInMB: '128',
-        getRemainingTimeInMillis: () => 1000
+        getRemainingTimeInMillis: () => 1000,
       };
 
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => 'success');
       await handler(defaultEvent, lambdaContext);
 
@@ -177,18 +174,14 @@ describe('createTracedHandler', () => {
 
   describe('API Gateway event handling', () => {
     it('should handle API Gateway v2 events', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler,
-        apiGatewayV2Extractor
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler, apiGatewayV2Extractor);
+
       const handler = traced(async (_event, _context) => 'success');
       await handler(apigwV2Event, defaultContext);
 
       // Get all calls to setAttribute
       const calls = mockSpan.setAttribute.mock.calls;
-            
+
       // Create a map of all attributes that were set
       const attributesSet = new Map<string, string | number | boolean>(
         calls.map(([k, v]: [string, string | number | boolean]) => [k, v])
@@ -206,18 +199,14 @@ describe('createTracedHandler', () => {
     });
 
     it('should handle API Gateway v1 events', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler,
-        apiGatewayV1Extractor
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler, apiGatewayV1Extractor);
+
       const handler = traced(async (_event, _context) => 'success');
       await handler(apigwV1Event, defaultContext);
 
       // Get all calls to setAttribute
       const calls = mockSpan.setAttribute.mock.calls;
-            
+
       // Create a map of all attributes that were set
       const attributesSet = new Map<string, string | number | boolean>(
         calls.map(([k, v]: [string, string | number | boolean]) => [k, v])
@@ -230,23 +219,21 @@ describe('createTracedHandler', () => {
       expect(attributesSet.get('url.path')).toBe('/path/to/resource');
       expect(attributesSet.get('url.scheme')).toBe('https');
       expect(attributesSet.get('user_agent.original')).toBe('Custom User Agent String');
-      expect(attributesSet.get('server.address')).toBe('1234567890.execute-api.us-east-1.amazonaws.com');
+      expect(attributesSet.get('server.address')).toBe(
+        '1234567890.execute-api.us-east-1.amazonaws.com'
+      );
       expect(attributesSet.get('client.address')).toBe('127.0.0.1');
     });
 
     it('should handle ALB events', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler,
-        albExtractor
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler, albExtractor);
+
       const handler = traced(async (_event, _context) => 'success');
       await handler(albEvent, defaultContext);
 
       // Get all calls to setAttribute
       const calls = mockSpan.setAttribute.mock.calls;
-            
+
       // Create a map of all attributes that were set
       const attributesSet = new Map<string, string | number | boolean>(
         calls.map(([k, v]: [string, string | number | boolean]) => [k, v])
@@ -257,23 +244,26 @@ describe('createTracedHandler', () => {
       expect(attributesSet.get('http.request.method')).toBe('POST');
       expect(attributesSet.get('url.path')).toBe('/path/to/resource');
       expect(attributesSet.get('url.scheme')).toBe('http');
-      expect(attributesSet.get('user_agent.original')).toBe('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36');
-      expect(attributesSet.get('server.address')).toBe('lambda-alb-123578498.us-east-2.elb.amazonaws.com');
+      expect(attributesSet.get('user_agent.original')).toBe(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36'
+      );
+      expect(attributesSet.get('server.address')).toBe(
+        'lambda-alb-123578498.us-east-2.elb.amazonaws.com'
+      );
       expect(attributesSet.get('client.address')).toBe('72.12.164.125');
-      expect(attributesSet.get('alb.target_group_arn')).toBe('arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/lambda-279XGJDqGZ5rsrHC2Fjr/49e9d65c45c6791a');
+      expect(attributesSet.get('alb.target_group_arn')).toBe(
+        'arn:aws:elasticloadbalancing:us-east-2:123456789012:targetgroup/lambda-279XGJDqGZ5rsrHC2Fjr/49e9d65c45c6791a'
+      );
     });
   });
 
   describe('HTTP response handling', () => {
     it('should handle successful HTTP responses', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => ({
         statusCode: 200,
-        body: 'success'
+        body: 'success',
       }));
       await handler(defaultEvent, defaultContext);
 
@@ -282,21 +272,18 @@ describe('createTracedHandler', () => {
     });
 
     it('should handle error HTTP responses', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => ({
         statusCode: 500,
-        body: 'error'
+        body: 'error',
       }));
       await handler(defaultEvent, defaultContext);
 
       expect(mockSpan.setAttribute).toHaveBeenCalledWith('http.status_code', 500);
       expect(mockSpan.setStatus).toHaveBeenCalledWith({
         code: SpanStatusCode.ERROR,
-        message: 'HTTP 500 response'
+        message: 'HTTP 500 response',
       });
     });
   });
@@ -304,11 +291,8 @@ describe('createTracedHandler', () => {
   describe('error handling', () => {
     it('should handle errors in handler', async () => {
       const error = new Error('test error');
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => {
         throw error;
       });
@@ -318,7 +302,7 @@ describe('createTracedHandler', () => {
       expect(mockSpan.setAttribute).toHaveBeenCalledWith('error', true);
       expect(mockSpan.setStatus).toHaveBeenCalledWith({
         code: SpanStatusCode.ERROR,
-        message: 'test error'
+        message: 'test error',
       });
     });
 
@@ -327,11 +311,8 @@ describe('createTracedHandler', () => {
         throw new Error('extraction error');
       });
 
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => 'success');
       const result = await handler(defaultEvent, defaultContext);
 
@@ -341,11 +322,8 @@ describe('createTracedHandler', () => {
 
     it('should complete telemetry even if handler throws', async () => {
       const error = new Error('test error');
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => {
         throw error;
       });
@@ -357,11 +335,8 @@ describe('createTracedHandler', () => {
 
   describe('cold start handling', () => {
     it('should handle cold start correctly', async () => {
-      const traced = createTracedHandler(
-        'test-handler',
-        completionHandler
-      );
-      
+      const traced = createTracedHandler('test-handler', completionHandler);
+
       const handler = traced(async (_event, _context) => 'success');
       await handler(defaultEvent, defaultContext);
 
@@ -369,4 +344,4 @@ describe('createTracedHandler', () => {
       expect(init.setColdStart).toHaveBeenCalledWith(false);
     });
   });
-}); 
+});

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts
@@ -12,10 +12,7 @@ describe('TelemetryCompletionHandler', () => {
 
       new TelemetryCompletionHandler(provider, ProcessorMode.Sync);
 
-      expect(getTracerSpy).toHaveBeenCalledWith(
-        VERSION.NAME,
-        VERSION.VERSION
-      );
+      expect(getTracerSpy).toHaveBeenCalledWith(VERSION.NAME, VERSION.VERSION);
     });
   });
 
@@ -23,7 +20,7 @@ describe('TelemetryCompletionHandler', () => {
     it('should return cached tracer instance', () => {
       const provider = new NodeTracerProvider();
       const getTracerSpy = jest.spyOn(provider, 'getTracer');
-      
+
       const handler = new TelemetryCompletionHandler(provider, ProcessorMode.Sync);
       const tracer1 = handler.getTracer();
       const tracer2 = handler.getTracer();
@@ -32,4 +29,4 @@ describe('TelemetryCompletionHandler', () => {
       expect(getTracerSpy).toHaveBeenCalledTimes(1);
     });
   });
-}); 
+});

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/init.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/init.test.ts
@@ -12,12 +12,12 @@ jest.mock('../../src/internal/logger', () => {
     debug: jest.fn(),
     info: jest.fn(),
     warn: jest.fn(),
-    error: jest.fn()
+    error: jest.fn(),
   };
   return {
     __esModule: true,
     default: mockLogger,
-    createLogger: () => mockLogger
+    createLogger: () => mockLogger,
   };
 });
 
@@ -41,7 +41,7 @@ describe('telemetry/init', () => {
 
       expect(completionHandler).toBeDefined();
       expect(tracer).toBeDefined();
-            
+
       // Verify that a provider is registered and can create spans
       const testSpan = tracer.startSpan('test');
       expect(testSpan).toBeDefined();
@@ -51,13 +51,13 @@ describe('telemetry/init', () => {
     it('should initialize telemetry with custom settings', () => {
       const { tracer, completionHandler } = initTelemetry({
         resource: new Resource({
-          'service.name': 'test-service'
-        })
+          'service.name': 'test-service',
+        }),
       });
 
       expect(completionHandler).toBeDefined();
       expect(tracer).toBeDefined();
-            
+
       // Verify that a provider is registered and can create spans
       const testSpan = tracer.startSpan('test');
       expect(testSpan).toBeDefined();
@@ -71,14 +71,14 @@ describe('telemetry/init', () => {
             forceFlush: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
             shutdown: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
             onStart: jest.fn(),
-            onEnd: jest.fn()
-          }
-        ]
+            onEnd: jest.fn(),
+          },
+        ],
       });
 
       expect(completionHandler).toBeDefined();
       expect(tracer).toBeDefined();
-            
+
       // Verify that a provider is registered and can create spans
       const testSpan = tracer.startSpan('test');
       expect(testSpan).toBeDefined();
@@ -92,14 +92,14 @@ describe('telemetry/init', () => {
             forceFlush: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
             shutdown: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
             onStart: jest.fn(),
-            onEnd: jest.fn()
-          }
-        ]
+            onEnd: jest.fn(),
+          },
+        ],
       });
 
       expect(completionHandler).toBeDefined();
       expect(tracer).toBeDefined();
-            
+
       // Verify that a provider is registered and can create spans
       const testSpan = tracer.startSpan('test');
       expect(testSpan).toBeDefined();
@@ -113,14 +113,14 @@ describe('telemetry/init', () => {
             forceFlush: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
             shutdown: jest.fn<() => Promise<void>>().mockImplementation(() => Promise.resolve()),
             onStart: jest.fn(),
-            onEnd: jest.fn()
-          }
-        ]
+            onEnd: jest.fn(),
+          },
+        ],
       });
 
       expect(completionHandler).toBeDefined();
       expect(tracer).toBeDefined();
-            
+
       // Verify that a provider is registered and can create spans
       const testSpan = tracer.startSpan('test');
       expect(testSpan).toBeDefined();
@@ -130,48 +130,48 @@ describe('telemetry/init', () => {
     it('should use service name from environment variables', () => {
       envManager.setup({
         OTEL_SERVICE_NAME: 'env-service',
-        AWS_LAMBDA_FUNCTION_NAME: 'lambda-function'
+        AWS_LAMBDA_FUNCTION_NAME: 'lambda-function',
       });
 
       const { completionHandler: _ } = initTelemetry();
-            
+
       // Service name will be in the provider's resource
       expect(state.provider?.resource.attributes['service.name']).toBe('env-service');
     });
 
     it('should fallback to Lambda function name if OTEL_SERVICE_NAME not set', () => {
       envManager.setup({
-        AWS_LAMBDA_FUNCTION_NAME: 'lambda-function'
+        AWS_LAMBDA_FUNCTION_NAME: 'lambda-function',
       });
 
       const { completionHandler: _ } = initTelemetry();
-            
+
       expect(state.provider?.resource.attributes['service.name']).toBe('lambda-function');
     });
 
     it('should use unknown_service if no environment variables set', () => {
       const { completionHandler: _ } = initTelemetry();
-            
+
       expect(state.provider?.resource.attributes['service.name']).toBe('unknown_service');
     });
 
     it('should use custom resource service name if provided', () => {
       const { completionHandler: _ } = initTelemetry({
         resource: new Resource({
-          'service.name': 'test-service'
-        })
+          'service.name': 'test-service',
+        }),
       });
-            
+
       expect(state.provider?.resource.attributes['service.name']).toBe('test-service');
     });
 
     it('should use custom resource if provided', () => {
       const customResource = new Resource({
-        'custom.attribute': 'value'
+        'custom.attribute': 'value',
       });
 
       const { completionHandler: _ } = initTelemetry({
-        resource: customResource
+        resource: customResource,
       });
 
       expect(state.provider?.resource.attributes['custom.attribute']).toBe('value');
@@ -198,9 +198,9 @@ describe('telemetry/init', () => {
       }
 
       const testProcessor = new TestProcessor();
-            
+
       const { tracer } = initTelemetry({
-        spanProcessors: [testProcessor]
+        spanProcessors: [testProcessor],
       });
 
       // Create and end a span to trigger the processor
@@ -213,11 +213,11 @@ describe('telemetry/init', () => {
 
     it('should configure default processor queue size from environment', () => {
       envManager.setup({
-        LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE: '1024'
+        LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE: '1024',
       });
 
       const { tracer } = initTelemetry();
-            
+
       // Create multiple spans to verify they are processed
       for (let i = 0; i < 10; i++) {
         const span = tracer.startSpan(`test-${i}`);
@@ -250,9 +250,9 @@ describe('telemetry/init', () => {
 
       const processor1 = new TestProcessor('processor1');
       const processor2 = new TestProcessor('processor2');
-            
+
       const { tracer } = initTelemetry({
-        spanProcessors: [processor1, processor2]
+        spanProcessors: [processor1, processor2],
       });
 
       // Create and end a span to trigger both processors
@@ -277,9 +277,9 @@ describe('telemetry/init', () => {
             forceFlush: () => Promise.resolve(),
             shutdown: () => Promise.resolve(),
             onStart: jest.fn(),
-            onEnd: jest.fn()
-          }
-        ]
+            onEnd: jest.fn(),
+          },
+        ],
       });
       expect(state.mode).toBe('sync');
     });
@@ -287,7 +287,7 @@ describe('telemetry/init', () => {
     it('should initialize with async mode', () => {
       // Set up environment and extension state
       envManager.setup({
-        LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: 'async'
+        LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: 'async',
       });
       state.extensionInitialized = true;
 
@@ -297,9 +297,9 @@ describe('telemetry/init', () => {
             forceFlush: () => Promise.resolve(),
             shutdown: () => Promise.resolve(),
             onStart: jest.fn(),
-            onEnd: jest.fn()
-          }
-        ]
+            onEnd: jest.fn(),
+          },
+        ],
       });
       expect(state.mode).toBe('async');
     });
@@ -307,7 +307,7 @@ describe('telemetry/init', () => {
     it('should initialize with finalize mode', () => {
       // Set up environment and extension state
       envManager.setup({
-        LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: 'finalize'
+        LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: 'finalize',
       });
       state.extensionInitialized = true;
 
@@ -317,9 +317,9 @@ describe('telemetry/init', () => {
             forceFlush: () => Promise.resolve(),
             shutdown: () => Promise.resolve(),
             onStart: jest.fn(),
-            onEnd: jest.fn()
-          }
-        ]
+            onEnd: jest.fn(),
+          },
+        ],
       });
       expect(state.mode).toBe('finalize');
     });
@@ -329,11 +329,11 @@ describe('telemetry/init', () => {
         forceFlush: () => Promise.resolve(),
         shutdown: () => Promise.resolve(),
         onStart: jest.fn(),
-        onEnd: jest.fn()
+        onEnd: jest.fn(),
       };
 
       const { completionHandler: _ } = initTelemetry({
-        spanProcessors: [mockSpanProcessor]
+        spanProcessors: [mockSpanProcessor],
       });
       expect(state.mode).toBe('sync');
     });
@@ -346,4 +346,4 @@ describe('telemetry/init', () => {
       expect(isColdStart()).toBe(false);
     });
   });
-}); 
+});

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/resource.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/resource.test.ts
@@ -25,28 +25,28 @@ describe('getLambdaResource', () => {
       AWS_LAMBDA_FUNCTION_NAME: 'test-function',
       AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
       AWS_LAMBDA_LOG_STREAM_NAME: 'test-stream',
-      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: '128'
+      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: '128',
     };
     envManager.setup(lambdaEnv);
 
     const resource = getLambdaResource();
-    
+
     expect(resource.attributes['cloud.region']).toBe('us-west-2');
     expect(resource.attributes['faas.name']).toBe('test-function');
     expect(resource.attributes['faas.version']).toBe('$LATEST');
     expect(resource.attributes['faas.instance']).toBe('test-stream');
-    expect(resource.attributes['faas.max_memory']).toBe('128');
+    expect(resource.attributes['faas.max_memory']).toBe(134217728); // 128MB in bytes
   });
 
   it('should only include Lambda environment variables that are present', () => {
     const lambdaEnv = {
       AWS_REGION: 'us-west-2',
-      AWS_LAMBDA_FUNCTION_NAME: 'test-function'
+      AWS_LAMBDA_FUNCTION_NAME: 'test-function',
     };
     envManager.setup(lambdaEnv);
 
     const resource = getLambdaResource();
-    
+
     expect(resource.attributes['cloud.region']).toBe('us-west-2');
     expect(resource.attributes['faas.name']).toBe('test-function');
     expect(resource.attributes['faas.version']).toBeUndefined();
@@ -57,7 +57,7 @@ describe('getLambdaResource', () => {
   it('should set service.name from OTEL_SERVICE_NAME if present', () => {
     envManager.setup({
       OTEL_SERVICE_NAME: 'otel-service',
-      AWS_LAMBDA_FUNCTION_NAME: 'lambda-function'
+      AWS_LAMBDA_FUNCTION_NAME: 'lambda-function',
     });
 
     const resource = getLambdaResource();
@@ -66,7 +66,7 @@ describe('getLambdaResource', () => {
 
   it('should fallback to AWS_LAMBDA_FUNCTION_NAME for service.name if OTEL_SERVICE_NAME is not set', () => {
     envManager.setup({
-      AWS_LAMBDA_FUNCTION_NAME: 'lambda-function'
+      AWS_LAMBDA_FUNCTION_NAME: 'lambda-function',
     });
 
     const resource = getLambdaResource();
@@ -80,7 +80,7 @@ describe('getLambdaResource', () => {
 
   it('should parse OTEL_RESOURCE_ATTRIBUTES correctly', () => {
     envManager.setup({
-      OTEL_RESOURCE_ATTRIBUTES: 'key1=value1,key2=value2,key3=value%20with%20spaces'
+      OTEL_RESOURCE_ATTRIBUTES: 'key1=value1,key2=value2,key3=value%20with%20spaces',
     });
 
     const resource = getLambdaResource();
@@ -91,7 +91,7 @@ describe('getLambdaResource', () => {
 
   it('should handle malformed OTEL_RESOURCE_ATTRIBUTES gracefully', () => {
     envManager.setup({
-      OTEL_RESOURCE_ATTRIBUTES: 'key1=value1,malformed,key2=value2,=empty,novalue='
+      OTEL_RESOURCE_ATTRIBUTES: 'key1=value1,malformed,key2=value2,=empty,novalue=',
     });
 
     const resource = getLambdaResource();
@@ -113,32 +113,36 @@ describe('getLambdaResource', () => {
       LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: 'async',
       LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE: '1024',
       LAMBDA_SPAN_PROCESSOR_BATCH_SIZE: '256',
-      OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL: '4'
+      OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL: '4',
     };
     envManager.setup(lambdaEnv);
 
     const resource = getLambdaResource();
-    
+
     // Check standard Lambda attributes
     expect(resource.attributes['cloud.region']).toBe('us-west-2');
     expect(resource.attributes['faas.name']).toBe('test-function');
     expect(resource.attributes['faas.version']).toBe('$LATEST');
     expect(resource.attributes['faas.instance']).toBe('test-stream');
-    expect(resource.attributes['faas.max_memory']).toBe('128');
+    expect(resource.attributes['faas.max_memory']).toBe(134217728); // 128MB in bytes
 
     // Check telemetry configuration attributes
     expect(resource.attributes['lambda_otel_lite.extension.span_processor_mode']).toBe('async');
-    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.queue_size']).toBe('1024');
-    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.batch_size']).toBe('256');
-    expect(resource.attributes['lambda_otel_lite.otlp_stdout_span_exporter.compression_level']).toBe('4');
+    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.queue_size']).toBe(1024);
+    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.batch_size']).toBe(256);
+    expect(
+      resource.attributes['lambda_otel_lite.otlp_stdout_span_exporter.compression_level']
+    ).toBe(4);
   });
 
   it('should use default values for telemetry configuration when not set', () => {
     const resource = getLambdaResource();
-    
+
     expect(resource.attributes['lambda_otel_lite.extension.span_processor_mode']).toBe('sync');
-    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.queue_size']).toBe('2048');
-    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.batch_size']).toBe('512');
-    expect(resource.attributes['lambda_otel_lite.otlp_stdout_span_exporter.compression_level']).toBe('6');
+    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.queue_size']).toBe(2048);
+    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.batch_size']).toBe(512);
+    expect(
+      resource.attributes['lambda_otel_lite.otlp_stdout_span_exporter.compression_level']
+    ).toBe(6);
   });
-}); 
+});

--- a/packages/node/lambda-otel-lite/__tests__/utils.ts
+++ b/packages/node/lambda-otel-lite/__tests__/utils.ts
@@ -12,7 +12,10 @@ export class TestSpanExporter implements SpanExporter {
   shutdownOnce = false;
   exportResult: { code: ExportResultCode; error?: Error } = { code: ExportResultCode.SUCCESS };
 
-  export(spans: ReadableSpan[], resultCallback: (result: { code: ExportResultCode; error?: Error }) => void): void {
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: { code: ExportResultCode; error?: Error }) => void
+  ): void {
     this.exportCalledTimes++;
     if (this.exportResult.code === ExportResultCode.SUCCESS) {
       this.spans.push(...spans);
@@ -43,7 +46,7 @@ export const createSpan = (spanName = 'default'): Span => {
     spanContext: () => ({
       traceId: 'd4cda95b652f4a1592b449d5929fda1b',
       spanId: '6e0c63257de34c92',
-      traceFlags: TraceFlags.SAMPLED
+      traceFlags: TraceFlags.SAMPLED,
     }),
     parentSpanId: undefined,
     startTime: [1566156729, 709],
@@ -59,7 +62,7 @@ export const createSpan = (spanName = 'default'): Span => {
     _spanContext: {
       traceId: 'd4cda95b652f4a1592b449d5929fda1b',
       spanId: '6e0c63257de34c92',
-      traceFlags: TraceFlags.SAMPLED
+      traceFlags: TraceFlags.SAMPLED,
     },
     _droppedAttributesCount: 0,
     _droppedEventsCount: 0,
@@ -86,7 +89,7 @@ export const createTestSpan = (spanName = 'default'): ReadableSpan => {
       return {
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
         spanId: '6e0c63257de34c92',
-        traceFlags: TraceFlags.SAMPLED
+        traceFlags: TraceFlags.SAMPLED,
       };
     },
     parentSpanId: undefined,
@@ -102,7 +105,7 @@ export const createTestSpan = (spanName = 'default'): ReadableSpan => {
     instrumentationLibrary: { name: 'default', version: '0.0.1' },
     droppedAttributesCount: 0,
     droppedEventsCount: 0,
-    droppedLinksCount: 0
+    droppedLinksCount: 0,
   };
 };
 
@@ -123,4 +126,4 @@ export class EnvVarManager {
   restore() {
     process.env = this.originalEnv;
   }
-} 
+}

--- a/packages/node/lambda-otel-lite/examples/README.md
+++ b/packages/node/lambda-otel-lite/examples/README.md
@@ -1,4 +1,4 @@
-# lambda-otel-lite Examples
+# Examples
 
 This directory contains examples demonstrating how to use `lambda-otel-lite` in AWS Lambda functions. The examples showcase different deployment methods and configurations using AWS SAM.
 

--- a/packages/node/lambda-otel-lite/examples/handler/app.js
+++ b/packages/node/lambda-otel-lite/examples/handler/app.js
@@ -43,7 +43,7 @@ async function nestedFunction(event) {
 const traced = createTracedHandler(
   'simple-handler',
   completionHandler,
-  { attributesExtractor: apiGatewayV2Extractor }
+  apiGatewayV2Extractor 
 );
 
 /**

--- a/packages/node/lambda-otel-lite/examples/handler/init.js
+++ b/packages/node/lambda-otel-lite/examples/handler/init.js
@@ -1,2 +1,2 @@
-// If using esbuild, this file is required to be loaded before any other imports using NODE_OPTIONS=--require init.js
+// If using esbuild, this file is required to be loaded before any other imports using NODE_OPTIONS=--require /var/task/init.js
 require('@dev7a/lambda-otel-lite/extension');

--- a/packages/node/lambda-otel-lite/examples/template.yaml
+++ b/packages/node/lambda-otel-lite/examples/template.yaml
@@ -12,7 +12,7 @@ Globals:
     Runtime: nodejs22.x
     LoggingConfig:
       LogFormat: JSON
-      ApplicationLogLevel: DEBUG
+      ApplicationLogLevel: INFO
       SystemLogLevel: INFO
   
 

--- a/packages/node/lambda-otel-lite/jest.config.ts
+++ b/packages/node/lambda-otel-lite/jest.config.ts
@@ -7,7 +7,7 @@ const config: Config.InitialOptions = {
   testMatch: ['**/*.test.ts'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.test.json'
     }]
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],

--- a/packages/node/lambda-otel-lite/package-lock.json
+++ b/packages/node/lambda-otel-lite/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dev7a/lambda-otel-lite",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@dev7a/otlp-stdout-span-exporter": "^0.1.0",
@@ -24,8 +24,10 @@
         "@typescript-eslint/eslint-plugin": "^8.19.1",
         "@typescript-eslint/parser": "^8.19.1",
         "eslint": "^8.57.1",
+        "eslint-config-prettier": "^10.0.1",
         "jest": "^29.7.0",
         "npm-package-json-lint": "^8.0.0",
+        "prettier": "^3.5.2",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
@@ -2851,6 +2853,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz",
+      "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "build/bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -5198,6 +5213,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
+      "integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -48,6 +48,8 @@
   "scripts": {
     "build": "rm -rf dist && tsc",
     "clean": "rm -rf dist",
+    "format": "prettier --write 'src/**/*.{js,ts}' '__tests__/**/*.{js,ts}'",
+    "format:check": "prettier --check 'src/**/*.{js,ts}' '__tests__/**/*.{js,ts}'",
     "lint": "eslint 'src/**/*.{js,ts}' '__tests__/**/*.{js,ts}' --fix && npx npm-package-json-lint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest -c jest.config.ts",
@@ -70,8 +72,10 @@
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.19.1",
     "eslint": "^8.57.1",
+    "eslint-config-prettier": "^10.0.1",
     "jest": "^29.7.0",
     "npm-package-json-lint": "^8.0.0",
+    "prettier": "^3.5.2",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"

--- a/packages/node/lambda-otel-lite/src/extension/index.js
+++ b/packages/node/lambda-otel-lite/src/extension/index.js
@@ -40,7 +40,6 @@ function syncHttpRequest(options, data) {
  * @param {string} extensionId - The extension ID
  */
 async function requestNextEvent(extensionId) {
-  const nextUrl = `http://${process.env.AWS_LAMBDA_RUNTIME_API}/2020-01-01/extension/event/next`;
   const [host, port] = (process.env.AWS_LAMBDA_RUNTIME_API || '').split(':');
 
   try {

--- a/packages/node/lambda-otel-lite/src/handler.ts
+++ b/packages/node/lambda-otel-lite/src/handler.ts
@@ -17,14 +17,6 @@ export interface LambdaContext {
 }
 
 /**
- * Optional configuration for traced handler
- */
-export interface TracerConfig {
-  /** Optional attribute extractor function */
-  attributesExtractor?: (event: unknown, context: LambdaContext) => SpanAttributes;
-}
-
-/**
  * A Lambda handler function type
  */
 export type TracedFunction<TEvent, TResult> = (
@@ -44,7 +36,7 @@ export type TracedFunction<TEvent, TResult> = (
  * const traced = createTracedHandler(
  *   'my-handler',
  *   completionHandler,
- *   { attributesExtractor: apiGatewayV2Extractor }
+ *   apiGatewayV2Extractor
  * );
  * 
  * // Use the traced handler to process Lambda events
@@ -64,7 +56,7 @@ export type TracedFunction<TEvent, TResult> = (
 export function createTracedHandler(
   name: string,
   completionHandler: TelemetryCompletionHandler,
-  config?: TracerConfig
+  attributesExtractor?: (event: unknown, context: LambdaContext) => SpanAttributes
 ) {
   return function <TEvent, TResult>(fn: TracedFunction<TEvent, TResult>) {
     return async function (event: TEvent, context: LambdaContext): Promise<TResult> {
@@ -72,7 +64,7 @@ export function createTracedHandler(
 
       try {
         // Extract attributes using provided extractor or default
-        const extracted = (config?.attributesExtractor || defaultExtractor)(event, context);
+        const extracted = (attributesExtractor || defaultExtractor)(event, context);
 
         // Extract context from carrier if available
         let parentContext = ROOT_CONTEXT;

--- a/packages/node/lambda-otel-lite/src/index.ts
+++ b/packages/node/lambda-otel-lite/src/index.ts
@@ -1,15 +1,15 @@
 // Re-export public API
 export { createTracedHandler } from './handler';
 export { initTelemetry, getLambdaResource } from './internal/telemetry/init';
-export { 
-  apiGatewayV1Extractor, 
-  apiGatewayV2Extractor, 
+export {
+  apiGatewayV1Extractor,
+  apiGatewayV2Extractor,
   albExtractor,
   TriggerType,
   type SpanAttributes,
   type APIGatewayV2Event,
   type APIGatewayV1Event,
-  type ALBEvent
+  type ALBEvent,
 } from './internal/telemetry/extractors';
 export * from './mode';
 

--- a/packages/node/lambda-otel-lite/src/index.ts
+++ b/packages/node/lambda-otel-lite/src/index.ts
@@ -15,4 +15,4 @@ export * from './mode';
 
 // Export types needed by users
 export type { TelemetryCompletionHandler } from './internal/telemetry/completion';
-export type { TracerConfig, TracedFunction, LambdaContext } from './handler';
+export type { TracedFunction, LambdaContext } from './handler';

--- a/packages/node/lambda-otel-lite/src/internal/logger.ts
+++ b/packages/node/lambda-otel-lite/src/internal/logger.ts
@@ -1,12 +1,16 @@
 interface Logger {
-    debug: (...args: unknown[]) => void;
-    info: (...args: unknown[]) => void;
-    warn: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
 }
 
 // Simple logger with level filtering
-const logLevel = (process.env.AWS_LAMBDA_LOG_LEVEL || process.env.LOG_LEVEL || 'info').toLowerCase();
+const logLevel = (
+  process.env.AWS_LAMBDA_LOG_LEVEL ||
+  process.env.LOG_LEVEL ||
+  'info'
+).toLowerCase();
 
 /* eslint-disable no-console */
 const logger: Logger = {
@@ -29,7 +33,7 @@ const logger: Logger = {
     if (logLevel !== 'none') {
       console.error('[lambda-otel-lite]', ...args);
     }
-  }
+  },
 };
 /* eslint-enable no-console */
 
@@ -38,8 +42,8 @@ export function createLogger(prefix: string): Logger {
     debug: (...args: unknown[]) => logger.debug(`[${prefix}]`, ...args),
     info: (...args: unknown[]) => logger.info(`[${prefix}]`, ...args),
     warn: (...args: unknown[]) => logger.warn(`[${prefix}]`, ...args),
-    error: (...args: unknown[]) => logger.error(`[${prefix}]`, ...args)
+    error: (...args: unknown[]) => logger.error(`[${prefix}]`, ...args),
   };
 }
 
-export default logger; 
+export default logger;

--- a/packages/node/lambda-otel-lite/src/internal/state.ts
+++ b/packages/node/lambda-otel-lite/src/internal/state.ts
@@ -9,22 +9,22 @@ class Signal {
   private listeners: Array<() => void> = [];
 
   /**
-     * Signal all listeners that the event has occurred
-     */
+   * Signal all listeners that the event has occurred
+   */
   signal(): void {
-    this.listeners.forEach(listener => listener());
+    this.listeners.forEach((listener) => listener());
   }
 
   /**
-     * Register a listener to be called when the event is signaled
-     */
+   * Register a listener to be called when the event is signaled
+   */
   on(listener: () => void): void {
     this.listeners.push(listener);
   }
 
   /**
-     * Remove a listener
-     */
+   * Remove a listener
+   */
   off(listener: () => void): void {
     const index = this.listeners.indexOf(listener);
     if (index !== -1) {
@@ -54,7 +54,7 @@ if (!global._lambdaOtelState) {
     provider: null,
     mode: null,
     extensionInitialized: false,
-    handlerComplete: new Signal()
+    handlerComplete: new Signal(),
   };
 }
 
@@ -64,4 +64,4 @@ if (!global._lambdaOtelState) {
 export const state = global._lambdaOtelState;
 
 // Export the handler complete signal for convenience
-export const handlerComplete = state.handlerComplete; 
+export const handlerComplete = state.handlerComplete;

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/completion.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/completion.ts
@@ -7,20 +7,20 @@ import logger from '../logger';
 
 /**
  * Manages the lifecycle of span export based on the processing mode.
- * 
+ *
  * This handler is responsible for ensuring that spans are properly exported before
  * the Lambda function completes. It MUST be used to signal when spans should be exported.
- * 
+ *
  * The behavior varies by processing mode:
  * - Sync: Forces immediate export in the handler thread
  * - Async: Signals the extension to export after the response is sent
  * - Finalize: Defers to span processor (used with BatchSpanProcessor)
- * 
+ *
  * @example
  * ```typescript
  * // Initialize once, outside the handler
  * const completionHandler = initTelemetry('my-service');
- * 
+ *
  * // Basic usage with try/finally to ensure completion
  * export const handler = async (event, context) => {
  *   try {
@@ -31,7 +31,7 @@ import logger from '../logger';
  *     completionHandler.complete();
  *   }
  * };
- * 
+ *
  * // Recommended: Use tracedHandler which handles completion automatically
  * export const handler = async (event, context) => {
  *   return tracedHandler({
@@ -43,7 +43,7 @@ import logger from '../logger';
  *   });
  * };
  * ```
- * 
+ *
  * @important
  * - Failing to call `complete()` may result in lost spans
  * - In sync mode, `complete()` blocks until spans are exported
@@ -59,29 +59,26 @@ export class TelemetryCompletionHandler {
     private readonly mode: ProcessorMode
   ) {
     // Initialize tracer once at construction
-    this._tracer = this.provider.getTracer(
-      VERSION.NAME,
-      VERSION.VERSION
-    );
+    this._tracer = this.provider.getTracer(VERSION.NAME, VERSION.VERSION);
   }
 
   /**
    * Complete telemetry processing for the current invocation.
-   * 
+   *
    * This method must be called to ensure spans are exported. The behavior depends
    * on the processing mode:
-   * 
+   *
    * - Sync mode: Blocks until spans are flushed. Any errors during flush are logged
    *   but do not affect the handler response.
-   * 
+   *
    * - Async mode: Schedules span export via the extension after the response is sent.
    *   This is non-blocking and optimizes perceived latency.
-   * 
+   *
    * - Finalize mode: No-op as export is handled by the span processor configuration
    *   (e.g., BatchSpanProcessor with custom export triggers).
-   * 
+   *
    * Multiple calls to this method are safe but have no additional effect.
-   * 
+   *
    * @example
    * ```typescript
    * // Always use try/finally when calling complete() directly
@@ -100,31 +97,32 @@ export class TelemetryCompletionHandler {
     switch (this.mode) {
       case ProcessorMode.Sync:
         if (this.provider.forceFlush) {
-          this.provider.forceFlush()
-            .catch(e => logger.warn('[completion] Error flushing telemetry:', e));
+          this.provider
+            .forceFlush()
+            .catch((e) => logger.warn('[completion] Error flushing telemetry:', e));
         }
         break;
       case ProcessorMode.Async:
-      // In async mode, we want to ensure the Lambda runtime has a chance to send the response
-      // before we signal completion and start flushing spans
+        // In async mode, we want to ensure the Lambda runtime has a chance to send the response
+        // before we signal completion and start flushing spans
         process.nextTick(() => {
           state.handlerComplete.signal();
         });
         break;
       case ProcessorMode.Finalize:
-      // Do nothing, handled by drop
+        // Do nothing, handled by drop
         break;
     }
   }
 
   /**
    * Get the tracer instance for creating spans.
-   * 
+   *
    * Returns the cached tracer instance configured with this package's instrumentation scope.
-   * The tracer is configured with the provider's settings and will automatically use 
+   * The tracer is configured with the provider's settings and will automatically use
    * the correct span processor based on the processing mode.
    */
   getTracer(): Tracer {
     return this._tracer;
   }
-} 
+}

--- a/packages/node/lambda-otel-lite/src/mode.ts
+++ b/packages/node/lambda-otel-lite/src/mode.ts
@@ -2,20 +2,20 @@
  * Controls how spans are processed and exported.
  */
 export enum ProcessorMode {
-    /**
-     * Synchronous flush in handler thread. Best for development.
-     */
-    Sync = 'sync',
+  /**
+   * Synchronous flush in handler thread. Best for development.
+   */
+  Sync = 'sync',
 
-    /**
-     * Asynchronous flush via extension. Best for production.
-     */
-    Async = 'async',
+  /**
+   * Asynchronous flush via extension. Best for production.
+   */
+  Async = 'async',
 
-    /**
-     * Let processor handle flushing. Best with BatchSpanProcessor.
-     */
-    Finalize = 'finalize'
+  /**
+   * Let processor handle flushing. Best with BatchSpanProcessor.
+   */
+  Finalize = 'finalize',
 }
 
 /**
@@ -23,7 +23,10 @@ export enum ProcessorMode {
  * @param envVar - Name of the environment variable to read
  * @param defaultMode - Default mode if environment variable is not set
  */
-export function processorModeFromEnv(envVar: string = 'LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE', defaultMode: ProcessorMode = ProcessorMode.Sync): ProcessorMode {
+export function processorModeFromEnv(
+  envVar: string = 'LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE',
+  defaultMode: ProcessorMode = ProcessorMode.Sync
+): ProcessorMode {
   const envValue = process.env[envVar];
   // Handle undefined, null, or non-string values
   if (!envValue || typeof envValue !== 'string') {
@@ -38,5 +41,7 @@ export function processorModeFromEnv(envVar: string = 'LAMBDA_EXTENSION_SPAN_PRO
   if (Object.values(ProcessorMode).includes(value as ProcessorMode)) {
     return value as ProcessorMode;
   }
-  throw new Error(`Invalid ${envVar}: ${envValue}. Must be one of: ${Object.values(ProcessorMode).join(', ')}`);
-} 
+  throw new Error(
+    `Invalid ${envVar}: ${envValue}. Must be one of: ${Object.values(ProcessorMode).join(', ')}`
+  );
+}

--- a/packages/node/lambda-otel-lite/src/version.ts
+++ b/packages/node/lambda-otel-lite/src/version.ts
@@ -6,5 +6,5 @@ export const VERSION = {
   /** Package name as it appears in package.json */
   NAME: '@dev7a/lambda-otel-lite',
   /** Current version of the package */
-  VERSION: '0.7.0'
-}; 
+  VERSION: '0.7.0',
+};

--- a/packages/node/lambda-otel-lite/tsconfig.json
+++ b/packages/node/lambda-otel-lite/tsconfig.json
@@ -6,6 +6,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -16,9 +17,7 @@
   },
   "include": [
     "src/**/*.ts",
-    "src/**/*.js",
-    "__tests__/**/*.ts",
-    "__tests__/**/*.json"
+    "src/**/*.js"
   ],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "__tests__"]
 } 

--- a/packages/node/lambda-otel-lite/tsconfig.test.json
+++ b/packages/node/lambda-otel-lite/tsconfig.test.json
@@ -1,11 +1,25 @@
 {
-  "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "checkJs": true,
+    "resolveJsonModule": true,
     "types": ["jest", "node"],
-    "rootDir": "."
+    "noEmit": true
   },
   "include": [
     "src/**/*.ts",
-    "__tests__/**/*.ts"
-  ]
+    "__tests__/**/*.ts",
+    "__tests__/**/*.json"
+  ],
+  "exclude": ["node_modules", "dist"]
 } 


### PR DESCRIPTION
This pull request introduces several changes to improve the code quality, configuration, and documentation of the `lambda-otel-lite` package. The most important changes include updates to the ESLint configuration, addition of Prettier for code formatting, updates to the changelog and publishing documentation, and improvements to the README for better clarity and usage examples.

### Configuration Updates:
* [`.eslintrc.js`](diffhunk://#diff-7c73809518884c5315ca65fd443e3f640c72e0117fc3f62bdc13c37a86e1ddbeL11-R71): Separated ESLint configurations for source and test files, added Prettier to the ESLint configuration, and removed unnecessary configurations for test files. [[1]](diffhunk://#diff-7c73809518884c5315ca65fd443e3f640c72e0117fc3f62bdc13c37a86e1ddbeL11-R71) [[2]](diffhunk://#diff-7c73809518884c5315ca65fd443e3f640c72e0117fc3f62bdc13c37a86e1ddbeR81-R91)
* [`.prettierignore`](diffhunk://#diff-a31cbd801c1a797c3f7dcc5ef977d111ed9bc452860127eb9294e7ffe95f2aabR1-R5): Added common directories and files to ignore during Prettier formatting.
* [`.prettierrc.json`](diffhunk://#diff-8628fcb04a8d3eef3a0444544513212314e708675a6c517dcf8aa31fb8a80128R1-R9): Added a Prettier configuration file to enforce consistent code style.

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR8-R29): Documented breaking changes, new features, and improvements in version 0.9.0.
* [`PUBLISHING.md`](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766R30-R31): Updated publishing steps to include code formatting and format checks. [[1]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766R30-R31) [[2]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766L45-R56)
* [`README.md`](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddL208-R208): Improved examples and explanations for creating traced handlers, using event extractors, and initializing telemetry with custom configurations. [[1]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddL208-R208) [[2]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddL235-R235) [[3]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddL248-R301) [[4]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddR313-R381) [[5]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddR397) [[6]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddR413-R432)

### Test Updates:
* `LambdaSpanProcessor.test.ts`, `ProcessorMode.test.ts`, `handler.test.ts`: Applied Prettier formatting to test files for consistency. [[1]](diffhunk://#diff-c8e5733991996e6caeb9e6b69d4294d71c954f21f0335702b804a8ea0ee36a50L34-R35) [[2]](diffhunk://#diff-c8e5733991996e6caeb9e6b69d4294d71c954f21f0335702b804a8ea0ee36a50L143-R155) [[3]](diffhunk://#diff-c8e5733991996e6caeb9e6b69d4294d71c954f21f0335702b804a8ea0ee36a50L162-R164) [[4]](diffhunk://#diff-77f98e9bea76f0e9cb49f741dc95b843b094ba6470649e7110495fcc1ff9e576L77-R79) [[5]](diffhunk://#diff-43cf92b5a265106b35e58dfdd6b7702b4214917dfa6bea6ebe54575ccf561affL4-R17) [[6]](diffhunk://#diff-43cf92b5a265106b35e58dfdd6b7702b4214917dfa6bea6ebe54575ccf561affL37-R44) [[7]](diffhunk://#diff-43cf92b5a265106b35e58dfdd6b7702b4214917dfa6bea6ebe54575ccf561affL53-R57) [[8]](diffhunk://#diff-43cf92b5a265106b35e58dfdd6b7702b4214917dfa6bea6ebe54575ccf561affL78-R104) [[9]](diffhunk://#diff-43cf92b5a265106b35e58dfdd6b7702b4214917dfa6bea6ebe54575ccf561affL109-R115)