### PR TITLE
Release packages/rust/lambda-otel-lite 0.10.0

### DIFF
--- a/.github/workflows/publish-rust-lambda-otel-lite.yml
+++ b/.github/workflows/publish-rust-lambda-otel-lite.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     paths:
       - 'packages/rust/lambda-otel-lite/**'
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
   # Trigger on merges to main that touch the Rust package
   push:
     branches:

--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.10.0] - 2025-03-03
+### Changed
+- Updated `otlp-stdout-span-exporter` dependency to version 0.10.0
+
 ## [0.9.0] - 2025-03-01
 ### Breaking Changes
 - **API Change**: Modified the return type of `init_telemetry()` to return a tuple `(tracer, completion_handler)` instead of just the completion handler

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version.workspace = true
+version = "0.10.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,7 +19,7 @@ opentelemetry_sdk.workspace = true
 tokio.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
-otlp-stdout-span-exporter = { version = "0.9.0" }
+otlp-stdout-span-exporter = { version = "0.10.0" }
 urlencoding = "2.1.3"
 lambda_runtime.workspace = true
 lambda-extension = "0.11.0"


### PR DESCRIPTION
This pull request includes updates to the `lambda-otel-lite` package, primarily focusing on version updates for dependencies and the package itself. The most important changes include updating the `otlp-stdout-span-exporter` dependency and the package version.

Dependency updates:

* [`packages/rust/lambda-otel-lite/Cargo.toml`](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L22-R22): Updated `otlp-stdout-span-exporter` dependency to version 0.10.0.

Version updates:

* [`packages/rust/lambda-otel-lite/Cargo.toml`](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L3-R3): Updated the package version to 0.10.0.
* [`packages/rust/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-186498266ac8e953c6310f423de26221c85a117655d116518dd6abf581d93900R9-R12): Added changelog entry for version 0.10.0, noting the update to `otlp-stdout-span-exporter` dependency.