### PR TITLE
Release/python lambda otel lite 0.9.0

### DIFF
--- a/packages/python/lambda_otel_lite/CHANGELOG.md
+++ b/packages/python/lambda_otel_lite/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-02-23
+
+### Changed
+- Version bump to align with Node.js package version
+- All functionality remains the same as 0.8.2
+
 ## [0.8.2] - 2025-02-22
 
 ### Changed

--- a/packages/python/lambda_otel_lite/README.md
+++ b/packages/python/lambda_otel_lite/README.md
@@ -417,27 +417,6 @@ ruff check .
 mypy src/lambda_otel_lite
 ```
 
-### Creating a Release
-
-1. Ensure all tests pass and code quality checks succeed
-2. Update version number in both:
-   - `src/lambda_otel_lite/__init__.py`: Update `__version__`
-   - `pyproject.toml`: Update `project.version`
-3. Update `CHANGELOG.md` with your changes
-4. Create and push a new tag:
-   ```bash
-   # Tag the current commit
-   git tag python/lambda-otel-lite/v0.8.0
-   
-   # Push the tag
-   git push origin python/lambda-otel-lite/v0.8.0
-   ```
-5. The GitHub Actions workflow will automatically:
-   - Verify version consistency
-   - Build the package
-   - Run all checks
-   - Publish to PyPI if on the main branch
-
 ## License
 
 MIT 

--- a/packages/python/lambda_otel_lite/examples/handler/app.py
+++ b/packages/python/lambda_otel_lite/examples/handler/app.py
@@ -47,6 +47,7 @@ def nested_function(event: dict[str, Any]) -> str:
                 raise RuntimeError("unexpected error")
         return "success"
 
+
 @traced
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Lambda handler function.

--- a/packages/python/lambda_otel_lite/pyproject.toml
+++ b/packages/python/lambda_otel_lite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lambda_otel_lite"
-version = "0.8.2"
+version = "0.9.0"
 description = "Lightweight OpenTelemetry instrumentation for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/python/lambda_otel_lite/src/lambda_otel_lite/__init__.py
+++ b/packages/python/lambda_otel_lite/src/lambda_otel_lite/__init__.py
@@ -9,7 +9,7 @@ import os
 from enum import Enum
 from typing import Final
 
-__version__ = "0.8.2"
+__version__ = "0.9.0"
 
 
 class ProcessorMode(str, Enum):


### PR DESCRIPTION
This pull request includes multiple changes to the `lambda_otel_lite` package, focusing on version updates, code refactoring, and documentation updates. The most important changes include version bumping, refactoring the `get_lambda_resource` function, and removing the release instructions from the `README.md`.

Version updates:
* [`packages/python/lambda_otel_lite/pyproject.toml`](diffhunk://#diff-1860126e0eaa261a6df72839e6a152cdc01af3d073bd1bfc763d2ad7fb333a4eL7-R7): Updated the version from `0.8.2` to `0.9.0`.
* [`packages/python/lambda_otel_lite/src/lambda_otel_lite/__init__.py`](diffhunk://#diff-846f926ecbfefc0ef2a514893a354260895ec60ec74e698b970fc5180e7b8830L12-R12): Updated the `__version__` from `0.8.2` to `0.9.0`.
* [`packages/python/lambda_otel_lite/CHANGELOG.md`](diffhunk://#diff-d6f402869001a759fd95d8bb35acac08ef8924dabe53b73d61b4f23658714031R8-R13): Added a new entry for version `0.9.0` to align with the Node.js package version.

Code refactoring:
* [`packages/python/lambda_otel_lite/src/lambda_otel_lite/telemetry.py`](diffhunk://#diff-214e6962832170f849c703a4fc15ab3cb198a4c24e7178948fb3fb313b0cfa28R124-R139): Refactored the `get_lambda_resource` function by adding helper functions `parse_numeric_env` and `parse_memory_value` to improve readability and maintainability. [[1]](diffhunk://#diff-214e6962832170f849c703a4fc15ab3cb198a4c24e7178948fb3fb313b0cfa28R124-R139) [[2]](diffhunk://#diff-214e6962832170f849c703a4fc15ab3cb198a4c24e7178948fb3fb313b0cfa28L136-R153) [[3]](diffhunk://#diff-214e6962832170f849c703a4fc15ab3cb198a4c24e7178948fb3fb313b0cfa28R168-R186)

Documentation updates:
* [`packages/python/lambda_otel_lite/README.md`](diffhunk://#diff-ea320936e156301cbf0b0f5b06edc04c076a5cafa747fbefdf23554e4f5e1270L420-L440): Removed the section on creating a release, including instructions for updating version numbers, tagging commits, and pushing tags.