### PR TITLE
Release node lambda-otel-lite v0.10.0

### DIFF
--- a/.github/workflows/publish-node-lambda-otel-lite.yml
+++ b/.github/workflows/publish-node-lambda-otel-lite.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: npm-publish
-      url: https://www.npmjs.com/package/lambda-otel-lite
+      url: https://www.npmjs.com/package/@dev7a/lambda-otel-lite
     defaults:
       run:
         working-directory: packages/node/lambda-otel-lite
@@ -84,6 +84,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate version file
+        run: npm run generate:version
+
       - name: Build package
         run: npm run build
 
@@ -91,7 +94,7 @@ jobs:
         id: version_check
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          VERSION_TS_VERSION=$(grep -o "'[0-9]\+\.[0-9]\+\.[0-9]\+'" src/version.ts | tr -d "'")
+          VERSION_TS_VERSION=$(grep -o '"[0-9]\+\.[0-9]\+\.[0-9]\+"' src/version.ts | tr -d '"')
           TAG_NAME="packages/node/lambda-otel-lite-v$PACKAGE_VERSION"
           echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
           

--- a/packages/node/lambda-otel-lite/.gitignore
+++ b/packages/node/lambda-otel-lite/.gitignore
@@ -24,3 +24,6 @@ coverage/
 Thumbs.db
 
 *.tgz
+
+# Generated files
+src/version.ts

--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2025-03-08
+
+### Changed
+- Updated versioning approach to use auto-generated version.ts file
+- Version is now managed in a single place (package.json)
+- Updated publishing process to use CI/CD pipeline for tagging and publishing
+
 ## [0.9.1] - 2025-02-24
 
 ### Fixed

--- a/packages/node/lambda-otel-lite/PUBLISHING.md
+++ b/packages/node/lambda-otel-lite/PUBLISHING.md
@@ -3,7 +3,7 @@
 Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these items are checked:
 
 ## Package.json Verification
-- [ ] `version` is correctly incremented (following semver) in package.json and in src/version.ts
+- [ ] `version` is correctly incremented (following semver)
 - [ ] `name` is correct
 - [ ] `description` is clear and up-to-date
 - [ ] `license` is specified
@@ -42,19 +42,22 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 - [ ] No unnecessary files in git
 - [ ] Git tags are ready to be created
 
+## Version Management
+- [ ] Update version in `package.json` only
+- [ ] Do NOT manually edit `version.ts` - it is auto-generated during build by the `generate:version` npm script
+
 ## Publishing Steps
-1. Update version in `package.json`
+1. Update version in `package.json` (this is the single source of truth for the version)
 2. Update `CHANGELOG.md`
 3. Format code: `npm run format`
 4. Run format check: `npm run format:check`
 5. Run linting: `npm run lint`
 6. Run tests: `npm test`
-7. Clean build: `npm run clean && npm run build`
-8. Commit changes: `git commit -am "Release vX.Y.Z"`
-9. Create git tag: `git tag vX.Y.Z`
-10. Push changes: `git push && git push --tags`
-11. Publish to npm: `npm publish`
-12. Verify package on npm: https://www.npmjs.com/package/@dev7a/lambda-otel-lite
+7. Build package: `npm run build` (this will automatically generate the version.ts file)
+8. Create a branch for the release following the pattern `release-node-<package-name>-v<version>`
+9. Commit changes to the release branch and push to GitHub
+10. Create a pull request from the release branch to main
+11. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing
 - [ ] Verify package installation works: `npm install @dev7a/lambda-otel-lite`
@@ -62,6 +65,7 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 - [ ] Verify all package files are included
 - [ ] Test the package in a new project
 - [ ] Update any dependent packages
+- [ ] Verify examples run correctly
 
 ## Common Issues to Check
 - Missing files in the published package
@@ -73,7 +77,9 @@ Before publishing a new version of `@dev7a/lambda-otel-lite`, ensure all these i
 - Unintended breaking changes
 
 ## Notes
