### PR TITLE
Release node otlp-stdout-span-exporter v0.10.1

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2025-03-05
+
+### Added
+- Support for OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL environment variable to configure compression level
+- Improved documentation to align with Python and Rust implementations
+- Added unit tests for environment variable compression level support
+- Updated code example to use current OpenTelemetry API patterns
+
 ## [0.10.0] - 2025-03-05
 
 ### Changed

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -1,18 +1,35 @@
-# @dev7a/otlp-stdout-span-exporter
+# Node.js OTLP Stdout Span Exporter
 
-An OpenTelemetry span exporter that writes spans to stdout in OTLP format with Protobuf serialization and GZIP compression. Designed for use in serverless environments where writing to stdout is preferred over direct HTTP export.
+A Node.js span exporter that writes OpenTelemetry spans to stdout, using a custom serialization format that embeds the spans serialized as OTLP protobuf in the `payload` field. The message envelope carries metadata about the spans, such as the service name, the OTLP endpoint, and the HTTP method:
+
+```json
+{
+  "__otel_otlp_stdout": "0.1.0",
+  "source": "my-service",
+  "endpoint": "http://localhost:4318/v1/traces",
+  "method": "POST",
+  "content-type": "application/x-protobuf",
+  "content-encoding": "gzip",
+  "headers": {
+    "custom-header": "value"
+  },
+  "payload": "<base64-encoded-gzipped-protobuf>",
+  "base64": true
+}
+```
+
+Outputting telemetry data in this format directly to stdout makes the library easily usable in network constrained environments, or in environments that are particularly sensitive to the overhead of HTTP connections, such as AWS Lambda.
 
 >[!IMPORTANT]
