### PR TITLE
Release/rust lambda otel lite 0.9.0

### DIFF
--- a/.github/workflows/publish-rust-lambda-otel-lite.yml
+++ b/.github/workflows/publish-rust-lambda-otel-lite.yml
@@ -1,0 +1,104 @@
+name: Publish Rust Lambda OTel Lite
+
+on:
+  # Trigger on PRs that touch the Rust package
+  pull_request:
+    paths:
+      - 'packages/rust/lambda-otel-lite/**'
+    types: [opened, synchronize]
+  # Trigger on merges to main that touch the Rust package
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/rust/lambda-otel-lite/**'
+
+# Add permissions needed for the workflow
+permissions:
+  contents: write  # Needed for pushing tags
+  id-token: write  # Needed for publishing to crates.io
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          # x64 runner
+          - os: ubuntu-latest
+            arch: x64
+            rust-version: stable
+          # arm64 runner
+          - os: ubuntu-22.04-arm
+            arch: arm64
+            rust-version: stable
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: packages/rust/lambda-otel-lite
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          components: rustfmt, clippy
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+
+      - name: Run quality checks
+        run: |
+          cargo fmt --check
+          cargo clippy -- -D warnings
+          cargo test
+          cargo build --release
+
+  publish:
+    needs: test
+    # Only run on pushes to main, never on PRs
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/rust/lambda-otel-lite
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/rust/lambda-otel-lite
+
+      - name: Build package
+        run: cargo build --release
+
+      - name: Verify package version
+        run: |
+          PACKAGE_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "lambda-otel-lite") | .version')
+          if git tag -l | grep -q "rust-v$PACKAGE_VERSION"; then
+            echo "Version $PACKAGE_VERSION already published"
+            exit 1
+          fi
+          echo "Publishing version $PACKAGE_VERSION"
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Create and push tag
+        run: |
+          PACKAGE_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "lambda-otel-lite") | .version')
+          git tag "rust-v$PACKAGE_VERSION"
+          git push origin "rust-v$PACKAGE_VERSION" 

--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated tracing-opentelemetry from v0.28.0 to v0.29.0
 - Updated error handling to use `OTelSdkError` and `OTelSdkResult` instead of `TraceError` and `TraceResult`
 
+### Improved
+- **Logging System**: Enhanced the `Logger` implementation with compile-time initialization support through `const_new`
+- **Module Loggers**: Added static module-specific loggers for improved performance and code readability
+
 ### Fixed
 - Fixed resource attribute access in tests to properly handle the tuple structure returned by the resource iterator
 
@@ -32,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated examples to handle the new tuple return type from `init_telemetry()`
 - Improved module-level documentation with clearer examples
 - Enhanced API documentation to reflect the updated methods
+- Added documentation for using static loggers with the new `const_new` constructor
 
 ## [0.6.0] - 2025-02-07
 ### Added

--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -6,7 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.6.0] - 2024-02-07
+## [0.9.0] - 2025-03-01
+### Breaking Changes
+- **API Change**: Modified the return type of `init_telemetry()` to return a tuple `(tracer, completion_handler)` instead of just the completion handler
+- **Removed**: The `library_name` parameter has been removed from `TelemetryConfig`
+- **Removed**: The `ProcessorConfig` struct has been removed, with its functionality integrated directly into the `LambdaSpanProcessor` builder pattern
+- **SDK Update**: Updated to OpenTelemetry SDK v0.28.0, which changes how resources and providers are created
+
+### Changed
+- **Resource Creation**: Changed from `Resource::new()` to `Resource::builder().with_attributes().build()` pattern
+- **Provider Creation**: Changed from `TracerProviderBuilder::default()` to `SdkTracerProvider::builder()`
+- **Batch Export**: Removed explicit runtime specification (e.g., `Tokio`) from batch exporter creation
+- **HTTP Client**: Updated HTTP client implementation to use `send_bytes` instead of `send`
+- **Shutdown Mechanism**: Changed from `global::shutdown_tracer_provider()` to `tracer_provider.shutdown()`
+- Added `max_batch_size` parameter directly to `LambdaSpanProcessor` for better control over batch processing
+- Added `get_tracer()` method to `TelemetryCompletionHandler` to retrieve the tracer
+- Updated tracing-opentelemetry from v0.28.0 to v0.29.0
+- Updated error handling to use `OTelSdkError` and `OTelSdkResult` instead of `TraceError` and `TraceResult`
+
+### Fixed
+- Fixed resource attribute access in tests to properly handle the tuple structure returned by the resource iterator
+
+### Documentation
+- Updated examples to use the new Resource builder pattern
+- Updated examples to handle the new tuple return type from `init_telemetry()`
+- Improved module-level documentation with clearer examples
+- Enhanced API documentation to reflect the updated methods
+
+## [0.6.0] - 2025-02-07
 ### Added
 - New `extractors` module for attribute extraction from Lambda events
 - New `resource` module for Lambda resource attribute management

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["examples/"]
 
 [dependencies]
 opentelemetry.workspace = true
-opentelemetry_sdk = { version = "0.27.1", features = ["testing"] }
+opentelemetry_sdk.workspace = true
 tokio.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
@@ -27,7 +27,7 @@ tower = "0.5.2"
 futures-util = "0.3.31"
 futures-executor = "0.3.31"
 tracing-subscriber = "0.3.19"
-tracing-opentelemetry = "0.28.0"
+tracing-opentelemetry.workspace = true
 pin-project = "1.1.8"
 serde.workspace = true
 aws_lambda_events.workspace = true
@@ -36,8 +36,10 @@ bon = "3.3"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "sync", "macros", "test-util"] }
 mockall = "0.13.1"
-serial_test = "2.0.0"
 opentelemetry-otlp = { workspace = true, features = ["http-proto", "http-json", "reqwest-client"] }
 libc = "0.2"
 doc-comment = "0.3"
+reqwest = { version = "0.12", features = ["json"] }
+rand = "0.9.0"
 sealed_test = "1.0"
+serial_test = "2.0.0"

--- a/packages/rust/lambda-otel-lite/PUBLISHING.md
+++ b/packages/rust/lambda-otel-lite/PUBLISHING.md
@@ -1,0 +1,100 @@
+# Publishing Checklist
+
+Before publishing a new version of `lambda-otel-lite`, ensure all these items are checked:
+
+## Cargo.toml Verification
+- [ ] `version` is correctly incremented (following semver)
+- [ ] `name` is correct
+- [ ] `description` is clear and up-to-date
+- [ ] `license` is specified
+- [ ] `keywords` are defined and relevant
+- [ ] `categories` are appropriate
+- [ ] `repository` information is complete and correct
+- [ ] `homepage` URL is valid
+- [ ] `documentation` URL is specified
+- [ ] Dependencies are up-to-date and correct
+- [ ] No extraneous dependencies
+- [ ] Development dependencies are in `[dev-dependencies]`
+- [ ] Feature flags are correctly defined
+- [ ] Minimum supported Rust version (MSRV) is specified if needed
+
+## Documentation
+- [ ] `README.md` is up-to-date
+- [ ] Version number in documentation matches Cargo.toml
+- [ ] All examples in documentation work
+- [ ] API documentation is complete (all public items have doc comments)
+- [ ] Breaking changes are clearly documented
+- [ ] `CHANGELOG.md` is updated
+- [ ] Feature flags are documented
+- [ ] All public APIs have usage examples
+
+## Code Quality
+- [ ] All tests pass (`cargo test`)
+- [ ] Code is properly formatted (`cargo fmt`)
+- [ ] Format check passes (`cargo fmt --check`)
+- [ ] Linting passes (`cargo clippy`)
+- [ ] No debug code or println! macros (except in logging)
+- [ ] Test coverage is satisfactory
+- [ ] All public APIs have proper documentation
+- [ ] No unsafe code (or if present, properly documented and justified)
+- [ ] All compiler warnings are addressed
+- [ ] Documentation tests (`cargo test --doc`) pass
+
+## Git Checks
+- [ ] Working on the correct branch
+- [ ] All changes are committed
+- [ ] No unnecessary files in git
+- [ ] Git tags are ready to be created
+- [ ] `.gitignore` is up-to-date
+
+## Publishing Steps
+1. Update version in `Cargo.toml`
+2. Update `CHANGELOG.md`
+3. Format code: `cargo fmt`
+4. Run format check: `cargo fmt --check`
+5. Run clippy: `cargo clippy -- -D warnings`
+6. Run tests: `cargo test`
+7. Run doc tests: `cargo test --doc`
+8. Build in release mode: `cargo build --release`
+9. Verify documentation: `cargo doc --no-deps`
+10. Commit changes: `git commit -am "Release vX.Y.Z"`
+11. Create a Pull Request to merge your changes to the main branch
+
+## Automated Publishing
+The package is automatically published to crates.io by the GitHub Action workflow `.github/workflows/publish-rust-lambda-otel-lite.yml` when changes are merged to the main branch. The workflow:
+
+1. Runs all tests and quality checks on both x64 and arm64 architectures
+2. Verifies the package version hasn't been published before
+3. Publishes the package to crates.io
+4. Creates and pushes a git tag in the format `rust-vX.Y.Z`
+
+There's no need to manually publish or create tags.
+
+## Post-Publishing
+- [ ] Verify package installation works: `cargo add lambda-otel-lite`
+- [ ] Verify documentation appears correctly on docs.rs
+- [ ] Test the package in a new project
+- [ ] Update any dependent crates
+- [ ] Verify examples compile and run correctly
+
+## Common Issues to Check
+- Missing files in the published package
+- Incorrect feature flags
+- Missing or incorrect documentation
+- Broken links in documentation
+- Incorrect version numbers
+- Missing changelog entries
+- Unintended breaking changes
+- Incomplete crate metadata
+- Platform-specific issues
+- MSRV compatibility issues
+
+## Notes
+- Always use `cargo package` first to verify the package contents
+- Test the package with different feature combinations
+- Consider cross-platform compatibility
+- Test with the minimum supported Rust version
+- Consider running `cargo audit` for security vulnerabilities
+- Use `cargo clippy` with all relevant feature combinations
+- Remember to update any related documentation or examples in the main repository
+- Consider testing on different architectures (x86_64, aarch64) 

--- a/packages/rust/lambda-otel-lite/README.md
+++ b/packages/rust/lambda-otel-lite/README.md
@@ -179,7 +179,7 @@ use lambda_runtime::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
     // ...
     Ok(())
 }
@@ -194,16 +194,18 @@ use lambda_runtime::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let resource = Resource::new(vec![
-        KeyValue::new("service.version", "1.0.0"),
-        KeyValue::new("deployment.environment", "production"),
-    ]);
+    let resource = Resource::builder()
+        .with_attributes(vec![
+            KeyValue::new("service.version", "1.0.0"),
+            KeyValue::new("deployment.environment", "production"),
+        ])
+        .build();
 
     let config = TelemetryConfig::builder()
         .resource(resource)
         .build();
 
-    let completion_handler = init_telemetry(config).await?;
+    let (_, completion_handler) = init_telemetry(config).await?;
     // ...
     Ok(())
 }
@@ -224,7 +226,7 @@ async fn main() -> Result<(), Error> {
         .with_propagator(BaggagePropagator::new())
         .build();
 
-    let completion_handler = init_telemetry(config).await?;
+    let (_, completion_handler) = init_telemetry(config).await?;
     // ...
     Ok(())
 }
@@ -246,14 +248,14 @@ async fn main() -> Result<(), Error> {
         .with_span_processor(SimpleSpanProcessor::new(
             Box::new(OtlpStdoutSpanExporter::default())
         ))
-        .library_name("instrumented-service".to_string())
         .enable_fmt_layer(true)
         .build();
 
-    let completion_handler = init_telemetry(config).await?;
+    let (_, completion_handler) = init_telemetry(config).await?;
     Ok(())
 }
 ```
+
 Note that the `.with_span_processor` method accepts a `SpanProcessor` trait object, so you can pass in any type that implements the `SpanProcessor` trait, and can be called multiple times. The order of the processors is the order of the calls to `.with_span_processor`.
 
 ### Using the Tower Layer
@@ -264,8 +266,9 @@ use lambda_otel_lite::{init_telemetry, TelemetryConfig, OtelTracingLayer};
 use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
 use lambda_runtime::tower::ServiceBuilder;
 use aws_lambda_events::event::apigw::ApiGatewayV2httpRequest;
+use serde_json::Value;
 
-async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<serde_json::Value, Error> {
+async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<Value, Error> {
     Ok(serde_json::json!({
         "statusCode": 200,
         "body": format!("Hello from request {}", event.context.request_id)
@@ -275,7 +278,7 @@ async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<serde_js
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize telemetry with default configuration
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
 
     // Build service with OpenTelemetry tracing middleware
     let service = ServiceBuilder::new()
@@ -283,36 +286,34 @@ async fn main() -> Result<(), Error> {
         .service_fn(handler);
 
     // Create and run the Lambda runtime
-    let runtime = Runtime::new(service);
-    runtime.run().await
+    Runtime::new(service).run().await
 }
 ```
 
 ### Using the handler wrapper function
-Or, you can use the `traced_handler` function to wrap your handler:
+Or, you can use the `create_traced_handler` function to wrap your handler:
 
 ```rust no_run
-use lambda_otel_lite::{init_telemetry, traced_handler, TelemetryConfig};
+use lambda_otel_lite::{init_telemetry, TelemetryConfig, create_traced_handler};
 use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
 use aws_lambda_events::event::apigw::ApiGatewayV2httpRequest;
+use serde_json::Value;
 
-async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<serde_json::Value, Error> {
-    Ok(serde_json::json!({
-        "statusCode": 200,
-        "body": format!("Hello from request {}", event.context.request_id)
-    }))
+async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<Value, Error> {
+    Ok(serde_json::json!({ "statusCode": 200 }))
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
     
-    // Create and run the Lambda runtime with the traced handler
-    let runtime = Runtime::new(service_fn(|event| {
-        traced_handler("my-handler", event, completion_handler.clone(), handler)
-    }));
+    let handler = create_traced_handler(
+        "my-handler",
+        completion_handler,
+        handler
+    );
 
-    runtime.run().await
+    Runtime::new(service_fn(handler)).run().await
 }
 ```
 
@@ -321,11 +322,12 @@ async fn main() -> Result<(), Error> {
 For other events than the one directly supported by the crate, you can implement the `SpanAttributesExtractor` trait for your own event types:
 
 ```rust no_run
-use lambda_otel_lite::{init_telemetry, traced_handler, TelemetryConfig, SpanAttributes, SpanAttributesExtractor};
+use lambda_otel_lite::{init_telemetry, TelemetryConfig, create_traced_handler, SpanAttributes, SpanAttributesExtractor};
 use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use opentelemetry::Value;
+use serde_json::Value as JsonValue;
 
 // Define a custom event type
 #[derive(Clone, Deserialize, Serialize)]
@@ -353,7 +355,7 @@ impl SpanAttributesExtractor for MyEvent {
     }
 }
 
-async fn handler(event: LambdaEvent<MyEvent>) -> Result<serde_json::Value, Error> {
+async fn handler(event: LambdaEvent<MyEvent>) -> Result<JsonValue, Error> {
     Ok(serde_json::json!({
         "statusCode": 200,
         "body": format!("Hello, user {}", event.payload.user_id)
@@ -362,51 +364,18 @@ async fn handler(event: LambdaEvent<MyEvent>) -> Result<serde_json::Value, Error
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let config = TelemetryConfig::default();
+    let (_, completion_handler) = init_telemetry(config).await?;
     
-    // Create and run the Lambda runtime with the traced handler
-    let runtime = Runtime::new(service_fn(|event| {
-        traced_handler("my-handler", event, completion_handler.clone(), handler)
-    }));
+    let handler = create_traced_handler(
+        "my-handler",
+        completion_handler,
+        handler
+    );
 
-    runtime.run().await
+    Runtime::new(service_fn(handler)).run().await
 }
 ```
-
-
-## Automatic FAAS Attributes
-
-The crate automatically sets relevant FAAS attributes based on the Lambda context and event:
-
-| Attribute Type | Attribute Name | Source | Description |
-|----------------|----------------|---------|-------------|
-| Resource Attributes | `cloud.provider` | "aws" | Cloud provider identifier |
-| | `cloud.region` | AWS_REGION | AWS region where function runs |
-| | `faas.name` | AWS_LAMBDA_FUNCTION_NAME | Lambda function name |
-| | `faas.version` | AWS_LAMBDA_FUNCTION_VERSION | Function version ($LATEST or version number) |
-| | `faas.instance` | AWS_LAMBDA_LOG_STREAM_NAME | Unique instance identifier |
-| | `faas.max_memory` | AWS_LAMBDA_FUNCTION_MEMORY_SIZE | Maximum memory in bytes |
-| | `service.name` | OTEL_SERVICE_NAME or function name | Service identifier |
-| | Additional attributes | OTEL_RESOURCE_ATTRIBUTES | Custom key-value pairs |
-| Span Attributes | `faas.coldstart` | Runtime detection | Boolean flag set to true only on first invocation of a new instance |
-| | `faas.invocation_id` | Lambda request ID | Unique invocation identifier |
-| | `cloud.account.id` | Function ARN | AWS account ID |
-| | `cloud.resource_id` | Function ARN | Complete function ARN |
-| | `otel.kind` | "SERVER" (default) | Span kind |
-| | `otel.status_code`/`message` | Response processing | Error details if applicable |
-| HTTP Attributes | `faas.trigger` | Event type detection | "http" for API/ALB events |
-| | `http.status_code` | Response | HTTP status code if present |
-| | `http.route` | Event source | Route key or resource path |
-| | `http.method` | Event source | HTTP method |
-| | `url.path` | Event source | Request path |
-| | `url.query` | Event source | Query parameters if present |
-| | `url.scheme` | Event source | Protocol (https) |
-| | `network.protocol.version` | Event source | HTTP version |
-| | `client.address` | Event source | Client IP address |
-| | `user_agent.original` | Event source | User agent string |
-| | `server.address` | Event source | Server hostname |
-
-The crate automatically detects API Gateway v1/v2 and ALB events and sets the appropriate HTTP attributes. For HTTP responses, the status code is automatically extracted from the handler's response and set as `http.status_code`. For 5xx responses, the span status is set to ERROR.
 
 ## Distributed Tracing with non-HTTP events
 
@@ -467,19 +436,17 @@ async fn function_handler(event: LambdaEvent<MyCustomEvent>) -> Result<JsonValue
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize telemetry with default configuration
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
 
     // Create a service with the OtelTracingLayer
     let service = ServiceBuilder::new()
-        .layer(OtelTracingLayer::<MyCustomEvent>::new(completion_handler))
+        .layer(OtelTracingLayer::new(completion_handler))
         .service_fn(function_handler);
 
     // Start the Lambda runtime
     Runtime::new(service).run().await
 }
 ```
-
-The above example shows how to implement distributed tracing for custom events. The `MyCustomEvent` type includes the standard W3C trace context fields (`traceparent` and `tracestate`). When an event is published to your Lambda function, the downstream service should include these trace context headers. The `SpanAttributesExtractor` implementation extracts these headers, allowing the Lambda function's spans to be properly connected to the downstream service's trace.
 
 ## Environment Variables
 
@@ -491,6 +458,7 @@ The crate can be configured using the following environment variables:
   - `async`: Deferred export via extension
   - `finalize`: Custom export strategy
 - `LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE`: Maximum number of spans to queue in the ring buffer (default: 2048)
+- `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE`: Maximum number of spans to export in a single batch (default: 512)
 
 ### Resource Configuration
 - `OTEL_SERVICE_NAME`: Override the service name (defaults to function name)
@@ -509,7 +477,8 @@ The crate can be configured using the following environment variables:
   - `RUST_LOG` takes precedence if both are set
   - Example: `RUST_LOG=lambda_otel_lite=debug`
   - Example: `AWS_LAMBDA_LOG_LEVEL=DEBUG` (used if RUST_LOG is not set)
+  - Can be customized via `TelemetryConfig::builder().env_var_name("CUSTOM_LOG_VAR")`
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details. 
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/rust/lambda-otel-lite/examples/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/examples/Cargo.toml
@@ -13,6 +13,9 @@ lambda_runtime.workspace = true
 tracing.workspace = true
 aws_lambda_events.workspace = true
 lambda-otel-lite.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
+rand = "0.9.0"
 
 [[bin]]
 name = "handler-example"

--- a/packages/rust/lambda-otel-lite/examples/handler/main.rs
+++ b/packages/rust/lambda-otel-lite/examples/handler/main.rs
@@ -1,46 +1,103 @@
 use aws_lambda_events::event::apigw::ApiGatewayV2httpRequest;
-use lambda_otel_lite::{init_telemetry, traced_handler, TelemetryConfig};
+use lambda_otel_lite::{create_traced_handler, init_telemetry, TelemetryConfig};
 use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
+use opentelemetry::trace::Status;
+use rand::Rng;
 use serde_json::Value;
+use std::borrow::Cow;
+use std::fmt::{self, Display};
+use tracing::{error, info, instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+// Define error type as a simple enum
+#[derive(Debug)]
+enum ErrorType {
+    Expected,
+    Unexpected,
+}
 
-use tracing::{info, info_span, instrument}; 
+impl Display for ErrorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
 
-/// Simple Lambda function that logs the event and returns it.
+/// Simple nested function that creates its own span.
+#[instrument(skip(event), level = "info", err)]
+async fn nested_function(event: &ApiGatewayV2httpRequest) -> Result<String, ErrorType> {
+    info!("Nested function called");
+
+    // Simulate random errors if the path is /error
+    if event.raw_path.as_deref() == Some("/error") {
+        let r: f64 = rand::rng().random();
+        if r < 0.25 {
+            return Err(ErrorType::Expected);
+        } else if r < 0.5 {
+            return Err(ErrorType::Unexpected);
+        }
+    }
+
+    Ok("success".to_string())
+}
+
+/// Simple Hello World Lambda function using lambda-otel-lite.
 ///
 /// This example demonstrates basic OpenTelemetry setup with lambda-otel-lite.
-/// It creates spans for each invocation and logs the event payload.
+/// It creates spans for each invocation and logs the event payload using span events.
 async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<Value, Error> {
     // Extract request ID from the event for correlation
     let request_id = &event.context.request_id;
-    info!(request_id, "handling request");
+    let current_span = tracing::Span::current();
 
-    nested_function().await;
+    // Set request ID as span attribute
+    current_span.set_attribute("request.id", request_id.to_string());
 
-    // Return a simple response
-    Ok(serde_json::json!({
-        "statusCode": 200,
-        "body": format!("Hello from request {}", request_id)
-    }))
-}
+    // Log the full event payload like in Python version
+    info!(
+        event = serde_json::to_string(&event.payload).unwrap_or_default(),
+        "handling request"
+    );
 
-/// Simple nested function that logs a message.
-///
-/// This function is used to demonstrate the nested span functionality of OpenTelemetry.
-#[instrument(skip_all)]
-async fn nested_function() {
-    info_span!("Nested function called");
+    // Call the nested function and handle potential errors
+    match nested_function(&event.payload).await {
+        Ok(_) => {
+            // Return a successful response
+            Ok(serde_json::json!({
+                "statusCode": 200,
+                "body": format!("Hello from request {}", request_id)
+            }))
+        }
+        Err(ErrorType::Expected) => {
+            // Log the error and return a 400 Bad Request
+            error!("Expected error occurred");
+
+            // Return a 400 Bad Request for expected errors
+            Ok(serde_json::json!({
+                "statusCode": 400,
+                "body": format!("{{\"message\": \"This is an expected error\"}}")
+            }))
+        }
+        Err(ErrorType::Unexpected) => {
+            // For other errors, propagate them up
+            error!("Unexpected error occurred");
+
+            // Set span status to ERROR like in Python version
+            current_span.set_status(Status::Error {
+                description: Cow::Borrowed("Unexpected error occurred"),
+            });
+
+            Err(Error::from("Unexpected error occurred"))
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize telemetry with default config
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
 
-    // Create the Lambda service function
-    let runtime = Runtime::new(service_fn(|event| {
-        traced_handler("simple-handler", event, completion_handler.clone(), handler)
-    }));
+    // Create the traced handler
+    let handler = create_traced_handler("simple-handler", completion_handler, handler);
 
-    // Run the Lambda service
-    runtime.run().await
+    // Use it directly with the runtime
+    Runtime::new(service_fn(handler)).run().await
 }

--- a/packages/rust/lambda-otel-lite/examples/template.yaml
+++ b/packages/rust/lambda-otel-lite/examples/template.yaml
@@ -6,19 +6,19 @@ Description: AWS SAM template for the serverless-otlp-forwarder application.
 Globals:
   Function:
     MemorySize: 128
-    Timeout: 30
+    Timeout: 3
     Architectures:
       - arm64
     Runtime: provided.al2023
     LoggingConfig:
       LogFormat: JSON
-      ApplicationLogLevel: INFO
-      SystemLogLevel: WARN
+      ApplicationLogLevel: DEBUG
+      SystemLogLevel: INFO
   
 
 Resources:
-
   HandlerExample:
+    # instrumented with create_traced_handler
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: rust-cargolambda
@@ -31,8 +31,12 @@ Resources:
       Description: 'Demo Handler Example Lambda function to showcase OpenTelemetry integration'
       FunctionUrlConfig:
         AuthType: NONE
+      Environment:
+        Variables:
+          LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: async
 
   TowerExample:
+    # instrumented with the Tower layer
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: rust-cargolambda
@@ -46,14 +50,11 @@ Resources:
       Description: 'Demo Tower Example Lambda function to showcase OpenTelemetry integration'
       FunctionUrlConfig:
         AuthType: NONE
+      Environment:
+        Variables:
+          LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: async
 
 Outputs:
-  HandlerExampleLambdaFunctionArn:
-    Description: 'ARN of the Demo Handler Example Lambda function'
-    Value: !GetAtt HandlerExample.Arn
-  TowerExampleLambdaFunctionArn:
-    Description: 'ARN of the Demo Tower Example Lambda function'
-    Value: !GetAtt TowerExample.Arn
   HandlerExampleFunctionUrl:
     Description: 'URL of the Demo Handler Example Lambda function'
     Value: !GetAtt HandlerExampleUrl.FunctionUrl

--- a/packages/rust/lambda-otel-lite/examples/tower/main.rs
+++ b/packages/rust/lambda-otel-lite/examples/tower/main.rs
@@ -1,38 +1,99 @@
 use aws_lambda_events::event::apigw::ApiGatewayV2httpRequest;
 use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 use lambda_runtime::{tower::ServiceBuilder, Error, LambdaEvent, Runtime};
+use opentelemetry::trace::Status;
+use rand::Rng;
 use serde_json::Value;
-use tracing::{info, instrument};
+use std::borrow::Cow;
+use std::fmt::{self, Display};
+use tracing::{error, info, instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+// Define error type as a simple enum
+#[derive(Debug)]
+enum ErrorType {
+    Expected,
+    Unexpected,
+}
 
-/// Simple Lambda function that logs the event and returns it.
+impl Display for ErrorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// Simple nested function that creates its own span.
+#[instrument(skip(event), level = "info", err)]
+async fn nested_function(event: &ApiGatewayV2httpRequest) -> Result<String, ErrorType> {
+    info!("Nested function called");
+
+    // Simulate random errors if the path is /error
+    if event.raw_path.as_deref() == Some("/error") {
+        let r: f64 = rand::rng().random();
+        if r < 0.25 {
+            return Err(ErrorType::Expected);
+        } else if r < 0.5 {
+            return Err(ErrorType::Unexpected);
+        }
+    }
+
+    Ok("success".to_string())
+}
+
+/// Simple Hello World Lambda function using lambda-otel-lite.
 ///
 /// This example demonstrates basic OpenTelemetry setup with lambda-otel-lite.
-/// It creates spans for each invocation and logs the event payload.
+/// It creates spans for each invocation and logs the event payload using span events.
 async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<Value, Error> {
     // Extract request ID from the event for correlation
     let request_id = &event.context.request_id;
-    info!(request_id, "handling request");
+    let current_span = tracing::Span::current();
 
-    nested_function().await;
-    // Return a simple response
-    Ok(serde_json::json!({
-        "statusCode": 200,
-        "body": format!("Hello from request {}", request_id)
-    }))
-}
+    // Set request ID as span attribute
+    current_span.set_attribute("request.id", request_id.to_string());
 
-/// Simple nested function that logs a message.
-///
-/// This function is used to demonstrate the nested span functionality of OpenTelemetry.
-#[instrument(skip_all)]
-async fn nested_function() {
-    tracing::debug!("Nested function called");
+    // Log the full event payload like in Python version
+    info!(
+        event = serde_json::to_string(&event.payload).unwrap_or_default(),
+        "handling request"
+    );
+
+    // Call the nested function and handle potential errors
+    match nested_function(&event.payload).await {
+        Ok(_) => {
+            // Return a successful response
+            Ok(serde_json::json!({
+                "statusCode": 200,
+                "body": format!("Hello from request {}", request_id)
+            }))
+        }
+        Err(ErrorType::Expected) => {
+            // Log the error and return a 400 Bad Request
+            error!("Expected error occurred");
+
+            // Return a 400 Bad Request for expected errors
+            Ok(serde_json::json!({
+                "statusCode": 400,
+                "body": format!("{{\"message\": \"This is an expected error\"}}")
+            }))
+        }
+        Err(ErrorType::Unexpected) => {
+            // For other errors, propagate them up
+            error!("Unexpected error occurred");
+
+            // Set span status to ERROR like in Python version
+            current_span.set_status(Status::Error {
+                description: Cow::Borrowed("Unexpected error occurred"),
+            });
+
+            Err(Error::from("Unexpected error occurred"))
+        }
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     // Initialize telemetry with default configuration
-    let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
 
     // Build service with OpenTelemetry tracing middleware
     let service = ServiceBuilder::new()

--- a/packages/rust/lambda-otel-lite/src/extension.rs
+++ b/packages/rust/lambda-otel-lite/src/extension.rs
@@ -35,8 +35,8 @@
 //! - Implements graceful shutdown on SIGTERM
 //! - Handles channel communication failures
 
-use crate::ProcessorMode;
 use crate::logger::Logger;
+use crate::ProcessorMode;
 use lambda_extension::{service_fn, Error, Extension, NextEvent};
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use std::sync::Arc;

--- a/packages/rust/lambda-otel-lite/src/lib.rs
+++ b/packages/rust/lambda-otel-lite/src/lib.rs
@@ -157,11 +157,11 @@ pub mod extension;
 pub mod extractors;
 pub mod handler;
 pub mod layer;
+pub mod logger;
 pub mod mode;
 pub mod processor;
 pub mod resource;
 pub mod telemetry;
-pub mod logger;
 
 pub use extension::OtelInternalExtension;
 pub use extractors::{SpanAttributes, SpanAttributesExtractor, TriggerType};

--- a/packages/rust/lambda-otel-lite/src/lib.rs
+++ b/packages/rust/lambda-otel-lite/src/lib.rs
@@ -100,28 +100,25 @@
 //! ## Using the Tower Layer
 //!
 //! ```no_run
-//! use lambda_otel_lite::{init_telemetry, TelemetryConfig, OtelTracingLayer};
+//! use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 //! use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
-//! use lambda_runtime::tower::ServiceBuilder;
 //! use aws_lambda_events::event::apigw::ApiGatewayV2httpRequest;
+//! use tower::ServiceBuilder;
+//! use serde_json::Value;
 //!
-//! async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<serde_json::Value, Error> {
-//!     Ok(serde_json::json!({
-//!         "statusCode": 200,
-//!         "body": format!("Hello from request {}", event.context.request_id)
-//!     }))
+//! async fn function_handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<Value, Error> {
+//!     Ok(serde_json::json!({ "statusCode": 200 }))
 //! }
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
-//!     let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
-//!
+//!     let (tracer, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
+//!     
 //!     let service = ServiceBuilder::new()
 //!         .layer(OtelTracingLayer::new(completion_handler).with_name("tower-handler"))
-//!         .service_fn(handler);
+//!         .service_fn(function_handler);
 //!
-//!     let runtime = Runtime::new(service);
-//!     runtime.run().await
+//!     Runtime::new(service).run().await
 //! }
 //! ```
 //!
@@ -130,26 +127,27 @@
 //! ## Using the Handler Wrapper
 //!
 //! ```no_run
-//! use lambda_otel_lite::{init_telemetry, TelemetryConfig, traced_handler};
+//! use lambda_otel_lite::{init_telemetry, create_traced_handler, TelemetryConfig};
 //! use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
-//! use aws_lambda_events::event::apigw::ApiGatewayV2httpRequest;
+//! use serde_json::Value;
 //!
-//! async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<serde_json::Value, Error> {
-//!     Ok(serde_json::json!({
-//!         "statusCode": 200,
-//!         "body": format!("Hello from request {}", event.context.request_id)
-//!     }))
+//! async fn handler(event: LambdaEvent<Value>) -> Result<Value, Error> {
+//!     Ok(serde_json::json!({ "statusCode": 200 }))
 //! }
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
-//!     let completion_handler = init_telemetry(TelemetryConfig::default()).await?;
+//!     let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
 //!     
-//!     let runtime = Runtime::new(service_fn(|event| {
-//!         traced_handler("my-handler", event, completion_handler.clone(), handler)
-//!     }));
+//!     // Create the traced handler
+//!     let handler = create_traced_handler(
+//!         "my-handler",
+//!         completion_handler,
+//!         handler
+//!     );
 //!
-//!     runtime.run().await
+//!     // Use it directly with the runtime
+//!     Runtime::new(service_fn(handler)).run().await
 //! }
 //! ```
 
@@ -159,15 +157,17 @@ pub mod extension;
 pub mod extractors;
 pub mod handler;
 pub mod layer;
+pub mod mode;
 pub mod processor;
 pub mod resource;
 pub mod telemetry;
 
-pub use extension::{register_extension, OtelInternalExtension};
+pub use extension::OtelInternalExtension;
 pub use extractors::{SpanAttributes, SpanAttributesExtractor, TriggerType};
-pub use handler::traced_handler;
+pub use handler::create_traced_handler;
 pub use layer::OtelTracingLayer;
-pub use processor::{LambdaSpanProcessor, ProcessorConfig, ProcessorMode};
+pub use mode::ProcessorMode;
+pub use processor::LambdaSpanProcessor;
 pub use resource::get_lambda_resource;
 pub use telemetry::{
     init_telemetry, TelemetryCompletionHandler, TelemetryConfig, TelemetryConfigBuilder,

--- a/packages/rust/lambda-otel-lite/src/lib.rs
+++ b/packages/rust/lambda-otel-lite/src/lib.rs
@@ -161,6 +161,7 @@ pub mod mode;
 pub mod processor;
 pub mod resource;
 pub mod telemetry;
+pub mod logger;
 
 pub use extension::OtelInternalExtension;
 pub use extractors::{SpanAttributes, SpanAttributesExtractor, TriggerType};

--- a/packages/rust/lambda-otel-lite/src/logger.rs
+++ b/packages/rust/lambda-otel-lite/src/logger.rs
@@ -1,0 +1,151 @@
+//! Logging utilities for lambda-otel-lite.
+//!
+//! This module provides a simple logging interface with level filtering and prefixing.
+//! 
+//! # Example
+//! ```
+//! use lambda_otel_lite::logger::Logger;
+//! 
+//! // Create a logger for your module
+//! let logger = Logger::new("my_module");
+//! logger.info("Starting module");
+//! ```
+//!
+//! # Static Logger Example
+//! ```
+//! use lambda_otel_lite::logger::Logger;
+//! 
+//! // Define a static logger for your module
+//! static LOGGER: Logger = Logger::const_new("my_module");
+//! 
+//! // Use it directly
+//! LOGGER.info("Starting module");
+//! ```
+
+use std::env;
+use std::sync::OnceLock;
+
+// Default log level used for const initialization
+const DEFAULT_LOG_LEVEL: &str = "info";
+
+// Global log level cache
+static LOG_LEVEL: OnceLock<&'static str> = OnceLock::new();
+
+/// Get the log level from environment variables
+fn get_log_level() -> &'static str {
+    LOG_LEVEL.get_or_init(|| {
+        let level = env::var("AWS_LAMBDA_LOG_LEVEL")
+        .or_else(|_| env::var("LOG_LEVEL"))
+        .unwrap_or_else(|_| "info".to_string())
+        .to_lowercase();
+
+        match level.as_str() {
+            "none" | "error" | "warn" | "info" | "debug" => Box::leak(level.into_boxed_str()),
+            _ => "info",
+        }
+    })
+}
+
+/// Logger with level filtering and consistent prefixing
+#[derive(Clone)]
+pub struct Logger {
+    prefix: &'static str,
+    log_level_fn: fn() -> &'static str,
+}
+
+impl Logger {
+    /// Create a new logger with the given prefix
+    pub fn new(prefix: impl Into<String>) -> Self {
+        // Convert the prefix to a &'static str
+        let static_prefix = Box::leak(prefix.into().into_boxed_str());
+        
+        Self {
+            prefix: static_prefix,
+            log_level_fn: get_log_level,
+        }
+    }
+    
+    /// Create a new logger with the given prefix that can be used in const contexts
+    pub const fn const_new(prefix: &'static str) -> Self {
+        Self {
+            prefix,
+            log_level_fn: || DEFAULT_LOG_LEVEL,
+        }
+    }
+
+    // Get the current log level
+    fn log_level(&self) -> &'static str {
+        (self.log_level_fn)()
+    }
+
+    fn should_log(&self, level: &str) -> bool {
+        match self.log_level() {
+            "none" => false,
+            "error" => level == "error",
+            "warn" => matches!(level, "error" | "warn"),
+            "info" => matches!(level, "error" | "warn" | "info"),
+            "debug" => matches!(level, "error" | "warn" | "info" | "debug"),
+            _ => matches!(level, "error" | "warn" | "info"),
+        }
+    }
+
+    fn format_message(&self, message: &str) -> String {
+        format!("[{}] {}", self.prefix, message)
+    }
+
+    /// Log a debug message
+    pub fn debug(&self, message: impl AsRef<str>) {
+        if self.should_log("debug") {
+            println!("{}", self.format_message(message.as_ref()));
+        }
+    }
+
+    /// Log an info message
+    pub fn info(&self, message: impl AsRef<str>) {
+        if self.should_log("info") {
+            println!("{}", self.format_message(message.as_ref()));
+        }
+    }
+
+    /// Log a warning message
+    pub fn warn(&self, message: impl AsRef<str>) {
+        if self.should_log("warn") {
+            eprintln!("{}", self.format_message(message.as_ref()));
+        }
+    }
+
+    /// Log an error message
+    pub fn error(&self, message: impl AsRef<str>) {
+        if self.should_log("error") {
+            eprintln!("{}", self.format_message(message.as_ref()));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_log_levels() {
+        let logger = Logger::new("test");
+        
+        assert!(logger.should_log("error"));
+        assert!(logger.should_log("warn"));
+        assert!(logger.should_log("info"));
+        assert!(!logger.should_log("invalid"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_format_message() {
+        let logger = Logger::new("test");
+        
+        assert_eq!(
+            logger.format_message("hello"),
+            "[test] hello"
+        );
+    }
+} 

--- a/packages/rust/lambda-otel-lite/src/logger.rs
+++ b/packages/rust/lambda-otel-lite/src/logger.rs
@@ -1,11 +1,11 @@
 //! Logging utilities for lambda-otel-lite.
 //!
 //! This module provides a simple logging interface with level filtering and prefixing.
-//! 
+//!
 //! # Example
 //! ```
 //! use lambda_otel_lite::logger::Logger;
-//! 
+//!
 //! // Create a logger for your module
 //! let logger = Logger::new("my_module");
 //! logger.info("Starting module");
@@ -14,10 +14,10 @@
 //! # Static Logger Example
 //! ```
 //! use lambda_otel_lite::logger::Logger;
-//! 
+//!
 //! // Define a static logger for your module
 //! static LOGGER: Logger = Logger::const_new("my_module");
-//! 
+//!
 //! // Use it directly
 //! LOGGER.info("Starting module");
 //! ```
@@ -35,9 +35,9 @@ static LOG_LEVEL: OnceLock<&'static str> = OnceLock::new();
 fn get_log_level() -> &'static str {
     LOG_LEVEL.get_or_init(|| {
         let level = env::var("AWS_LAMBDA_LOG_LEVEL")
-        .or_else(|_| env::var("LOG_LEVEL"))
-        .unwrap_or_else(|_| "info".to_string())
-        .to_lowercase();
+            .or_else(|_| env::var("LOG_LEVEL"))
+            .unwrap_or_else(|_| "info".to_string())
+            .to_lowercase();
 
         match level.as_str() {
             "none" | "error" | "warn" | "info" | "debug" => Box::leak(level.into_boxed_str()),
@@ -58,13 +58,13 @@ impl Logger {
     pub fn new(prefix: impl Into<String>) -> Self {
         // Convert the prefix to a &'static str
         let static_prefix = Box::leak(prefix.into().into_boxed_str());
-        
+
         Self {
             prefix: static_prefix,
             log_level_fn: get_log_level,
         }
     }
-    
+
     /// Create a new logger with the given prefix that can be used in const contexts
     pub const fn const_new(prefix: &'static str) -> Self {
         Self {
@@ -131,7 +131,7 @@ mod tests {
     #[serial]
     fn test_log_levels() {
         let logger = Logger::new("test");
-        
+
         assert!(logger.should_log("error"));
         assert!(logger.should_log("warn"));
         assert!(logger.should_log("info"));
@@ -142,10 +142,7 @@ mod tests {
     #[serial]
     fn test_format_message() {
         let logger = Logger::new("test");
-        
-        assert_eq!(
-            logger.format_message("hello"),
-            "[test] hello"
-        );
+
+        assert_eq!(logger.format_message("hello"), "[test] hello");
     }
-} 
+}

--- a/packages/rust/lambda-otel-lite/src/mode.rs
+++ b/packages/rust/lambda-otel-lite/src/mode.rs
@@ -1,0 +1,135 @@
+use opentelemetry::{otel_debug, otel_warn};
+use std::env;
+
+/// Controls how spans are processed and exported.
+///
+/// This enum determines when and how OpenTelemetry spans are flushed from the buffer
+/// to the configured exporter. Each mode offers different tradeoffs between latency,
+/// reliability, and flexibility.
+///
+/// # Modes
+///
+/// - `Sync`: Immediate flush in handler thread
+///   - Spans are flushed before handler returns
+///   - Direct export without extension coordination
+///   - May be more efficient for small payloads and low memory configurations
+///   - Guarantees span delivery before response
+///
+/// - `Async`: Flush via Lambda extension
+///   - Spans are flushed after handler returns
+///   - Requires coordination with extension process
+///   - Additional overhead from IPC with extension
+///   - Provides retry capabilities through extension
+///
+/// - `Finalize`: Delegated to processor
+///   - Spans handled by configured processor
+///   - Compatible with BatchSpanProcessor
+///   - Best for custom export strategies
+///   - Full control over export timing
+///
+/// # Configuration
+///
+/// The mode can be configured using the `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE` environment variable:
+/// - "sync" for Sync mode (default)
+/// - "async" for Async mode
+/// - "finalize" for Finalize mode
+///
+/// # Example
+///
+/// ```no_run
+/// use lambda_otel_lite::ProcessorMode;
+/// use std::env;
+///
+/// // Set mode via environment variable
+/// env::set_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE", "async");
+///
+/// // Get mode from environment
+/// let mode = ProcessorMode::from_env();
+/// assert!(matches!(mode, ProcessorMode::Async));
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProcessorMode {
+    /// Synchronous flush in handler thread. Best for development and debugging.
+    Sync,
+    /// Asynchronous flush via extension. Best for production use to minimize latency.
+    Async,
+    /// Let processor handle flushing. Best with BatchSpanProcessor for custom export strategies.
+    Finalize,
+}
+
+impl ProcessorMode {
+    /// Create ProcessorMode from environment variable.
+    ///
+    /// Uses LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE environment variable.
+    /// Defaults to Sync mode if not set or invalid.
+    pub fn from_env() -> Self {
+        match env::var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE")
+            .map(|s| s.to_lowercase())
+            .as_deref()
+        {
+            Ok("sync") => {
+                otel_debug!(
+                    name: "ProcessorMode.from_env",
+                    message = "using sync processor mode"
+                );
+                ProcessorMode::Sync
+            }
+            Ok("async") => {
+                otel_debug!(
+                    name: "ProcessorMode.from_env",
+                    message = "using async processor mode"
+                );
+                ProcessorMode::Async
+            }
+            Ok("finalize") => {
+                otel_debug!(
+                    name: "ProcessorMode.from_env",
+                    message = "using finalize processor mode"
+                );
+                ProcessorMode::Finalize
+            }
+            Ok(value) => {
+                otel_warn!(
+                    name: "ProcessorMode.from_env",
+                    message = format!("invalid processor mode: {}, defaulting to sync", value)
+                );
+                ProcessorMode::Sync
+            }
+            Err(_) => {
+                otel_debug!(
+                    name: "ProcessorMode.from_env",
+                    message = "no processor mode set, defaulting to sync"
+                );
+                ProcessorMode::Sync
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_processor_mode_from_env() {
+        // Test default when not set
+        env::remove_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE");
+        assert!(matches!(ProcessorMode::from_env(), ProcessorMode::Sync));
+
+        // Test sync mode
+        env::set_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE", "sync");
+        assert!(matches!(ProcessorMode::from_env(), ProcessorMode::Sync));
+
+        // Test async mode
+        env::set_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE", "async");
+        assert!(matches!(ProcessorMode::from_env(), ProcessorMode::Async));
+
+        // Test finalize mode
+        env::set_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE", "finalize");
+        assert!(matches!(ProcessorMode::from_env(), ProcessorMode::Finalize));
+
+        // Test invalid value
+        env::set_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE", "invalid");
+        assert!(matches!(ProcessorMode::from_env(), ProcessorMode::Sync));
+    }
+}

--- a/packages/rust/lambda-otel-lite/src/processor.rs
+++ b/packages/rust/lambda-otel-lite/src/processor.rs
@@ -103,8 +103,8 @@
 //!    - Monitor for export failures in logs
 //!    - Consider retry strategies in custom exporters
 
-use bon::bon;
 use crate::logger::Logger;
+use bon::bon;
 
 /// Module-specific logger
 static LOGGER: Logger = Logger::const_new("processor");
@@ -351,10 +351,7 @@ where
                 if !batch.is_empty() {
                     let result = futures_executor::block_on(exporter.export(batch));
                     if let Err(err) = &result {
-                        LOGGER.debug(format!(
-                            "LambdaSpanProcessor.force_flush.Error: {:?}",
-                            err
-                        ));
+                        LOGGER.debug(format!("LambdaSpanProcessor.force_flush.Error: {:?}", err));
                         return result;
                     }
                 }
@@ -399,9 +396,9 @@ mod tests {
         trace::SpanExporter,
         trace::{SpanEvents, SpanLinks},
     };
+    use serial_test::serial;
     use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc};
     use tokio::sync::Mutex;
-    use serial_test::serial;
 
     fn setup_test_logger() -> Logger {
         Logger::new("test")

--- a/packages/rust/lambda-otel-lite/src/processor.rs
+++ b/packages/rust/lambda-otel-lite/src/processor.rs
@@ -1,32 +1,8 @@
 //! Span processor implementation optimized for AWS Lambda functions.
 //!
 //! This module provides a Lambda-optimized span processor that efficiently manages OpenTelemetry spans
-//! in a serverless environment. It uses a ring buffer to store spans in memory and supports different
-//! processing modes to balance latency and reliability.
-//!
-//! # Processing Modes
-//!
-//! The processor supports three modes for span export:
-//!
-//! 1. **Sync Mode** (default):
-//!    - Direct, synchronous export in handler thread
-//!    - Recommended for low-volume telemetry or when latency is not critical
-//!    - Best for development and debugging
-//!    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=sync`
-//!
-//! 2. **Async Mode**:
-//!    - Export via Lambda extension using AWS Lambda Extensions API
-//!    - Spans are queued and exported after handler completion
-//!    - Uses channel-based communication between handler and extension
-//!    - Best for production use with high telemetry volume
-//!    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=async`
-//!
-//! 3. **Finalize Mode**:
-//!    - Only registers extension with no events
-//!    - Ensures SIGTERM handler for graceful shutdown
-//!    - Compatible with BatchSpanProcessor for custom export strategies
-//!    - Best for specialized export requirements
-//!    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=finalize`
+//! in a serverless environment. It uses a ring buffer to store spans in memory and provides efficient
+//! batch processing capabilities.
 //!
 //! # Architecture
 //!
@@ -49,13 +25,12 @@
 //!
 //! The processor can be configured through environment variables:
 //!
-//! - `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE`: Controls processing mode
-//!   - "sync" for Sync mode (default)
-//!   - "async" for Async mode
-//!   - "finalize" for Finalize mode
-//!
 //! - `LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE`: Controls buffer size
 //!   - Defaults to 2048 spans
+//!   - Should be tuned based on span volume
+//!
+//! - `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE`: Controls batch size
+//!   - Defaults to 512 spans
 //!   - Should be tuned based on span volume
 //!
 //! # Usage Examples
@@ -63,27 +38,35 @@
 //! Basic setup with default configuration:
 //!
 //! ```no_run
-//! use lambda_otel_lite::{ProcessorConfig, LambdaSpanProcessor};
+//! use lambda_otel_lite::LambdaSpanProcessor;
 //! use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
 //!
-//! let processor = LambdaSpanProcessor::new(
-//!     Box::new(OtlpStdoutSpanExporter::default()),
-//!     ProcessorConfig::default()
-//! );
+//! let processor = LambdaSpanProcessor::builder()
+//!     .exporter(OtlpStdoutSpanExporter::default())
+//!     .build();
 //! ```
 //!
-//! Custom configuration for high-volume scenarios:
+//! Using with an OTLP HTTP exporter:
 //!
 //! ```no_run
-//! use lambda_otel_lite::{ProcessorConfig, LambdaSpanProcessor};
-//! use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+//! use lambda_otel_lite::LambdaSpanProcessor;
+//! use opentelemetry_otlp::{SpanExporter, Protocol};
+//! use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 //!
-//! let processor = LambdaSpanProcessor::new(
-//!     Box::new(OtlpStdoutSpanExporter::default()),
-//!     ProcessorConfig {
-//!         max_queue_size: 4096, // Larger buffer for high volume
-//!     }
-//! );
+//! // Important: When using HTTP exporters, always use reqwest::blocking::Client
+//! // Using async clients will cause deadlocks
+//! let exporter = SpanExporter::builder()
+//!     .with_http()
+//!     .with_http_client(reqwest::blocking::Client::new())
+//!     .with_protocol(Protocol::HttpBinary)
+//!     .build()
+//!     .expect("Failed to create exporter");
+//!
+//! let processor = LambdaSpanProcessor::builder()
+//!     .exporter(exporter)
+//!     .max_queue_size(4096)
+//!     .max_batch_size(1024)
+//!     .build();
 //! ```
 //!
 //! # Performance Considerations
@@ -94,9 +77,9 @@
 //!    - Default 2048 spans ≈ 0.5-1MB memory
 //!
 //! 2. **Latency Impact**:
-//!    - Sync mode: Adds export time to handler latency
-//!    - Async mode: Minimal impact (just span queueing)
-//!    - Finalize mode: Depends on processor implementation
+//!    - Batch processing reduces network overhead
+//!    - Configurable batch size allows tuning for your use case
+//!    - Force flush available for immediate export when needed
 //!
 //! 3. **Reliability**:
 //!    - Spans may be dropped if buffer fills
@@ -105,186 +88,35 @@
 //!
 //! # Best Practices
 //!
-//! 1. **Mode Selection**:
-//!    - Consider payload size and memory/CPU configuration
-//!    - Use Sync mode for simple exports or low resource environments
-//!    - Use Async mode the telemetrry payload is expected to be large, and the extension overhead is an acceptable trade-off with the handler latency
-//!    - Use Finalize mode for custom export strategies
-//!
-//! 2. **Buffer Sizing**:
+//! 1. **Buffer Sizing**:
 //!    - Monitor dropped_spans metric
 //!    - Size based on max spans per invocation
 //!    - Consider function memory when sizing
+//!
+//! 2. **Batch Configuration**:
+//!    - Larger batches improve throughput but increase memory usage
+//!    - Smaller batches reduce memory but increase network overhead
+//!    - Default values work well for most use cases
 //!
 //! 3. **Error Handling**:
 //!    - Export errors are logged but don't fail function
 //!    - Monitor for export failures in logs
 //!    - Consider retry strategies in custom exporters
 
+use bon::bon;
+use opentelemetry::Context;
 use opentelemetry::{otel_debug, otel_warn};
-use opentelemetry::{
-    trace::{TraceError, TraceResult},
-    Context,
-};
 use opentelemetry_sdk::{
-    export::trace::{SpanData, SpanExporter},
+    error::{OTelSdkError, OTelSdkResult},
     trace::{Span, SpanProcessor},
+    trace::{SpanData, SpanExporter},
     Resource,
 };
+use std::env;
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
     Arc, Mutex,
 };
-
-/// Controls how spans are processed and exported.
-///
-/// This enum determines when and how OpenTelemetry spans are flushed from the buffer
-/// to the configured exporter. Each mode offers different tradeoffs between latency,
-/// reliability, and flexibility.
-///
-/// # Modes
-///
-/// - `Sync`: Immediate flush in handler thread
-///   - Spans are flushed before handler returns
-///   - Direct export without extension coordination
-///   - May be more efficient for small payloads and low memory configurations
-///   - Guarantees span delivery before response
-///
-/// - `Async`: Flush via Lambda extension
-///   - Spans are flushed after handler returns
-///   - Requires coordination with extension process
-///   - Additional overhead from IPC with extension
-///   - Provides retry capabilities through extension
-///
-/// - `Finalize`: Delegated to processor
-///   - Spans handled by configured processor
-///   - Compatible with BatchSpanProcessor
-///   - Best for custom export strategies
-///   - Full control over export timing
-///
-/// # Configuration
-///
-/// The mode can be configured using the `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE` environment variable:
-/// - "sync" for Sync mode (default)
-/// - "async" for Async mode
-/// - "finalize" for Finalize mode
-///
-/// # Example
-///
-/// ```no_run
-/// use lambda_otel_lite::ProcessorMode;
-/// use std::env;
-///
-/// // Set mode via environment variable
-/// env::set_var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE", "async");
-///
-/// // Get mode from environment
-/// let mode = ProcessorMode::from_env();
-/// assert!(matches!(mode, ProcessorMode::Async));
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-pub enum ProcessorMode {
-    /// Synchronous flush in handler thread. Best for development and debugging.
-    Sync,
-    /// Asynchronous flush via extension. Best for production use to minimize latency.
-    Async,
-    /// Let processor handle flushing. Best with BatchSpanProcessor for custom export strategies.
-    Finalize,
-}
-
-impl ProcessorMode {
-    /// Create ProcessorMode from environment variable.
-    ///
-    /// Uses LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE environment variable.
-    /// Defaults to Sync mode if not set or invalid.
-    pub fn from_env() -> Self {
-        match std::env::var("LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE")
-            .map(|s| s.to_lowercase())
-            .as_deref()
-        {
-            Ok("sync") => {
-                otel_debug!(
-                    name: "ProcessorMode.from_env",
-                    message = "using sync processor mode"
-                );
-                ProcessorMode::Sync
-            }
-            Ok("async") => {
-                otel_debug!(
-                    name: "ProcessorMode.from_env",
-                    message = "using async processor mode"
-                );
-                ProcessorMode::Async
-            }
-            Ok("finalize") => {
-                otel_debug!(
-                    name: "ProcessorMode.from_env",
-                    message = "using finalize processor mode"
-                );
-                ProcessorMode::Finalize
-            }
-            Ok(value) => {
-                otel_warn!(
-                    name: "ProcessorMode.from_env",
-                    message = format!("invalid processor mode: {}, defaulting to sync", value)
-                );
-                ProcessorMode::Sync
-            }
-            Err(_) => {
-                otel_debug!(
-                    name: "ProcessorMode.from_env",
-                    message = "no processor mode set, defaulting to sync"
-                );
-                ProcessorMode::Sync
-            }
-        }
-    }
-}
-
-/// Configuration for the Lambda span processor.
-///
-/// This struct allows customizing the behavior of the span processor to match your
-/// workload's requirements. The configuration affects memory usage, span handling
-/// capacity, and potential span loss under high load.
-///
-/// # Configuration Options
-///
-/// - `max_queue_size`: Maximum number of spans that can be stored in memory
-///   - Determines memory usage (each span ≈ 100-500 bytes)
-///   - When full, new spans are dropped with warning logs
-///   - Should be sized based on expected span volume
-///
-/// # Environment Variables
-///
-/// The queue size can be configured using the `LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE`
-/// environment variable. If not set, defaults to 2048 spans.
-///
-/// # Example
-///
-/// ```no_run
-/// use lambda_otel_lite::ProcessorConfig;
-///
-/// // Default configuration (2048 spans)
-/// let config = ProcessorConfig::default();
-///
-/// // Custom configuration for high volume
-/// let config = ProcessorConfig {
-///     max_queue_size: 4096,
-/// };
-/// ```
-#[derive(Debug)]
-pub struct ProcessorConfig {
-    /// Maximum number of spans that can be stored in memory
-    pub max_queue_size: usize,
-}
-
-impl Default for ProcessorConfig {
-    fn default() -> Self {
-        Self {
-            max_queue_size: 2048,
-        }
-    }
-}
 
 /// A fixed-size ring buffer for storing spans efficiently.
 ///
@@ -317,6 +149,12 @@ struct SpanRingBuffer {
     capacity: usize,
 }
 
+impl Default for SpanRingBuffer {
+    fn default() -> Self {
+        Self::new(2048) // Default capacity
+    }
+}
+
 impl SpanRingBuffer {
     fn new(capacity: usize) -> Self {
         let mut buffer = Vec::with_capacity(capacity);
@@ -341,17 +179,23 @@ impl SpanRingBuffer {
         true
     }
 
-    fn take_all(&mut self) -> Vec<SpanData> {
-        let mut result = Vec::with_capacity(self.size);
-        while self.size > 0 {
+    fn take_batch(&mut self, max_batch_size: usize) -> Vec<SpanData> {
+        let batch_size = self.size.min(max_batch_size);
+        let mut result = Vec::with_capacity(batch_size);
+
+        for _ in 0..batch_size {
             if let Some(span) = self.buffer[self.tail].take() {
                 result.push(span);
             }
             self.tail = (self.tail + 1) % self.capacity;
             self.size -= 1;
         }
-        self.head = 0;
-        self.tail = 0;
+
+        if self.size == 0 {
+            self.head = 0;
+            self.tail = 0;
+        }
+
         result
     }
 
@@ -360,71 +204,98 @@ impl SpanRingBuffer {
     }
 }
 
-/// Lambda-optimized span processor implementation.
+/// A span processor optimized for AWS Lambda functions.
 ///
-/// This processor is designed specifically for AWS Lambda functions, providing:
-/// - Efficient span storage through a ring buffer
-/// - Configurable processing modes for different use cases
-/// - Thread-safe operations for concurrent span submission
-/// - Automatic span sampling and filtering
-/// - Batch export capabilities
+/// This processor efficiently manages spans in a Lambda environment:
+/// - Uses a fixed-size ring buffer to prevent memory growth
+/// - Supports synchronous and asynchronous export modes
+/// - Handles graceful shutdown for Lambda termination
 ///
-/// # Memory Usage
+/// # Examples
 ///
-/// The processor uses a fixed amount of memory based on the configured queue size:
-/// - Each span typically uses 100-500 bytes
-/// - Default configuration (2048 spans) uses 0.5-1MB
-/// - When buffer is full, new spans are dropped with warnings
-///
-/// # Thread Safety
-///
-/// All operations are thread-safe through:
-/// - Mutex protection for span buffer access
-/// - Atomic operations for state management
-/// - Safe sharing between threads with Arc
-///
-/// # Example
-///
-/// ```no_run
-/// use lambda_otel_lite::{LambdaSpanProcessor, ProcessorConfig};
+/// ```
+/// use lambda_otel_lite::LambdaSpanProcessor;
 /// use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
 ///
-/// let processor = LambdaSpanProcessor::new(
-///     Box::new(OtlpStdoutSpanExporter::default()),
-///     ProcessorConfig::default(),
-/// );
-///
-/// // Processor can be safely shared between threads
-/// let processor = std::sync::Arc::new(processor);
+/// let processor = LambdaSpanProcessor::builder()
+///     .exporter(OtlpStdoutSpanExporter::default())
+///     .build();
 /// ```
 ///
-/// # Error Handling
+/// With custom configuration:
 ///
-/// The processor handles errors gracefully:
-/// - Export failures are logged but don't fail the function
-/// - Dropped spans are counted and logged with warnings
-/// - Buffer overflow warnings help with capacity planning
+/// ```
+/// use lambda_otel_lite::LambdaSpanProcessor;
+/// use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+///
+/// let processor = LambdaSpanProcessor::builder()
+///     .exporter(OtlpStdoutSpanExporter::default())
+///     .max_queue_size(1000)
+///     .max_batch_size(100)
+///     .build();
+/// ```
 #[derive(Debug)]
-pub struct LambdaSpanProcessor {
-    exporter: Mutex<Box<dyn SpanExporter>>,
+pub struct LambdaSpanProcessor<E>
+where
+    E: SpanExporter + std::fmt::Debug,
+{
+    /// The exporter used to export spans
+    exporter: Mutex<E>,
+
+    /// Internal buffer for storing spans
     spans: Mutex<SpanRingBuffer>,
+
+    /// Flag indicating whether the processor is shut down
     is_shutdown: Arc<AtomicBool>,
+
+    /// Counter for dropped spans
     dropped_count: AtomicUsize,
+
+    /// Maximum number of spans to export in a single batch
+    max_batch_size: usize,
 }
 
-impl LambdaSpanProcessor {
-    /// Creates a new LambdaSpanProcessor with the given configuration
-    pub fn new(exporter: Box<dyn SpanExporter>, config: ProcessorConfig) -> Self {
+#[bon]
+impl<E> LambdaSpanProcessor<E>
+where
+    E: SpanExporter + std::fmt::Debug,
+{
+    /// Returns the default max batch size from environment or fallback value
+    fn default_max_batch_size() -> usize {
+        env::var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(512)
+    }
+
+    /// Returns the default max queue size from environment or fallback value
+    fn default_max_queue_size() -> usize {
+        env::var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2048)
+    }
+
+    /// Creates a new LambdaSpanProcessor with the given exporter and configuration
+    #[builder]
+    pub fn new(exporter: E, max_batch_size: Option<usize>, max_queue_size: Option<usize>) -> Self {
+        let max_batch_size = max_batch_size.unwrap_or_else(Self::default_max_batch_size);
+        let max_queue_size = max_queue_size.unwrap_or_else(Self::default_max_queue_size);
+
         Self {
             exporter: Mutex::new(exporter),
-            spans: Mutex::new(SpanRingBuffer::new(config.max_queue_size)),
+            spans: Mutex::new(SpanRingBuffer::new(max_queue_size)),
             is_shutdown: Arc::new(AtomicBool::new(false)),
             dropped_count: AtomicUsize::new(0),
+            max_batch_size,
         }
     }
 }
 
-impl SpanProcessor for LambdaSpanProcessor {
+impl<E> SpanProcessor for LambdaSpanProcessor<E>
+where
+    E: SpanExporter + std::fmt::Debug,
+{
     fn on_start(&self, _span: &mut Span, _cx: &Context) {
         // No-op, as we only process spans on end
     }
@@ -459,44 +330,51 @@ impl SpanProcessor for LambdaSpanProcessor {
         }
     }
 
-    fn force_flush(&self) -> TraceResult<()> {
-        // Take the spans while holding the lock
-        let batch = {
-            if let Ok(mut spans) = self.spans.lock() {
-                if spans.is_empty() {
-                    return Ok(());
-                }
-                spans.take_all()
-            } else {
-                return Err(TraceError::Other(
-                    "Failed to acquire spans lock in force_flush".into(),
-                ));
+    fn force_flush(&self) -> OTelSdkResult {
+        if let Ok(mut spans) = self.spans.lock() {
+            if spans.is_empty() {
+                return Ok(());
             }
-        };
 
-        let result = self
-            .exporter
-            .lock()
-            .map_err(|_| TraceError::Other("LambdaSpanProcessor mutex poison".into()))
-            .and_then(|mut exporter| futures_executor::block_on(exporter.export(batch)));
-        if let Err(err) = result {
-            otel_debug!(
-                name: "LambdaSpanProcessor.force_flush.Error",
-                reason = format!("{:?}", err)
-            );
+            let mut exporter = self.exporter.lock().map_err(|_| {
+                OTelSdkError::InternalFailure(
+                    "Failed to acquire exporter lock in force_flush".to_string(),
+                )
+            })?;
+
+            // Process spans in batches
+            while !spans.is_empty() {
+                let batch = spans.take_batch(self.max_batch_size);
+                if !batch.is_empty() {
+                    let result = futures_executor::block_on(exporter.export(batch));
+                    if let Err(err) = &result {
+                        otel_debug!(
+                            name: "LambdaSpanProcessor.force_flush.Error",
+                            reason = format!("{:?}", err)
+                        );
+                        return result;
+                    }
+                }
+            }
+            Ok(())
+        } else {
+            Err(OTelSdkError::InternalFailure(
+                "Failed to acquire spans lock in force_flush".to_string(),
+            ))
         }
-
-        Ok(())
     }
 
-    fn shutdown(&self) -> TraceResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
         self.is_shutdown.store(true, Ordering::Relaxed);
         // Flush any remaining spans
         self.force_flush()?;
         if let Ok(mut exporter) = self.exporter.lock() {
-            exporter.shutdown();
+            exporter.shutdown()
+        } else {
+            Err(OTelSdkError::InternalFailure(
+                "Failed to acquire exporter lock in shutdown".to_string(),
+            ))
         }
-        Ok(())
     }
 
     fn set_resource(&mut self, resource: &Resource) {
@@ -514,7 +392,7 @@ mod tests {
         InstrumentationScope,
     };
     use opentelemetry_sdk::{
-        export::trace::SpanExporter,
+        trace::SpanExporter,
         trace::{SpanEvents, SpanLinks},
     };
     use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc};
@@ -538,7 +416,7 @@ mod tests {
         fn export(
             &mut self,
             batch: Vec<SpanData>,
-        ) -> Pin<Box<dyn Future<Output = TraceResult<()>> + Send>> {
+        ) -> Pin<Box<dyn Future<Output = OTelSdkResult> + Send>> {
             let spans = self.spans.clone();
             Box::pin(async move {
                 let mut spans = spans.lock().await;
@@ -547,7 +425,9 @@ mod tests {
             })
         }
 
-        fn shutdown(&mut self) {}
+        fn shutdown(&mut self) -> OTelSdkResult {
+            Ok(())
+        }
     }
 
     // Helper function to create a test span
@@ -556,8 +436,8 @@ mod tests {
 
         SpanData {
             span_context: SpanContext::new(
-                TraceId::from_u128(1),
-                SpanId::from_u64(1),
+                TraceId::from_hex("01000000000000000000000000000000").unwrap(),
+                SpanId::from_hex("0100000000000001").unwrap(),
                 flags,
                 false,
                 TraceState::default(),
@@ -582,7 +462,7 @@ mod tests {
 
         // Test empty buffer
         assert!(buffer.is_empty());
-        assert_eq!(buffer.take_all(), vec![]);
+        assert_eq!(buffer.take_batch(2), vec![]);
 
         // Test adding spans
         buffer.push(create_test_span("span1"));
@@ -591,7 +471,7 @@ mod tests {
         assert!(!buffer.is_empty());
 
         // Test taking spans
-        let spans = buffer.take_all();
+        let spans = buffer.take_batch(2);
         assert_eq!(spans.len(), 2);
         assert!(buffer.is_empty());
     }
@@ -608,10 +488,25 @@ mod tests {
         let success = buffer.push(create_test_span("span3"));
         assert!(!success); // Should fail since buffer is full
 
-        let spans = buffer.take_all();
+        let spans = buffer.take_batch(2);
         assert_eq!(spans.len(), 2);
         assert!(spans.iter().any(|s| s.name == "span1"));
         assert!(spans.iter().any(|s| s.name == "span2"));
+    }
+
+    #[test]
+    fn test_ring_buffer_batch_operations() {
+        let mut buffer = SpanRingBuffer::new(5);
+
+        // Add 5 spans
+        for i in 0..5 {
+            buffer.push(create_test_span(&format!("span{}", i)));
+        }
+
+        assert_eq!(buffer.take_batch(2).len(), 2);
+        assert_eq!(buffer.take_batch(2).len(), 2);
+        assert_eq!(buffer.take_batch(2).len(), 1);
+        assert!(buffer.is_empty());
     }
 
     #[tokio::test]
@@ -619,10 +514,11 @@ mod tests {
         let mock_exporter = MockExporter::new();
         let spans_exported = mock_exporter.spans.clone();
 
-        let processor = LambdaSpanProcessor::new(
-            Box::new(mock_exporter),
-            ProcessorConfig { max_queue_size: 10 },
-        );
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .max_queue_size(10)
+            .max_batch_size(5)
+            .build();
 
         // Test span processing
         processor.on_end(create_test_span("test_span"));
@@ -641,8 +537,11 @@ mod tests {
         let mock_exporter = MockExporter::new();
         let spans_exported = mock_exporter.spans.clone();
 
-        let processor =
-            LambdaSpanProcessor::new(Box::new(mock_exporter), ProcessorConfig::default());
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .max_queue_size(10)
+            .max_batch_size(5)
+            .build();
 
         // Add some spans
         processor.on_end(create_test_span("span1"));
@@ -665,12 +564,13 @@ mod tests {
         let mock_exporter = MockExporter::new();
         let spans_exported = mock_exporter.spans.clone();
 
-        let processor = Arc::new(LambdaSpanProcessor::new(
-            Box::new(mock_exporter),
-            ProcessorConfig {
-                max_queue_size: 100,
-            },
-        ));
+        let processor = Arc::new(
+            LambdaSpanProcessor::builder()
+                .exporter(mock_exporter)
+                .max_queue_size(100)
+                .max_batch_size(25)
+                .build(),
+        );
 
         let mut handles = Vec::new();
 
@@ -695,5 +595,112 @@ mod tests {
         let exported = spans_exported.lock().await;
         assert_eq!(exported.len(), 100);
         assert_eq!(processor.dropped_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_batch_processing() {
+        let mock_exporter = MockExporter::new();
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .max_queue_size(10)
+            .max_batch_size(3)
+            .build();
+
+        // Add 5 spans
+        for i in 0..5 {
+            processor.on_end(create_test_span(&format!("span{}", i)));
+        }
+
+        // Force flush should process in batches of 3
+        processor.force_flush().unwrap();
+
+        // Add 2 more spans
+        processor.on_end(create_test_span("span5"));
+        processor.on_end(create_test_span("span6"));
+
+        // Final flush
+        processor.force_flush().unwrap();
+    }
+
+    #[test]
+    fn test_builder_default_values() {
+        let mock_exporter = MockExporter::new();
+
+        // Remove any existing env vars to test true defaults
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE");
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE");
+
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .build();
+
+        // Check default values
+        assert_eq!(processor.max_batch_size, 512); // Default batch size
+        assert_eq!(processor.spans.lock().unwrap().capacity, 2048); // Default queue size
+    }
+
+    #[test]
+    fn test_builder_env_var_values() {
+        let mock_exporter = MockExporter::new();
+
+        // Set custom values via env vars
+        env::set_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE", "100");
+        env::set_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE", "1000");
+
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .build();
+
+        // Check that env var values were used
+        assert_eq!(processor.max_batch_size, 100);
+        assert_eq!(processor.spans.lock().unwrap().capacity, 1000);
+
+        // Clean up
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE");
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE");
+    }
+
+    #[test]
+    fn test_builder_explicit_values_override_env() {
+        let mock_exporter = MockExporter::new();
+
+        // Set env vars that should be overridden
+        env::set_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE", "100");
+        env::set_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE", "1000");
+
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .max_batch_size(200)
+            .max_queue_size(2000)
+            .build();
+
+        // Check that explicit values were used instead of env vars
+        assert_eq!(processor.max_batch_size, 200);
+        assert_eq!(processor.spans.lock().unwrap().capacity, 2000);
+
+        // Clean up
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE");
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE");
+    }
+
+    #[test]
+    fn test_builder_invalid_env_vars() {
+        let mock_exporter = MockExporter::new();
+
+        // Set invalid values in env vars
+        env::set_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE", "not_a_number");
+        env::set_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE", "also_not_a_number");
+
+        let processor = LambdaSpanProcessor::builder()
+            .exporter(mock_exporter)
+            .build();
+
+        // Check that defaults were used
+        assert_eq!(processor.max_batch_size, 512);
+        assert_eq!(processor.spans.lock().unwrap().capacity, 2048);
+
+        // Clean up
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_BATCH_SIZE");
+        env::remove_var("LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE");
     }
 }

--- a/packages/rust/lambda-otel-utils/Cargo.toml
+++ b/packages/rust/lambda-otel-utils/Cargo.toml
@@ -27,8 +27,8 @@ lambda_runtime.workspace = true
 otlp-stdout-client.workspace = true
 thiserror.workspace = true
 pin-project = "1.1.0"
-opentelemetry-aws = { version = "0.15.0", features = ["detector-aws-lambda"] }
-opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
+opentelemetry-aws = { version = "0.16.0", features = ["detector-aws-lambda"] }
+opentelemetry-semantic-conventions = { version = "0.28.0", features = ["semconv_experimental"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "json"] }
 rustc_version_runtime = "0.3.0"
 

--- a/packages/rust/lambda-otel-utils/examples/tracing_example.rs
+++ b/packages/rust/lambda-otel-utils/examples/tracing_example.rs
@@ -140,10 +140,8 @@ async fn main() -> Result<(), Box<dyn StdError + Send + Sync + 'static>> {
     });
 
     // flush and shutdown
-    for result in tracer_provider_ref.force_flush() {
-        if let Err(e) = result {
-            eprintln!("Error flushing tracer provider: {}", e);
-        }
+    if let Err(e) = tracer_provider_ref.force_flush() {
+        eprintln!("Error flushing tracer provider: {}", e);
     }
     if let Err(e) = meter_provider_ref.force_flush() {
         eprintln!("Error flushing meter provider: {}", e);
@@ -152,7 +150,7 @@ async fn main() -> Result<(), Box<dyn StdError + Send + Sync + 'static>> {
 }
 
 fn shutdown_providers(
-    tracer_provider: &opentelemetry_sdk::trace::TracerProvider,
+    tracer_provider: &opentelemetry_sdk::trace::SdkTracerProvider,
     meter_provider: &opentelemetry_sdk::metrics::SdkMeterProvider,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     tracer_provider.shutdown()?;

--- a/packages/rust/lambda-otel-utils/src/http_tracer_provider.rs
+++ b/packages/rust/lambda-otel-utils/src/http_tracer_provider.rs
@@ -38,7 +38,7 @@ use opentelemetry_http::HttpClient;
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::{
     propagation::TraceContextPropagator,
-    trace::{IdGenerator, RandomIdGenerator, TracerProvider as SdkTracerProvider},
+    trace::{IdGenerator, RandomIdGenerator, SdkTracerProvider},
 };
 use otlp_stdout_client::StdoutClient;
 use std::{env, fmt::Debug};
@@ -366,8 +366,7 @@ where
 
         let builder = match self.exporter_type {
             ExporterType::Simple => SdkTracerProvider::builder().with_simple_exporter(exporter),
-            ExporterType::Batch => SdkTracerProvider::builder()
-                .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio),
+            ExporterType::Batch => SdkTracerProvider::builder().with_batch_exporter(exporter),
         };
 
         let tracer_provider = builder

--- a/packages/rust/lambda-otel-utils/src/subscriber.rs
+++ b/packages/rust/lambda-otel-utils/src/subscriber.rs
@@ -66,7 +66,7 @@
 //! ```
 
 use opentelemetry::trace::TracerProvider;
-use opentelemetry_sdk::{metrics::SdkMeterProvider, trace::TracerProvider as SdkTracerProvider};
+use opentelemetry_sdk::{metrics::SdkMeterProvider, trace::SdkTracerProvider};
 use tracing_subscriber::prelude::*;
 
 /// Returns a tracing layer configured with the given tracer provider and tracer name.


### PR DESCRIPTION
This pull request includes several significant updates to the Rust Lambda OTel Lite package, focusing on workflow automation, version updates, and documentation improvements. The most important changes include the addition of a GitHub Actions workflow for automated publishing, updates to the `Cargo.toml` dependencies, and extensive updates to the `CHANGELOG.md` and `README.md` files to reflect new features and breaking changes.

### Workflow Automation:
* [`.github/workflows/publish-rust-lambda-otel-lite.yml`](diffhunk://#diff-7c7f2e57b880ccb60948479759186fbd39aa3c96ff73a0a9e5764034ac976f03R1-R104): Added a GitHub Actions workflow to automate testing and publishing of the Rust Lambda OTel Lite package on merges to the main branch. This workflow includes steps for setting up the Rust toolchain, caching dependencies, running quality checks, and publishing the package to crates.io.

### Dependency Updates:
* [`packages/rust/lambda-otel-lite/Cargo.toml`](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L18-R18): Updated dependencies to use workspace settings for `opentelemetry_sdk`, `tracing-opentelemetry`, and added new dependencies such as `reqwest` and `rand`. [[1]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L18-R18) [[2]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L30-R30) [[3]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L39-R45)

### Changelog and Versioning:
* [`packages/rust/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-186498266ac8e953c6310f423de26221c85a117655d116518dd6abf581d93900L9-R36): Updated the changelog to version 0.9.0, detailing breaking changes, new features, and improvements. Notable changes include the modification of the return type of `init_telemetry()`, removal of the `library_name` parameter, and updates to the OpenTelemetry SDK.

### Documentation Improvements:
* [`packages/rust/lambda-otel-lite/README.md`](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL182-R182): Updated the README to reflect the new tuple return type from `init_telemetry()`, changes in resource and provider creation, and added new examples and usage instructions. [[1]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL182-R182) [[2]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL197-R208) [[3]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL227-R229) [[4]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL249-R258) [[5]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aR269-R271) [[6]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL278-R316) [[7]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL324-R330) [[8]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL356-R358) [[9]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL365-L410) [[10]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aL470-L483)

### Publishing Checklist:
* [`packages/rust/lambda-otel-lite/PUBLISHING.md`](diffhunk://#diff-ea2bff3bedf3b0ab3b13846b626165934ccb1d0f06f015c1cf900433c3370a12R1-R100): Added a comprehensive publishing checklist to ensure all necessary steps are followed before publishing a new version of the package. This includes verifying `Cargo.toml`, updating documentation, and running all tests and quality checks.