-- Always use `npm publish --dry-run` first to verify the package contents
-- Consider using `npm pack` to inspect the exact files that will be published
-- Test the package in a clean environment before publishing
-- Consider the impact on dependent packages 
+- Always run `npm run build` before publishing (which automatically generates the `version.ts` file)
+- Test the package with different Node.js versions
+- Consider cross-platform compatibility
+- Test with the minimum supported Node.js version
+- Consider running security checks
+- Remember to update any related documentation or examples in the main repository 

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts
@@ -6,12 +6,12 @@ import { TelemetryCompletionHandler } from '../../src/internal/telemetry/complet
 
 describe('TelemetryCompletionHandler', () => {
   let provider: NodeTracerProvider;
-  let handler: TelemetryCompletionHandler;
+  let _handler: TelemetryCompletionHandler;
 
   beforeEach(() => {
     provider = new NodeTracerProvider();
     const getTracerSpy = jest.spyOn(provider, 'getTracer');
-    handler = new TelemetryCompletionHandler(provider, ProcessorMode.Sync);
+    _handler = new TelemetryCompletionHandler(provider, ProcessorMode.Sync);
 
     // Verify tracer is initialized with correct package info
     expect(getTracerSpy).toHaveBeenCalledWith('@dev7a/lambda-otel-lite', VERSION);

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts
@@ -1,10 +1,22 @@
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { ProcessorMode } from '../../src/mode';
 import { VERSION } from '../../src/version';
+import { ProcessorMode } from '../../src/mode';
 import { TelemetryCompletionHandler } from '../../src/internal/telemetry/completion';
 
 describe('TelemetryCompletionHandler', () => {
+  let provider: NodeTracerProvider;
+  let handler: TelemetryCompletionHandler;
+
+  beforeEach(() => {
+    provider = new NodeTracerProvider();
+    const getTracerSpy = jest.spyOn(provider, 'getTracer');
+    handler = new TelemetryCompletionHandler(provider, ProcessorMode.Sync);
+
+    // Verify tracer is initialized with correct package info
+    expect(getTracerSpy).toHaveBeenCalledWith('@dev7a/lambda-otel-lite', VERSION);
+  });
+
   describe('constructor', () => {
     it('should create tracer with package instrumentation scope', () => {
       const provider = new NodeTracerProvider();
@@ -12,7 +24,7 @@ describe('TelemetryCompletionHandler', () => {
 
       new TelemetryCompletionHandler(provider, ProcessorMode.Sync);
 
-      expect(getTracerSpy).toHaveBeenCalledWith(VERSION.NAME, VERSION.VERSION);
+      expect(getTracerSpy).toHaveBeenCalledWith('@dev7a/lambda-otel-lite', VERSION);
     });
   });
 

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [
@@ -46,10 +46,11 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "npm run clean && npm run generate:version && tsc",
     "clean": "rm -rf dist",
     "format": "prettier --write 'src/**/*.{js,ts}' '__tests__/**/*.{js,ts}'",
     "format:check": "prettier --check 'src/**/*.{js,ts}' '__tests__/**/*.{js,ts}'",
+    "generate:version": "echo '// This file is auto-generated. Do not edit manually.\\nexport const VERSION = \"'$(node -p \"require('./package.json').version\")'\";' > src/version.ts",
     "lint": "eslint 'src/**/*.{js,ts}' '__tests__/**/*.{js,ts}' --fix && npx npm-package-json-lint .",
     "lint:fix": "npm run lint -- --fix",
     "test": "jest -c jest.config.ts",

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/completion.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/completion.ts
@@ -59,7 +59,7 @@ export class TelemetryCompletionHandler {
     private readonly mode: ProcessorMode
   ) {
     // Initialize tracer once at construction
-    this._tracer = this.provider.getTracer(VERSION.NAME, VERSION.VERSION);
+    this._tracer = this.provider.getTracer('@dev7a/lambda-otel-lite', VERSION);
   }
 
   /**

--- a/packages/node/lambda-otel-lite/src/version.ts
+++ b/packages/node/lambda-otel-lite/src/version.ts
@@ -1,10 +1,2 @@
-/**
- * Package version information.
- * These values identify the library in telemetry data.
- */
-export const VERSION = {
-  /** Package name as it appears in package.json */
-  NAME: '@dev7a/lambda-otel-lite',
-  /** Current version of the package */
-  VERSION: '0.9.1',
-};
+// This file is auto-generated. Do not edit manually.
+export const VERSION = "0.10.0";


### PR DESCRIPTION
This pull request includes several changes to improve version management and streamline the publishing process for the `@dev7a/lambda-otel-lite` package. The most important changes include updating the versioning approach, modifying the CI/CD pipeline, and updating documentation and tests accordingly.

Version management improvements:

* [`packages/node/lambda-otel-lite/package.json`](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3): Updated the version to `0.10.0` and added a script to auto-generate the `version.ts` file during the build process. [[1]](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3) [[2]](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L49-R53)
* [`packages/node/lambda-otel-lite/src/version.ts`](diffhunk://#diff-691bd3ab607ea739e3de7cfce9f353f83de4000e15510ed62c81680d3cb365b8L1-R2): Changed the `version.ts` file to be auto-generated, removing manual version management.

CI/CD pipeline updates:

* [`.github/workflows/publish-node-lambda-otel-lite.yml`](diffhunk://#diff-263fbeb601c9a1874edd8f0a3922d4787f18d9e2396959c5ba53dd6cdc27894cL67-R67): Updated the URL for npm publishing and added a step to generate the version file during the CI build process. [[1]](diffhunk://#diff-263fbeb601c9a1874edd8f0a3922d4787f18d9e2396959c5ba53dd6cdc27894cL67-R67) [[2]](diffhunk://#diff-263fbeb601c9a1874edd8f0a3922d4787f18d9e2396959c5ba53dd6cdc27894cR87-R97)

Documentation updates:

* [`packages/node/lambda-otel-lite/PUBLISHING.md`](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766L6-R6): Updated the publishing steps to reflect the new version management process and CI/CD pipeline. [[1]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766L6-R6) [[2]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766R45-R68) [[3]](diffhunk://#diff-a92f7d22c35604d8c008e921a83f02869be316678e76f5f546247e199d859766L76-R85)

Test updates:

* [`packages/node/lambda-otel-lite/__tests__/telemetry/completion.test.ts`](diffhunk://#diff-79d167b31095df26d339bf72445b99c6e9e2b04777d8c020236e13a4336b66beL1-R27): Added a `beforeEach` hook to initialize the tracer and handler, and updated the test to check for the correct package information.

These changes ensure that the version is managed in a single place (`package.json`), streamline the publishing process, and improve the overall maintainability of the package.