### PR TITLE
Release/node lambda otel lite 0.9.1

### DIFF
--- a/.github/workflows/publish-node-lambda-otel-lite.yml
+++ b/.github/workflows/publish-node-lambda-otel-lite.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Verify package version
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          VERSION_TS_VERSION=$(grep -o "'[0-9]\+\.[0-9]\+\.[0-9]\+'" src/version.ts | tr -d "'")
+          
+          if [ "$PACKAGE_VERSION" != "$VERSION_TS_VERSION" ]; then
+            echo "Version mismatch: package.json ($PACKAGE_VERSION) != version.ts ($VERSION_TS_VERSION)"
+            exit 1
+          fi
+          
           if git tag -l | grep -q "node-v$PACKAGE_VERSION"; then
             echo "Version $PACKAGE_VERSION already published"
             exit 1

--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2025-02-24
+
+### Fixed
+- Fixed version mismatch in package.json and src/version.ts
+
+### Changed
+- Updated publishing workflow to validate version consistency
+
 ## [0.9.0] - 2025-02-22
 
 ### Breaking Changes

--- a/packages/node/lambda-otel-lite/PUBLISHING.md
+++ b/packages/node/lambda-otel-lite/PUBLISHING.md
@@ -25,7 +25,6 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 - [ ] API documentation is complete
 - [ ] Breaking changes are clearly documented
 - [ ] `CHANGELOG.md` is updated
-- 
 
 ## Code Quality
 - [ ] All tests pass (`npm test`)

--- a/packages/node/lambda-otel-lite/PUBLISHING.md
+++ b/packages/node/lambda-otel-lite/PUBLISHING.md
@@ -3,7 +3,8 @@
 Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these items are checked:
 
 ## Package.json Verification
-- [ ] `version` is correctly incremented (following semver)
+- [ ] `version` is correctly incremented (following semver) in package.json and in src/version.ts
+- [ ] `name` is correct
 - [ ] `description` is clear and up-to-date
 - [ ] `license` is specified
 - [ ] `keywords` are defined and relevant
@@ -24,6 +25,7 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 - [ ] API documentation is complete
 - [ ] Breaking changes are clearly documented
 - [ ] `CHANGELOG.md` is updated
+- 
 
 ## Code Quality
 - [ ] All tests pass (`npm test`)

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [

--- a/packages/node/lambda-otel-lite/src/version.ts
+++ b/packages/node/lambda-otel-lite/src/version.ts
@@ -6,5 +6,5 @@ export const VERSION = {
   /** Package name as it appears in package.json */
   NAME: '@dev7a/lambda-otel-lite',
   /** Current version of the package */
-  VERSION: '0.7.0',
+  VERSION: '0.9.1',
 };


### PR DESCRIPTION
This pull request includes several changes aimed at ensuring version consistency between `package.json` and `src/version.ts`, as well as updating documentation and workflows accordingly.

### Version Consistency:

* [`.github/workflows/publish-node-lambda-otel-lite.yml`](diffhunk://#diff-263fbeb601c9a1874edd8f0a3922d4787f18d9e2396959c5ba53dd6cdc27894cR89-R95): Added a step to verify that the version in `package.json` matches the version in `src/version.ts` before publishing.
* [`packages/node/lambda-otel-lite/package.json`](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3): Updated the version to `0.9.1`.
* [`packages/node/lambda-otel-lite/src/version.ts`](diffhunk://#diff-691bd3ab607ea739e3de7cfce9f353f83de4000e15510ed62c81680d3cb365b8L9-R9): Updated the version to `0.9.1` to match `package.json`.

### Documentation Updates:

* [`packages/node/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR8-R15): Added an entry for version `0.9.1`, documenting the fixed version mismatch and updated publishing workflow.
* [`packages/node/lambda-otel-lite/PUBLISHING.md`](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766L6-R7): Updated the checklist to ensure version consistency between `package.json` and `src/version.ts`. [[1]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766L6-R7) [[2]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766R28)