->This package is part of the serverless-otlp-forwarder project and is designed for AWS Lambda environments. While it can be used in other contexts, it's primarily tested with AWS Lambda.
+>This package is part of the [serverless-otlp-forwarder](https://github.com/dev7a/serverless-otlp-forwarder) project and is designed for AWS Lambda environments. While it can be used in other contexts, it's primarily tested with AWS Lambda.
 
 ## Features
 
-- Writes spans in OTLP format to stdout
-- Uses Protobuf serialization for efficient encoding
-- Applies GZIP compression with configurable level
-- Supports automatic service name detection from environment variables
-- Follows standard OTLP format for compatibility
-- Allows custom headers via environment variables
+- Uses OTLP Protobuf serialization for efficient encoding
+- Applies GZIP compression with configurable levels
+- Detects service name from environment variables
+- Supports custom headers via environment variables
+- Consistent JSON output format
 - Zero external HTTP dependencies
 - Lightweight and fast
 
@@ -24,53 +41,36 @@ npm install @dev7a/otlp-stdout-span-exporter
 
 ## Usage
 
-Basic usage with default configuration:
+The recommended way to use this exporter is with the standard OpenTelemetry `BatchSpanProcessor`, which provides better performance by buffering and exporting spans in batches, or, in conjunction with the [lambda-otel-lite](https://www.npmjs.com/package/@dev7a/lambda-otel-lite) package, with the `LambdaSpanProcessor`, which is particularly optimized for AWS Lambda.
+
+You can create a simple tracer provider with the BatchSpanProcessor and the OTLPStdoutSpanExporter:
 
 ```typescript
-import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
+import { trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
 
+// Initialize the exporter
+const exporter = new OTLPStdoutSpanExporter({ gzipLevel: 6 });
+// Use batching processor for efficiency
+const processor = new BatchSpanProcessor(exporter);
 // Create a tracer provider
-const provider = new NodeTracerProvider();
-
-// Create and configure the exporter
-const exporter = new OTLPStdoutSpanExporter();
-
-// Use BatchSpanProcessor for efficient processing
-provider.addSpanProcessor(new BatchSpanProcessor(exporter));
-
-// Register the provider
-provider.register();
-```
-
-Advanced usage with custom configuration:
-
-```typescript
-import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import * as zlib from 'zlib';
-
-// Create a tracer provider with custom configuration
 const provider = new NodeTracerProvider({
-  resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'my-service',
-  }),
+  // Register the exporter with the provider
+  spanProcessors: [processor]
 });
 
-// Configure the exporter with maximum compression
-const exporter = new OTLPStdoutSpanExporter({
-  gzipLevel: zlib.constants.Z_BEST_COMPRESSION, // Level 9
-});
-
-// Use BatchSpanProcessor with custom configuration
-provider.addSpanProcessor(new BatchSpanProcessor(exporter, {
-  maxQueueSize: 2048,
-  scheduledDelayMillis: 1000,
-}));
-
+// Set as global default tracer provider
 provider.register();
+
+// Your instrumentation code here
+const tracer = trace.getTracer('example-tracer');
+tracer.startActiveSpan('my-operation', span => {
+  span.setAttribute('my.attribute', 'value');
+  // ... do work ...
+  span.end();
+});
 ```
 
 ## Configuration
@@ -78,64 +78,66 @@ provider.register();
 ### Constructor Options
 
 ```typescript
-interface OTLPStdoutSpanExporterOptions {
-  gzipLevel?: number; // Optional, defaults to 6 (0-9, where 9 is maximum compression)
+interface OTLPStdoutSpanExporterConfig {
+  // GZIP compression level (0-9, where 0 is no compression and 9 is maximum compression)
+  // Defaults to 6 or value from OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL
+  gzipLevel?: number;
 }
 ```
 
+The explicit configuration via code will override any environment variable setting.
+
 ### Environment Variables
 
-The exporter respects standard OpenTelemetry environment variables:
+The exporter respects the following environment variables:
 
-- `OTEL_SERVICE_NAME`: Service name for span source
-- `AWS_LAMBDA_FUNCTION_NAME`: Fallback service name (if OTEL_SERVICE_NAME not set)
-- `OTEL_EXPORTER_OTLP_HEADERS`: Global headers for all OTLP exporters
-- `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (takes precedence over global headers)
+- `OTEL_SERVICE_NAME`: Service name to use in output
+- `AWS_LAMBDA_FUNCTION_NAME`: Fallback service name (if `OTEL_SERVICE_NAME` not set)
+- `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
+- `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (which take precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
+- `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9). Defaults to 6.
 
-Header format examples:
-```bash
-# Single header
-export OTEL_EXPORTER_OTLP_HEADERS="api-key=secret123"
+>[!NOTE]
+>For security best practices, avoid including authentication credentials or sensitive information in headers. The serverless-otlp-forwarder infrastructure is designed to handle authentication at the destination, rather than embedding credentials in your telemetry data.
 
-# Multiple headers
-export OTEL_EXPORTER_OTLP_HEADERS="api-key=secret123,custom-header=value"
 
-# Headers with special characters
-export OTEL_EXPORTER_OTLP_HEADERS="authorization=Basic dXNlcjpwYXNzd29yZA=="
-```
-
-### Output Format
+## Output Format
 
 The exporter writes JSON objects to stdout with the following structure:
 
 ```json
 {
-  "__otel_otlp_stdout": "@dev7a/otlp-stdout-span-exporter@0.1.0",
-  "source": "service-name",
+  "__otel_otlp_stdout": "0.1.0",
+  "source": "my-service",
   "endpoint": "http://localhost:4318/v1/traces",
   "method": "POST",
   "content-type": "application/x-protobuf",
   "content-encoding": "gzip",
   "headers": {
+    "tenant-id": "tenant-12345",
     "custom-header": "value"
   },
   "base64": true,
-  "payload": "<base64-encoded-gzipped-protobuf-data>"
+  "payload": "<base64-encoded-gzipped-protobuf>"
 }
 ```
 
-The `payload` field contains the base64-encoded, gzipped, Protobuf-serialized span data in OTLP format.
-
-## Error Handling
-
-The exporter handles various error conditions:
-- Failed compression attempts
-- Stdout write errors
-- Invalid environment variables
-- Malformed headers
-
-All errors are properly propagated through the OpenTelemetry error handling system.
+- `__otel_otlp_stdout` is a marker to identify the output of this exporter.
+- `source` is the emitting service name.
+- `endpoint` is the OTLP endpoint (defaults to `http://localhost:4318/v1/traces` and just indicates the signal type. The actual endpoint is determined by the process that forwards the data).
+- `method` is the HTTP method (always `POST`).
+- `content-type` is the content type (always `application/x-protobuf`).
+- `content-encoding` is the content encoding (always `gzip`).
+- `headers` is the headers defined in the `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TRACES_HEADERS` environment variables.
+- `payload` is the base64-encoded, gzipped, Protobuf-serialized span data in OTLP format.
+- `base64` is a boolean flag to indicate if the payload is base64-encoded (always `true`).
 
 ## License
 
-MIT 
+MIT
+
+## See Also
+
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder) - The main project repository for the Serverless OTLP Forwarder project
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/python/otlp-stdout-span-exporter) | [PyPI](https://pypi.org/project/otlp-stdout-span-exporter/) - The Python version of this exporter
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/rust/otlp-stdout-span-exporter) | [crates.io](https://crates.io/crates/otlp-stdout-span-exporter) - The Rust version of this exporter 

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `otlp-stdout-span-exporter` package. The most significant changes include the addition of support for configuring the GZIP compression level via an environment variable, improvements to documentation, and updates to unit tests to cover the new functionality.

### Enhancements and New Features:
* Added support for the `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable to configure the GZIP compression level. [[1]](diffhunk://#diff-98d7656b1775668a361eb259643823fb60356e4f05cc19ce00f0d804403e6012R8-R15) [[2]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821R9-R19)
* Improved documentation to align with the Python and Rust implementations and updated the code example to use current OpenTelemetry API patterns. [[1]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L1-R32) [[2]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L27-R143)

### Documentation and Configuration:
* Updated `README.md` to provide detailed usage instructions, including the new environment variable for compression level and the updated output format. [[1]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L1-R32) [[2]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L27-R143)
* Updated the `CHANGELOG.md` to reflect the new version 0.10.1 and list the added features.

### Code and Test Updates:
* Incremented the package version to 0.10.1 in `package.json`.
* Added new unit tests to validate the behavior of the GZIP compression level configuration via the environment variable and explicit configuration. [[1]](diffhunk://#diff-0b74609b17a83ab78303de879512381862895897acb22edf246633a8c5c497d0R47) [[2]](diffhunk://#diff-0b74609b17a83ab78303de879512381862895897acb22edf246633a8c5c497d0R95-R146)
* Introduced a method to retrieve the compression level from the environment variable and handle invalid or out-of-range values. [[1]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821R81-R96) [[2]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821L85-R108)
