### PR TITLE
refactor: Rename Lambda function and resource names for clarity

### DIFF
--- a/forwarders/experimental/aws-span-processor/processor/Cargo.toml
+++ b/forwarders/experimental/aws-span-processor/processor/Cargo.toml
@@ -12,17 +12,14 @@ tokio.workspace = true
 anyhow.workspace = true
 aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }
 lambda_runtime.workspace = true
-aws-sdk-secretsmanager.workspace = true
 reqwest.workspace = true
 tracing.workspace = true
 lambda-otel-lite.workspace = true
-opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true
 otlp-sigv4-client.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 opentelemetry-proto = "0.28.0"
 prost = "0.13.5" 

--- a/forwarders/experimental/aws-span-processor/template.yaml
+++ b/forwarders/experimental/aws-span-processor/template.yaml
@@ -29,7 +29,7 @@ Conditions:
   HasVpcConfig: !Not [!Equals [!Ref VpcId, '']]
 
 Resources:
-  SpanProcessorFunction:
+  SpansProcessorFunction:
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: rust-cargolambda
@@ -87,24 +87,24 @@ Resources:
     Properties:
       LogGroupName: !Ref SpanLogGroupName
       FilterPattern: '' # Empty pattern to capture all logs
-      DestinationArn: !GetAtt SpanProcessorFunction.Arn
+      DestinationArn: !GetAtt SpansProcessorFunction.Arn
 
   SpanProcessorPermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
-      FunctionName: !Ref SpanProcessorFunction
+      FunctionName: !Ref SpansProcessorFunction
       Principal: logs.amazonaws.com
       SourceArn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${SpanLogGroupName}:*'
 
 Outputs:
-  SpanProcessorFunctionName:
+  SpansProcessorFunctionName:
     Description: Name of the Span processor Lambda function
-    Value: !Ref SpanProcessorFunction
+    Value: !Ref SpansProcessorFunction
 
-  SpanProcessorFunctionArn:
+  SpansProcessorFunctionArn:
     Description: ARN of the Span processor Lambda function
