### PR TITLE
Release otlp-stdout-span-exporter v0.9.0

### DIFF
--- a/.github/workflows/publish-rust-otlp-stdout-span-exporter.yml
+++ b/.github/workflows/publish-rust-otlp-stdout-span-exporter.yml
@@ -1,0 +1,104 @@
+name: Publish Rust OTLP Stdout Span Exporter
+
+on:
+  # Trigger on PRs that touch the Rust package
+  pull_request:
+    paths:
+      - 'packages/rust/otlp-stdout-span-exporter/**'
+    types: [opened, synchronize]
+  # Trigger on merges to main that touch the Rust package
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/rust/otlp-stdout-span-exporter/**'
+
+# Add permissions needed for the workflow
+permissions:
+  contents: write  # Needed for pushing tags
+  id-token: write  # Needed for publishing to crates.io
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          # x64 runner
+          - os: ubuntu-latest
+            arch: x64
+            rust-version: stable
+          # arm64 runner
+          - os: ubuntu-22.04-arm
+            arch: arm64
+            rust-version: stable
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: packages/rust/otlp-stdout-span-exporter
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          components: rustfmt, clippy
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+
+      - name: Run quality checks
+        run: |
+          cargo fmt --check
+          cargo clippy -- -D warnings
+          cargo test
+          cargo build --release
+
+  publish:
+    needs: test
+    # Only run on pushes to main, never on PRs
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/rust/otlp-stdout-span-exporter
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/rust/otlp-stdout-span-exporter
+
+      - name: Build package
+        run: cargo build --release
+
+      - name: Verify package version
+        run: |
+          PACKAGE_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "otlp-stdout-span-exporter") | .version')
+          if git tag -l | grep -q "rust-v$PACKAGE_VERSION"; then
+            echo "Version $PACKAGE_VERSION already published"
+            exit 1
+          fi
+          echo "Publishing version $PACKAGE_VERSION"
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Create and push tag
+        run: |
+          PACKAGE_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "otlp-stdout-span-exporter") | .version')
+          git tag "rust-v$PACKAGE_VERSION"
+          git push origin "rust-v$PACKAGE_VERSION" 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "lambda-otel-lite"
-version = "0.6.0"
+version = "0.9.0"
 dependencies = [
  "aws_lambda_events",
  "bon",
@@ -2361,7 +2361,7 @@ dependencies = [
  "opentelemetry-aws",
  "opentelemetry-http",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions 0.27.0",
+ "opentelemetry-semantic-conventions 0.28.0",
  "opentelemetry_sdk",
  "otlp-stdout-client",
  "pin-project",
@@ -2389,10 +2389,12 @@ dependencies = [
  "chrono",
  "flate2",
  "futures",
+ "lambda-otel-lite",
  "lambda-otel-utils",
  "lambda_runtime",
  "mockito",
  "opentelemetry",
+ "opentelemetry-otlp",
  "otlp-sigv4-client",
  "otlp-stdout-client",
  "regex",
@@ -2681,36 +2683,35 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-aws"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eacb6bb0b662955ba69d788c979462b079e70903e29867c2303cc1305ec8de"
+checksum = "b128be0f8e3e1f04e762572b484b0555c6a7410e299b181dd27727fd6fe5de0c"
 dependencies = [
- "once_cell",
  "opentelemetry",
- "opentelemetry-semantic-conventions 0.27.0",
+ "opentelemetry-semantic-conventions 0.28.0",
  "opentelemetry_sdk",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2721,13 +2722,14 @@ dependencies = [
  "opentelemetry",
  "reqwest",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -2739,24 +2741,24 @@ dependencies = [
  "prost",
  "reqwest",
  "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tonic",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
+ "base64 0.22.1",
  "hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "serde",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
@@ -2767,15 +2769,15 @@ checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
  "async-std",
  "async-trait",
@@ -2787,7 +2789,7 @@ dependencies = [
  "percent-encoding",
  "rand",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2900,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "otlp-stdout-span-exporter"
-version = "0.6.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4359,9 +4361,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Alessandro Bologna <alessandro.bologna@gmail.com>"]
 license = "MIT"
@@ -28,7 +28,7 @@ lambda-otel-utils = { path = "packages/rust/lambda-otel-utils" }
 lambda-lw-http-router = { path = "packages/rust/lambda-lw-http-router" }
 lambda-lw-http-router-core = { path = "packages/rust/lambda-lw-http-router/router-core" }
 lambda-lw-http-router-macro = { path = "packages/rust/lambda-lw-http-router/router-macro" }
-otlp-stdout-span-exporter = { version = "0.6.0", path = "packages/rust/otlp-stdout-span-exporter" }
+otlp-stdout-span-exporter = { path = "packages/rust/otlp-stdout-span-exporter" }
 lambda-otel-lite = { path = "packages/rust/lambda-otel-lite" }
 # Runtime and async
 tokio = { version = "1", features = ["full"] }
@@ -36,13 +36,14 @@ async-trait = "0.1.82"
 futures = "0.3.31"
 
 # OpenTelemetry and tracing
-opentelemetry = { version = "0.27.1", features = ["trace"] }
-opentelemetry-http = { version = "0.27.0" }
-opentelemetry_sdk = { version = "0.27.1", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.27.0", features = ["http-proto", "http-json", "reqwest-client"] }
-opentelemetry-aws = { version = "0.15.0", features = ["detector-aws-lambda"] }
+opentelemetry = { version = "0.28.0", features = ["trace"] }
+opentelemetry-http = { version = "0.28.0" }
+opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.28.0", features = ["http-proto", "http-json", "reqwest-client"] }
+opentelemetry-proto = { version = "0.28.0", features = ["gen-tonic", "trace"] }
+opentelemetry-aws = { version = "0.16.0", features = ["detector-aws-lambda"] }
 tracing = { version = "0.1", features = ["log"] }
-tracing-opentelemetry = "0.28.0"
+tracing-opentelemetry = "0.29.0"
 
 # AWS related
 aws-config = { version = "1.5.7", features = ["behavior-version-latest"] }

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.9.0] - 2025-02-24
+
+### Added
+- Support for configuring GZIP compression level via `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable
+- Comprehensive tests for GZIP compression level functionality
+
+### Changed
+- Upgraded OpenTelemetry dependencies from 0.27.0 to 0.28.0
+- Updated API implementation to match OpenTelemetry SDK 0.28.0 changes
+- Improved error handling using `OTelSdkError` instead of `TraceError`
+- Enhanced documentation with examples for the new environment variable
+
 ## [0.6.0] - 2025-02-09
 
 ### Changed

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["development-tools::debugging", "development-tools::profiling"]
 [dependencies]
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
-opentelemetry-proto = { version = "0.27", features = ["gen-tonic", "trace"] }
+opentelemetry-proto.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 futures-util = "0.3.31"

--- a/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
@@ -1,0 +1,97 @@
+# Publishing Checklist
+
+Before publishing a new version of `otlp-stdout-span-exporter`, ensure all these items are checked:
+
+## Cargo.toml Verification
+- [ ] `version` is correctly incremented (following semver)
+- [ ] `name` is correct
+- [ ] `description` is clear and up-to-date
+- [ ] `license` is specified
+- [ ] `keywords` are defined and relevant
+- [ ] `categories` are appropriate
+- [ ] `repository` information is complete and correct
+- [ ] `homepage` URL is valid
+- [ ] `documentation` URL is specified
+- [ ] Dependencies are up-to-date and correct (currently using OpenTelemetry 0.28.0)
+- [ ] No extraneous dependencies
+- [ ] Development dependencies are in `[dev-dependencies]`
+- [ ] Feature flags are correctly defined
+- [ ] Minimum supported Rust version (MSRV) is specified if needed
+
+## Documentation
+- [ ] `README.md` is up-to-date
+- [ ] Version number in documentation matches Cargo.toml
+- [ ] All examples in documentation work
+- [ ] API documentation is complete (all public items have doc comments)
+- [ ] Breaking changes are clearly documented
+- [ ] `CHANGELOG.md` is updated
+- [ ] Feature flags are documented
+- [ ] All public APIs have usage examples
+- [ ] All environment variables are documented (`OTEL_SERVICE_NAME`, `AWS_LAMBDA_FUNCTION_NAME`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`)
+
+## Code Quality
+- [ ] All tests pass (`cargo test`)
+- [ ] Code is properly formatted (`cargo fmt`)
+- [ ] Format check passes (`cargo fmt --check`)
+- [ ] Linting passes (`cargo clippy`)
+- [ ] No debug code or println! macros (except in logging)
+- [ ] Test coverage is satisfactory
+- [ ] All public APIs have proper documentation
+- [ ] No unsafe code (or if present, properly documented and justified)
+- [ ] All compiler warnings are addressed
+- [ ] Documentation tests (`cargo test --doc`) pass
+
+## Git Checks
+- [ ] Working on the correct branch
+- [ ] All changes are committed
+- [ ] No unnecessary files in git
+- [ ] Git tags are ready to be created
+- [ ] `.gitignore` is up-to-date
+
+## Publishing Steps
+1. Update version in `Cargo.toml` (or in workspace Cargo.toml if using workspace version)
+2. Update `CHANGELOG.md`
+3. Format code: `cargo fmt`
+4. Run format check: `cargo fmt --check`
+5. Run clippy: `cargo clippy -- -D warnings`
+6. Run tests: `cargo test`
+7. Run doc tests: `cargo test --doc`
+8. Build in release mode: `cargo build --release`
+9. Verify documentation: `cargo doc --no-deps`
+10. Commit changes: `git commit -am "Release vX.Y.Z"`
+11. Create git tag: `git tag rust-vX.Y.Z`
+12. Push changes: `git push && git push --tags`
+13. Publish to crates.io: `cargo publish`
+14. Verify package on crates.io: https://crates.io/crates/otlp-stdout-span-exporter
+
+## Post-Publishing
+- [ ] Verify package installation works: `cargo add otlp-stdout-span-exporter`
+- [ ] Verify documentation appears correctly on docs.rs
+- [ ] Test the package in a new project
+- [ ] Update any dependent crates
+- [ ] Verify examples compile and run correctly
+
+## Common Issues to Check
+- Missing files in the published package
+- Incorrect feature flags
+- Missing or incorrect documentation
+- Broken links in documentation
+- Incorrect version numbers
+- Missing changelog entries
+- Unintended breaking changes
+- Incomplete crate metadata
+- Platform-specific issues
+- MSRV compatibility issues
+
+## Notes
+- Always use `cargo package` first to verify the package contents
+- Test the package with different feature combinations
+- Consider cross-platform compatibility
+- Test with the minimum supported Rust version
+- Consider running `cargo audit` for security vulnerabilities
+- Use `cargo clippy` with all relevant feature combinations
+- Remember to update any related documentation or examples in the main repository
+- Consider testing on different architectures (x86_64, aarch64)
+- Ensure GZIP compression functionality is properly tested at all levels (0-9)
+- Verify both simple and batch export modes work correctly
+- Test with different values of `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable 

--- a/packages/rust/otlp-stdout-span-exporter/README.md
+++ b/packages/rust/otlp-stdout-span-exporter/README.md
@@ -75,6 +75,7 @@ The exporter respects the following environment variables:
 - `AWS_LAMBDA_FUNCTION_NAME`: Fallback service name (if `OTEL_SERVICE_NAME` not set)
 - `OTEL_EXPORTER_OTLP_HEADERS`: Global headers for OTLP export
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (takes precedence)
+- `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9, default: 6)
 
 Header format examples:
 ```bash
@@ -86,6 +87,9 @@ export OTEL_EXPORTER_OTLP_HEADERS="api-key=secret123,custom-header=value"
 
 # Headers with special characters
 export OTEL_EXPORTER_OTLP_HEADERS="authorization=Basic dXNlcjpwYXNzd29yZA=="
+
+# Set compression level (0 = no compression, 9 = maximum compression)
+export OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL="9"
 ```
 
 ## Output Format
@@ -117,6 +121,8 @@ The exporter can be configured with different GZIP compression levels:
 // Create exporter with custom GZIP level (0-9)
 let exporter = OtlpStdoutSpanExporter::with_gzip_level(9);
 ```
+
+You can also configure the compression level using the `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable. The explicit configuration via code will override any environment variable setting.
 
 ## Development
 

--- a/packages/rust/otlp-stdout-span-exporter/examples/hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/hello.rs
@@ -1,5 +1,5 @@
 use opentelemetry::trace::{Tracer, TracerProvider};
-use opentelemetry_sdk::{runtime, trace::TracerProvider as SdkTracerProvider, Resource};
+use opentelemetry_sdk::{trace::SdkTracerProvider, Resource};
 use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
 use std::thread;
 use std::time::Duration;
@@ -13,8 +13,8 @@ async fn main() {
 
     // Create a new tracer provider with the exporter
     let provider = SdkTracerProvider::builder()
-        .with_batch_exporter(exporter, runtime::Tokio)
-        .with_resource(Resource::default())
+        .with_batch_exporter(exporter)
+        .with_resource(Resource::builder().build())
         .build();
 
     // Create a tracer


### PR DESCRIPTION
This pull request introduces several changes to the Rust OTLP Stdout Span Exporter package, including the addition of a GitHub Actions workflow for publishing, version updates, and enhancements to the exporter functionality and documentation.

### Workflow and Automation:
* Added a new GitHub Actions workflow to automate testing and publishing of the Rust OTLP Stdout Span Exporter package. The workflow triggers on pull requests and pushes to the main branch, running tests on both x64 and arm64 architectures, and publishing to crates.io if tests pass. (`.github/workflows/publish-rust-otlp-stdout-span-exporter.yml`)

### Version and Dependency Updates:
* Updated the package version to `0.9.0` and upgraded OpenTelemetry dependencies to version `0.28.0`. (`Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-R17) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L31-R46)
* Updated the `CHANGELOG.md` to reflect the new version and changes. (`packages/rust/otlp-stdout-span-exporter/CHANGELOG.md`)

### New Features and Enhancements:
* Added support for configuring GZIP compression level via the `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable. (`packages/rust/otlp-stdout-span-exporter/src/lib.rs`) [[1]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L85-R103) [[2]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L225-R233) [[3]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040R277-R295)
* Improved error handling by using `OTelSdkError` instead of `TraceError`. (`packages/rust/otlp-stdout-span-exporter/src/lib.rs`) [[1]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L115-R127) [[2]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L151-R155)

### Documentation:
* Enhanced the documentation to include examples for the new environment variable and updated the `README.md` to reflect changes in configuration options. (`packages/rust/otlp-stdout-span-exporter/README.md`) [[1]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R78) [[2]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R90-R92) [[3]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R125-R126)
* Added a comprehensive `PUBLISHING.md` checklist to guide the publishing process. (`packages/rust/otlp-stdout-span-exporter/PUBLISHING.md`)