### PR TITLE
Standardize Rust package workflow files

### DIFF
--- a/.github/workflows/publish-rust-otlp-sigv4-client.yml
+++ b/.github/workflows/publish-rust-otlp-sigv4-client.yml
@@ -1,17 +1,17 @@
-name: Publish Rust Lambda OTel Lite
+name: Publish Rust OTLP SigV4 Client
 
 on:
   # Trigger on PRs that touch the Rust package
   pull_request:
     paths:
-      - 'packages/rust/lambda-otel-lite/**'
+      - 'packages/rust/otlp-sigv4-client/**'
     types: [opened, synchronize]
   # Trigger on merges to main that touch the Rust package
   push:
     branches:
       - main
     paths:
-      - 'packages/rust/lambda-otel-lite/**'
+      - 'packages/rust/otlp-sigv4-client/**'
 
 # Add permissions needed for the workflow
 permissions:
@@ -24,19 +24,18 @@ jobs:
       matrix:
         include:
           # x64 runner
-          - os: ubuntu-24.04
+          - os: ubuntu-latest
             arch: x64
             rust-version: stable
           # arm64 runner
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             arch: arm64
             rust-version: stable
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        working-directory: packages/rust/lambda-otel-lite
+        working-directory: packages/rust/otlp-sigv4-client
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'approved')
-
     steps:
       - uses: actions/checkout@v4
 
@@ -65,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: packages/rust/lambda-otel-lite
+        working-directory: packages/rust/otlp-sigv4-client
 
     steps:
       - uses: actions/checkout@v4
@@ -79,7 +78,7 @@ jobs:
       - name: Set up Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: packages/rust/lambda-otel-lite
+          workspaces: packages/rust/otlp-sigv4-client
 
       - name: Build package
         run: cargo build --release
@@ -87,8 +86,8 @@ jobs:
       - name: Verify package version
         id: version_check
         run: |
-          PACKAGE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "lambda-otel-lite") | .version')
-          TAG_NAME="packages/rust/lambda-otel-lite-v$PACKAGE_VERSION"
+          PACKAGE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "otlp-sigv4-client") | .version')
+          TAG_NAME="packages/rust/otlp-sigv4-client-v$PACKAGE_VERSION"
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           
           if git tag -l | grep -q "$TAG_NAME"; then

--- a/.github/workflows/publish-rust-otlp-stdout-client.yml
+++ b/.github/workflows/publish-rust-otlp-stdout-client.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Verify package version
         id: version_check
         run: |
-          PACKAGE_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "otlp-stdout-client") | .version')
+          PACKAGE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "otlp-stdout-client") | .version')
           TAG_NAME="packages/rust/otlp-stdout-client-v$PACKAGE_VERSION"
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           


### PR DESCRIPTION
This pull request includes several updates to GitHub Actions workflows for Rust packages. The changes focus on improving the versioning and tagging process, as well as adding a new workflow for the `otlp-sigv4-client` package.

Improvements to existing workflows:

* [`.github/workflows/publish-rust-lambda-otel-lite.yml`](diffhunk://#diff-7c7f2e57b880ccb60948479759186fbd39aa3c96ff73a0a9e5764034ac976f03R38): Added a condition to run the job only on specific events and updated the version verification and tagging logic to include the full package path in the tag name. [[1]](diffhunk://#diff-7c7f2e57b880ccb60948479759186fbd39aa3c96ff73a0a9e5764034ac976f03R38) [[2]](diffhunk://#diff-7c7f2e57b880ccb60948479759186fbd39aa3c96ff73a0a9e5764034ac976f03R88-R98) [[3]](diffhunk://#diff-7c7f2e57b880ccb60948479759186fbd39aa3c96ff73a0a9e5764034ac976f03L102-R108)
* [`.github/workflows/publish-rust-otlp-stdout-client.yml`](diffhunk://#diff-bc21643059c9f6951224ceebdcdece1a150ac30c76e77480127e9fb7c0c97b42L89-R89): Modified the version check step to use `--no-deps` for faster metadata retrieval.

New workflow:

* [`.github/workflows/publish-rust-otlp-sigv4-client.yml`](diffhunk://#diff-1cbe6ba2092ab1ed996b20f7a04afd17e2c196502c167ca2036f362125955d16R1-R107): Added a new workflow to publish the `otlp-sigv4-client` package, including steps for testing, building, verifying the version, and publishing to crates.io.