-    Value: !GetAtt SpanProcessorFunction.Arn
+    Value: !GetAtt SpansProcessorFunction.Arn
 
   SpanProcessorSecurityGroupId:
     Description: ID of the security group for the Span processor Lambda function

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/processor/Cargo.toml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/processor/Cargo.toml
@@ -11,20 +11,15 @@ lambda-otlp-forwarder = { path = "../../../otlp-stdout-logs-processor/processor"
 tokio.workspace = true
 anyhow.workspace = true
 lambda_runtime.workspace = true
-aws-sdk-secretsmanager.workspace = true
 reqwest.workspace = true
 tracing.workspace = true
 lambda-otel-lite.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true
-opentelemetry.workspace = true
 otlp-sigv4-client.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
-serde.workspace = true
 serde_json.workspace = true
-opentelemetry-proto = "0.28.0"
-prost = "0.13.5"
 aws_lambda_events = { workspace = true, features = ["kinesis"] }
 
 [dev-dependencies]

--- a/forwarders/otlp-stdout-logs-processor/template.yaml
+++ b/forwarders/otlp-stdout-logs-processor/template.yaml
@@ -29,7 +29,7 @@ Conditions:
   HasVpcConfig: !Not [!Equals [!Ref VpcId, '']]
 
 Resources:
-  OtlpStdoutProcessor:
+  LogsProcessorFunction:
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: rust-cargolambda
@@ -76,14 +76,14 @@ Resources:
       VpcConfig: !If 
         - HasVpcConfig
         - SecurityGroupIds: 
-            - !Ref OtlpProcessorSecurityGroup
+            - !Ref LogsProcessorSecurityGroup
           SubnetIds: !Ref SubnetIds
         - !Ref AWS::NoValue
 
-  OtlpStdoutProcessorPermission:
+  LogsProcessorFunctionPermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !Ref OtlpStdoutProcessor
+      FunctionName: !Ref LogsProcessorFunction
       Action: lambda:InvokeFunction
       Principal: logs.amazonaws.com
       SourceAccount: !Ref AWS::AccountId
@@ -92,31 +92,31 @@ Resources:
     Type: AWS::Logs::AccountPolicy
     Condition: RouteAllLogs
     DependsOn:
-      - OtlpStdoutProcessorPermission
+      - LogsProcessorFunctionPermission
     Properties:
       PolicyName: "LambdaSubscriptionPolicy"
       PolicyDocument: 
         Fn::Sub: |
           {
-            "DestinationArn": "${OtlpStdoutProcessor.Arn}",
-            "FilterPattern": "{ $.__otel_otlp_stdout = * }",
+            "DestinationArn": "${LogsProcessorFunction.Arn}",
+            "FilterPattern": "{ $.__otel_otlp_stdout = * }"
           }
       PolicyType: "SUBSCRIPTION_FILTER_POLICY"
       Scope: "ALL"
-      SelectionCriteria: !Sub "LogGroupName NOT IN [\"/aws/${OtlpStdoutProcessor}\"]"
+      SelectionCriteria: !Sub "LogGroupName NOT IN [\"/aws/${LogsProcessorFunction}\"]"
 
-  OtlpProcessorSecurityGroup:
+  LogsProcessorSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: HasVpcConfig
     Properties:
-      GroupDescription: Security group for OTLP Processor Lambda
+      GroupDescription: Security group for OTLP Logs Processor Lambda
       VpcId: !Ref VpcId
       SecurityGroupEgress:
         - IpProtocol: -1
           CidrIp: 0.0.0.0/0
 
 Outputs:
-  OtlpStdoutProcessorArn:
+  LogsProcessorFunctionArn:
     Description: ARN of the OTLP stdout processor Lambda function
-    Value: !GetAtt OtlpStdoutProcessor.Arn
+    Value: !GetAtt LogsProcessorFunction.Arn
   


### PR DESCRIPTION
This pull request includes several changes to the `forwarders/experimental/aws-span-processor` and `forwarders/experimental/otlp-stdout-logs-processor` components, focusing on renaming resources and updating dependencies. The most important changes are listed below:

### Resource Renaming:
* Renamed `SpanProcessorFunction` to `SpansProcessorFunction` in `template.yaml` for AWS Span Processor. This change affects multiple references within the file. [[1]](diffhunk://#diff-a9df9e326d219b9a05189a86e4b7be28121f66e4162dd1ff9d342d37e6a9008bL32-R32) [[2]](diffhunk://#diff-a9df9e326d219b9a05189a86e4b7be28121f66e4162dd1ff9d342d37e6a9008bL90-R107)
* Renamed `OtlpStdoutProcessor` to `LogsProcessorFunction` in `template.yaml` for OTLP Stdout Logs Processor. This change affects multiple references within the file. [[1]](diffhunk://#diff-26203096792fbf0585008389c679fd451c16315b8d91fcf463949bc97e60f010L32-R32) [[2]](diffhunk://#diff-26203096792fbf0585008389c679fd451c16315b8d91fcf463949bc97e60f010L79-R86) [[3]](diffhunk://#diff-26203096792fbf0585008389c679fd451c16315b8d91fcf463949bc97e60f010L95-R121)

### Dependency Updates:
* Removed several workspace dependencies (`aws-sdk-secretsmanager`, `opentelemetry`, `serde`, `opentelemetry-proto`, `prost`) from `Cargo.toml` in both AWS Span Processor and OTLP Stdout Kinesis Processor. [[1]](diffhunk://#diff-399b0e73babbff736d84b1391422aedee1673031efecc9b7ddf7f543ba887220L15-L25) [[2]](diffhunk://#diff-9d4883846d4a58f8f5e9a7018d9ab3c751a66016cbc24542afe7d5f7e5b44671L14-L27)This commit updates the naming of Lambda functions and related resources in multiple CloudFormation templates and Cargo.toml files:

- Renamed `SpanProcessorFunction` to `SpansProcessorFunction` in AWS span processor template
- Renamed `OtlpStdoutProcessor` to `LogsProcessorFunction` in OTLP stdout logs processor template
- Removed unused dependencies in Cargo.toml files for AWS span processor and OTLP stdout Kinesis processor