### PR TITLE
Release node lambda-otel-lite 0.10.1

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2025-03-11
+
+### Added
+- Support for custom context propagators via the `propagators` option in `initTelemetry`
+- Added documentation and examples for using custom propagators
+
+### Changed
+- Updated dependencies:
+  - `@dev7a/otlp-stdout-span-exporter` from ^0.1.0 to ^0.10.1
+  - `@opentelemetry/core` from ^1.19.0 to ^1.30.1
+  - `@opentelemetry/resources` from ^1.19.0 to ^1.30.1
+
 ## [0.10.0] - 2025-03-08
 
 ### Changed

--- a/packages/node/lambda-otel-lite/README.md
+++ b/packages/node/lambda-otel-lite/README.md
@@ -1,11 +1,40 @@
 # Lambda OTel Lite
 
+[![npm](https://img.shields.io/npm/v/@dev7a/lambda-otel-lite.svg)](https://www.npmjs.com/package/@dev7a/lambda-otel-lite)
+
 The `@dev7a/lambda-otel-lite` package provides a lightweight, efficient OpenTelemetry implementation specifically designed for AWS Lambda environments in Node.js. It features a custom span processor and internal extension mechanism that optimizes telemetry collection for Lambda's unique execution model.
 
 By leveraging Lambda's execution lifecycle and providing multiple processing modes, this package enables efficient telemetry collection with minimal impact on function latency. By default, it uses the `@dev7a/otlp-stdout-span-exporter` to export spans to CloudWatch Logs, where they can be collected and forwarded by the [serverless-otlp-forwarder](https://github.com/dev7a/serverless-otlp-forwarder).
 
 >[!IMPORTANT]
 >This package is highly experimental and should not be used in production. Contributions are welcome.
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Features](#features)
+- [Architecture and Modules](#architecture-and-modules)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Processing Modes](#processing-modes)
+  - [Async Processing Mode Architecture](#async-processing-mode-architecture)
+- [Telemetry Configuration](#telemetry-configuration)
+  - [Custom configuration with custom resource attributes](#custom-configuration-with-custom-resource-attributes)
+  - [Custom configuration with custom span processors](#custom-configuration-with-custom-span-processors)
+  - [Custom configuration with context propagators](#custom-configuration-with-context-propagators)
+  - [Library specific Resource Attributes](#library-specific-resource-attributes)
+- [Event Extractors](#event-extractors)
+  - [Automatic Attributes extraction](#automatic-attributes-extraction)
+  - [Built-in Extractors](#built-in-extractors)
+  - [Custom Extractors](#custom-extractors)
+- [Environment Variables](#environment-variables)
+  - [Processing Configuration](#processing-configuration)
+  - [Resource Configuration](#resource-configuration)
+  - [Export Configuration](#export-configuration)
+  - [Logging](#logging)
+  - [AWS Lambda Environment](#aws-lambda-environment)
+- [License](#license)
+- [See Also](#see-also)
 
 ## Requirements
 - Node.js >= 18.0.0
@@ -15,10 +44,9 @@ By leveraging Lambda's execution lifecycle and providing multiple processing mod
 - **Flexible Processing Modes**: Support for synchronous, asynchronous, and custom export strategies
 - **Automatic Resource Detection**: Automatic extraction of Lambda environment attributes
 - **Lambda Extension Integration**: Built-in extension for efficient telemetry export
-- **Efficient Memory Usage**: Queue-based buffering to prevent memory growth
+- **Efficient Memory Usage**: Fixed-size queue to prevent memory growth
 - **AWS Event Support**: Automatic extraction of attributes from common AWS event types (API Gateway v1/v2, ALB)
 - **Flexible Context Propagation**: Support for W3C Trace Context
-- **TypeScript Support**: Full TypeScript type definitions included
 
 ## Architecture and Modules
 
@@ -42,7 +70,7 @@ graph TD
   - Returns a `TelemetryCompletionHandler` for span lifecycle management
 
 - `processor`: Lambda-optimized span processor
-  - Queue-based implementation
+  - Fixed-size queue implementation
   - Multiple processing modes
   - Coordinates with extension for async export
 
@@ -69,36 +97,57 @@ npm install --save @opentelemetry/exporter-trace-otlp-http
 ## Quick Start
 
 ```typescript
-import { trace } from '@opentelemetry/api';
+import { trace, StatusCode } from '@opentelemetry/api';
 import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
 import { apiGatewayV2Extractor } from '@dev7a/lambda-otel-lite/extractors';
 
 // Initialize telemetry once, outside the handler
 const { tracer, completionHandler } = initTelemetry();
 
-// Create traced handler with configuration
+// Create traced handler with specific extractor
 const traced = createTracedHandler(
-    'my-handler',
-    completionHandler,
-    apiGatewayV2Extractor  // Optional: Use event-specific extractor
+  'my-api-handler',
+  completionHandler,
+  apiGatewayV2Extractor
 );
 
-function processEvent(event: any) {
-    // Your business logic here
-    return {
-        statusCode: 200,
-        body: JSON.stringify({ message: "Success" })
-    };
+// Define business logic separately
+async function processUser(userId) {
+  // Your business logic here
+  return { name: 'User Name', id: userId };
 }
 
+// Create the Lambda handler
 export const handler = traced(async (event, context) => {
-    // Access current span via OpenTelemetry API
+  try {
+    // Get current span to add custom attributes
     const currentSpan = trace.getActiveSpan();
-    currentSpan?.setAttribute("custom", "value");
+    currentSpan?.setAttribute('handler.version', '1.0');
     
-    // Your handler code here
-    const result = await processEvent(event);
-    return result;
+    // Extract userId from event path parameters
+    const userId = event.pathParameters?.userId || 'unknown';
+    currentSpan?.setAttribute('user.id', userId);
+    
+    // Process business logic
+    const user = await processUser(userId);
+    
+    // Return formatted HTTP response
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ success: true, data: user })
+    };
+  } catch (error) {
+    // Simple error handling
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ 
+        success: false, 
+        error: 'Internal server error' 
+      })
+    };
+  }
 });
 ```
 
@@ -108,7 +157,10 @@ The package supports three processing modes for span export:
 
 1. **Sync Mode** (default):
    - Direct, synchronous export in handler thread
-   - Recommended for low-volume telemetry or when latency is not critical
+   - Recommended for:
+     - low-volume telemetry
+     - limited resources (memory, cpu)
+     - when latency is not critical
    - Set via `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE=sync`
 
 2. **Async Mode**:
@@ -175,6 +227,200 @@ The async mode leverages Lambda's extension API to optimize perceived latency by
 4. Single event loop handles both extension and handler code
 5. SIGTERM handler ensures graceful shutdown with span flushing
 
+## Telemetry Configuration
+
+The package provides several ways to configure the OpenTelemetry tracing pipeline, which is a required first step to instrument your Lambda function:
+
+### Custom configuration with custom resource attributes
+
+```typescript
+import { Resource } from '@opentelemetry/resources';
+import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
+
+// Create a custom resource with additional attributes
+const resource = new Resource({
+  'service.version': '1.0.0',
+  'deployment.environment': 'production',
+  'custom.attribute': 'value'
+});
+
+// Initialize with custom resource
+const { tracer, completionHandler } = initTelemetry({
+  resource
+});
+
+// Use the tracer and completion handler as usual
+```
+
+### Custom configuration with custom span processors
+
+```typescript
+import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+
+// Create a custom processor with OTLP HTTP exporter
+const processor = new BatchSpanProcessor(
+  new OTLPTraceExporter({
+    url: 'https://your-otlp-endpoint/v1/traces'
+  })
+);
+
+// Initialize with custom processor
+const { tracer, completionHandler } = initTelemetry({
+  spanProcessors: [processor]
+});
+```
+
+You can provide multiple span processors, and they will all be used to process spans. This allows you to send telemetry to multiple destinations or use different processing strategies for different types of spans.
+
+### Custom configuration with context propagators
+
+```typescript
+import { initTelemetry } from '@dev7a/lambda-otel-lite';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import { B3Propagator } from '@opentelemetry/propagator-b3';
+
+// Initialize with custom propagators
+const { tracer, completionHandler } = initTelemetry({
+  propagators: [
+    new W3CTraceContextPropagator(),  // W3C Trace Context
+    new B3Propagator(),  // B3 format for Zipkin compatibility
+  ]
+});
+```
+
+By default, OpenTelemetry Node.js uses W3C Trace Context and W3C Baggage propagators. The `propagators` parameter allows you to customize which propagators are used for context extraction and injection. This is useful when you need to integrate with systems that use different context propagation formats.
+
+You can provide multiple propagators, and they will be combined into a composite propagator. The order matters - propagators are applied in the order they are provided.
+
+> **Note:** The OpenTelemetry SDK also supports configuring propagators via the `OTEL_PROPAGATORS` environment variable. If set, this environment variable takes precedence over programmatic configuration. See the [OpenTelemetry JavaScript documentation](https://opentelemetry.io/docs/languages/js/propagation/) for more details.
+
+### Library specific Resource Attributes
+
+The package adds several resource attributes under the `lambda_otel_lite` namespace to provide configuration visibility:
+
+- `lambda_otel_lite.extension.span_processor_mode`: Current processing mode (`sync`, `async`, or `finalize`)
+- `lambda_otel_lite.lambda_span_processor.queue_size`: Maximum number of spans that can be queued
+- `lambda_otel_lite.lambda_span_processor.batch_size`: Maximum batch size for span export
+- `lambda_otel_lite.otlp_stdout_span_exporter.compression_level`: GZIP compression level used for span export
+
+These attributes are automatically added to the resource and can be used to understand the telemetry configuration in your observability backend.
+
+## Event Extractors
+
+Event extractors are responsible for extracting span attributes and context from Lambda event and context objects. The library provides built-in extractors for common Lambda triggers.
+
+### Automatic Attributes extraction
+
+The library automatically sets relevant FAAS attributes based on the Lambda context and event. Both `event` and `context` parameters must be passed to `tracedHandler` to enable all automatic attributes:
+
+- Resource Attributes (set at initialization):
+  - `cloud.provider`: "aws"
+  - `cloud.region`: from AWS_REGION
+  - `faas.name`: from AWS_LAMBDA_FUNCTION_NAME
+  - `faas.version`: from AWS_LAMBDA_FUNCTION_VERSION
+  - `faas.instance`: from AWS_LAMBDA_LOG_STREAM_NAME
+  - `faas.max_memory`: from AWS_LAMBDA_FUNCTION_MEMORY_SIZE
+  - `service.name`: from OTEL_SERVICE_NAME (defaults to function name)
+  - Additional attributes from OTEL_RESOURCE_ATTRIBUTES (URL-decoded)
+
+- Span Attributes (set per invocation when passing context):
+  - `faas.cold_start`: true on first invocation
+  - `cloud.account.id`: extracted from context's invokedFunctionArn
+  - `faas.invocation_id`: from awsRequestId
+  - `cloud.resource_id`: from context's invokedFunctionArn
+
+- HTTP Attributes (set for API Gateway events):
+  - `faas.trigger`: "http"
+  - `http.status_code`: from handler response
+  - `http.route`: from routeKey (v2) or resource (v1)
+  - `http.method`: from requestContext (v2) or httpMethod (v1)
+  - `http.target`: from path
+  - `http.scheme`: from protocol
+
+The library automatically detects API Gateway v1 and v2 events and sets the appropriate HTTP attributes. For HTTP responses, the status code is automatically extracted from the handler's response and set as `http.status_code`. For 5xx responses, the span status is set to ERROR.
+
+### Built-in Extractors
+
+```typescript
+import {
+    apiGatewayV1Extractor,  // API Gateway REST API
+    apiGatewayV2Extractor,  // API Gateway HTTP API
+    albExtractor,           // Application Load Balancer
+    defaultExtractor        // Basic Lambda attributes
+} from '@dev7a/lambda-otel-lite/extractors';
+```
+
+Each extractor is designed to handle a specific event type and extract relevant attributes:
+
+- `apiGatewayV1Extractor`: Extracts HTTP attributes from API Gateway REST API events
+- `apiGatewayV2Extractor`: Extracts HTTP attributes from API Gateway HTTP API events
+- `albExtractor`: Extracts HTTP attributes from Application Load Balancer events
+- `defaultExtractor`: Extracts basic Lambda attributes from any event type
+
+
+```typescript
+import { apiGatewayV1Extractor } from '@dev7a/lambda-otel-lite/extractors';
+
+// Initialize telemetry with default configuration
+const { tracer, completionHandler } = initTelemetry();
+
+export const traced = createTracedHandler(
+    'api-v1-handler',
+    completionHandler,
+    apiGatewayV1Extractor
+);
+
+export const handler = traced(async (event, context) => {
+    // Your handler code
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: 'Hello, world!' })
+    };
+});
+```
+
+### Custom Extractors
+
+You can create custom extractors for event types not directly supported by the library by implementing the extractor interface:
+
+```typescript
+import { SpanAttributes, TriggerType } from '@dev7a/lambda-otel-lite/types';
+
+const customExtractor = (event, context): SpanAttributes => ({
+    trigger: TriggerType.OTHER,  // Or any custom string
+    attributes: {
+        'custom.attribute': 'value',
+        // ... other attributes
+    },
+    spanName: 'custom-operation',  // Optional
+    carrier: event?.headers,  // Optional: For context propagation
+});
+
+export const traced = createTracedHandler(
+    'custom-handler',
+    completionHandler,
+    customExtractor
+);
+
+export const handler = traced(async (event, context) => {
+    // Your handler code
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ message: 'Hello, world!' })
+    };
+});
+```
+
+The `SpanAttributes` object returned by the extractor contains:
+
+- `trigger`: The type of trigger (HTTP, SQS, etc.) - affects how spans are named
+- `attributes`: An attributes object to add to the span
+- `spanName`: Optional custom name for the span (defaults to handler name)
+- `carrier`: Optional object containing trace context headers for propagation
+
+
 ## Environment Variables
 
 The package can be configured using the following environment variables:
@@ -209,314 +455,13 @@ The following AWS Lambda environment variables are automatically used for resour
 - `AWS_LAMBDA_LOG_STREAM_NAME`: Log stream name
 - `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`: Function memory size
 
-## Automatic Attributes extraction
-
-The library automatically sets relevant FAAS attributes based on the Lambda context and event. Both `event` and `context` parameters must be passed to `tracedHandler` to enable all automatic attributes:
-
-- Resource Attributes (set at initialization):
-  - `cloud.provider`: "aws"
-  - `cloud.region`: from AWS_REGION
-  - `faas.name`: from AWS_LAMBDA_FUNCTION_NAME
-  - `faas.version`: from AWS_LAMBDA_FUNCTION_VERSION
-  - `faas.instance`: from AWS_LAMBDA_LOG_STREAM_NAME
-  - `faas.max_memory`: from AWS_LAMBDA_FUNCTION_MEMORY_SIZE
-  - `service.name`: from OTEL_SERVICE_NAME (defaults to function name)
-  - Additional attributes from OTEL_RESOURCE_ATTRIBUTES (URL-decoded)
-
-- Span Attributes (set per invocation when passing context):
-  - `faas.cold_start`: true on first invocation
-  - `cloud.account.id`: extracted from context's invokedFunctionArn
-  - `faas.invocation_id`: from awsRequestId
-  - `cloud.resource_id`: from context's invokedFunctionArn
-
-- HTTP Attributes (set for API Gateway events):
-  - `faas.trigger`: "http"
-  - `http.status_code`: from handler response
-  - `http.route`: from routeKey (v2) or resource (v1)
-  - `http.method`: from requestContext (v2) or httpMethod (v1)
-  - `http.target`: from path
-  - `http.scheme`: from protocol
-
-The library automatically detects API Gateway v1 and v2 events and sets the appropriate HTTP attributes. For HTTP responses, the status code is automatically extracted from the handler's response and set as `http.status_code`. For 5xx responses, the span status is set to ERROR.
-
-### Library specific Resource Attributes
-
-The package adds several resource attributes under the `lambda_otel_lite` namespace to provide configuration visibility:
-
-- `lambda_otel_lite.extension.span_processor_mode`: Current processing mode (`sync`, `async`, or `finalize`)
-- `lambda_otel_lite.lambda_span_processor.queue_size`: Maximum number of spans that can be queued
-- `lambda_otel_lite.lambda_span_processor.batch_size`: Maximum batch size for span export
-- `lambda_otel_lite.otlp_stdout_span_exporter.compression_level`: GZIP compression level used for span export
-
-These attributes are automatically added to the resource and can be used to understand the telemetry configuration in your observability backend.
-
-## Error Handling
-
-The package provides automatic error tracking and span status updates based on handler behavior:
-
-### HTTP Response Status
-If your handler returns a standard HTTP response object, the status code is automatically recorded:
-```typescript
-import { StatusCode } from '@opentelemetry/api';
-
-export const handler = traced(async (event, context) => {
-    try {
-        const result = await processEvent(event);
-        return {
-            statusCode: 200,
-            body: JSON.stringify({ message: "Success" })
-        };
-    } catch (error) {
-        if (error instanceof ValidationError) {
-            // Return a 4xx response - this won't set the span status to ERROR
-            return {
-                statusCode: 400,
-                body: JSON.stringify({ error: error.message })
-            };
-        }
-        // Return a 5xx response - this will set the span status to ERROR
-        return {
-            statusCode: 500,
-            body: JSON.stringify({ error: "Internal error" })
-        };
-    }
-});
-```
-
-Any response with status code >= 500 will automatically set the span status to ERROR.
-
-### Exception Handling
-While the package will automatically record uncaught exceptions, it's recommended to handle exceptions explicitly in your handler:
-
-```typescript
-import { trace, StatusCode } from '@opentelemetry/api';
-
-export const handler = traced(async (event, context) => {
-    try {
-        // Your code here
-        throw new Error("invalid input");
-    } catch (error) {
-        // Record the error and set appropriate status
-        const currentSpan = trace.getActiveSpan();
-        if (currentSpan) {
-            currentSpan.recordException(error as Error);
-            currentSpan.setStatus({
-                code: StatusCode.ERROR,
-                message: error instanceof Error ? error.message : String(error)
-            });
-        }
-        return {
-            statusCode: 400,
-            body: JSON.stringify({ error: String(error) })
-        };
-    }
-});
-```
-
-This gives you more control over:
-- Which exceptions to record
-- What status code to return
-- What error message to include
-- Whether to set the span status to ERROR
-
-Uncaught exceptions will still be recorded as a fallback, but this should be considered a last resort.
-
-## Advanced Usage
-
-### Event Extractors
-
-Built-in extractors for common Lambda triggers:
-
-```typescript
-import { createTracedHandler, initTelemetry } from '@dev7a/lambda-otel-lite';
-import {
-    apiGatewayV1Extractor,  // API Gateway REST API
-    apiGatewayV2Extractor,  // API Gateway HTTP API
-    albExtractor,           // Application Load Balancer
-    defaultExtractor        // Basic Lambda attributes
-} from '@dev7a/lambda-otel-lite/extractors';
-
-// Initialize telemetry with default configuration
-const { tracer, completionHandler } = initTelemetry();
-
-// Create handlers for different event types
-export const apiV2Handler = createTracedHandler(
-    'api-v2-handler',
-    completionHandler,
-    apiGatewayV2Extractor
-);
-
-export const apiV1Handler = createTracedHandler(
-    'api-v1-handler',
-    completionHandler,
-    apiGatewayV1Extractor
-);
-
-export const albHandler = createTracedHandler(
-    'alb-handler',
-    completionHandler,
-    albExtractor
-);
-```
-
-Custom extractors can be created by implementing the extractor interface:
-
-```typescript
-import { SpanAttributes, TriggerType } from '@dev7a/lambda-otel-lite/types';
-import type { Context as LambdaContext } from 'aws-lambda';
-
-const customExtractor = (event: unknown, context: LambdaContext): SpanAttributes => ({
-    trigger: TriggerType.OTHER,  // Or any custom string
-    attributes: {
-        'custom.attribute': 'value',
-        // ... other attributes
-    },
-    spanName: 'custom-operation',  // Optional
-    carrier: event?.headers,  // Optional: For context propagation
-});
-
-export const customHandler = createTracedHandler(
-    'custom-handler',
-    completionHandler,
-    customExtractor
-);
-```
-
-### Custom Resource
-
-You can provide custom resource attributes during initialization:
-
-```typescript
-import { Resource } from '@opentelemetry/resources';
-import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
-
-// Create a custom resource
-const resource = new Resource({
-    'service.version': '1.0.0',
-    'deployment.environment': 'production'
-});
-
-// Initialize with custom resource
-const { tracer, completionHandler } = initTelemetry({
-    resource
-});
-
-// Create a traced handler as usual
-export const handler = createTracedHandler(
-    'custom-resource-handler',
-    completionHandler
-)(async (event, context) => {
-    return {
-        statusCode: 200,
-        body: JSON.stringify({ message: 'Hello World' })
-    };
-});
-```
-
-### Custom Span Processor
-
-For advanced use cases, you can use custom span processors:
-
-```typescript
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { initTelemetry, createTracedHandler } from '@dev7a/lambda-otel-lite';
-
-// Create a custom processor with OTLP HTTP exporter
-const processor = new BatchSpanProcessor(
-    new OTLPTraceExporter({
-        url: 'https://your-otlp-endpoint/v1/traces'
-    })
-);
-
-// Initialize with custom processor
-const { tracer, completionHandler } = initTelemetry({
-    spanProcessors: [processor]
-});
-
-// Create a traced handler as usual
-export const handler = createTracedHandler(
-    'custom-processor-handler',
-    completionHandler
-)(async (event, context) => {
-    return {
-        statusCode: 200,
-        body: JSON.stringify({ message: 'Hello World' })
-    };
-});
-```
-
-## Local Development
-
-### Building the Package
-
-The package uses static versioning with version numbers defined in both `package.json` and `src/version.ts`. Version tags follow the format `node/lambda-otel-lite/vX.Y.Z` (e.g., `node/lambda-otel-lite/v0.8.0`).
-
-When building locally:
-
-```bash
-# Install dependencies
-npm install
-
-# Build the package
-npm run build
-
-# Run tests
-npm test
-```
-
-### Installing for Development
-
-For development, install in link mode:
-
-```bash
-# Clone the repository
-git clone https://github.com/dev7a/lambda-otel-lite.git
-cd lambda-otel-lite
-
-# Install dependencies
-npm install
-
-# Build and link the package
-npm run build
-npm link
-
-# In your project directory
-npm link @dev7a/lambda-otel-lite
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-npm test
-
-# Run with coverage
-npm run test:coverage
-
-# Run specific test file
-npm test -- src/__tests__/handler.test.ts
-
-# Run tests in watch mode
-npm run test:watch
-```
-
-### Code Quality
-
-```bash
-# Format code
-npm run format
-
-# Run linter
-npm run lint
-
-# Run type checker
-npm run type-check
-
-# Run all checks
-npm run check
-```
 
 ## License
 
 [MIT License](LICENSE)
+
+## See Also
+
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder) - The main project repository for the Serverless OTLP Forwarder project
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/python/lambda-otel-lite) | [PyPI](https://pypi.org/project/lambda-otel-lite/) - The Python version of this library
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/rust/lambda-otel-lite) | [crates.io](https://crates.io/crates/lambda-otel-lite) - The Rust version of this library

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/init.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/init.test.ts
@@ -1,5 +1,12 @@
 import { jest, describe, it, beforeEach, afterEach, expect } from '@jest/globals';
-import { trace, propagation, TextMapPropagator, TextMapGetter, TextMapSetter, Context, context } from '@opentelemetry/api';
+import {
+  trace,
+  propagation,
+  TextMapPropagator,
+  TextMapGetter,
+  TextMapSetter,
+  Context,
+} from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { initTelemetry, isColdStart, setColdStart } from '../../src/internal/telemetry/init';
@@ -91,12 +98,12 @@ describe('telemetry/init', () => {
         extractCalled = false;
         injectCalled = false;
 
-        extract(context: Context, carrier: unknown, getter?: TextMapGetter): Context {
+        extract(_context: Context, _carrier: unknown, _getter?: TextMapGetter): Context {
           this.extractCalled = true;
-          return context;
+          return _context;
         }
 
-        inject(context: Context, carrier: unknown, setter?: TextMapSetter): void {
+        inject(_context: Context, _carrier: unknown, _setter?: TextMapSetter): void {
           this.injectCalled = true;
         }
 
@@ -121,7 +128,7 @@ describe('telemetry/init', () => {
 
       // Verify setGlobalPropagator was called
       expect(setGlobalPropagatorSpy).toHaveBeenCalled();
-      
+
       // Clean up spy
       setGlobalPropagatorSpy.mockRestore();
     });

--- a/packages/node/lambda-otel-lite/__tests__/telemetry/init.test.ts
+++ b/packages/node/lambda-otel-lite/__tests__/telemetry/init.test.ts
@@ -1,5 +1,5 @@
 import { jest, describe, it, beforeEach, afterEach, expect } from '@jest/globals';
-import { trace } from '@opentelemetry/api';
+import { trace, propagation, TextMapPropagator, TextMapGetter, TextMapSetter, Context, context } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { initTelemetry, isColdStart, setColdStart } from '../../src/internal/telemetry/init';
@@ -83,6 +83,47 @@ describe('telemetry/init', () => {
       const testSpan = tracer.startSpan('test');
       expect(testSpan).toBeDefined();
       testSpan.end();
+    });
+
+    it('should initialize telemetry with custom propagators', () => {
+      // Create a mock propagator for testing
+      class MockPropagator implements TextMapPropagator {
+        extractCalled = false;
+        injectCalled = false;
+
+        extract(context: Context, carrier: unknown, getter?: TextMapGetter): Context {
+          this.extractCalled = true;
+          return context;
+        }
+
+        inject(context: Context, carrier: unknown, setter?: TextMapSetter): void {
+          this.injectCalled = true;
+        }
+
+        fields(): string[] {
+          return ['mock-header'];
+        }
+      }
+
+      // Create a custom propagator
+      const mockPropagator = new MockPropagator();
+
+      // Spy on setGlobalPropagator
+      const setGlobalPropagatorSpy = jest.spyOn(propagation, 'setGlobalPropagator');
+
+      // Initialize telemetry with the custom propagator
+      const { tracer, completionHandler } = initTelemetry({
+        propagators: [mockPropagator],
+      });
+
+      expect(completionHandler).toBeDefined();
+      expect(tracer).toBeDefined();
+
+      // Verify setGlobalPropagator was called
+      expect(setGlobalPropagatorSpy).toHaveBeenCalled();
+      
+      // Clean up spy
+      setGlobalPropagatorSpy.mockRestore();
     });
 
     it('should initialize telemetry with custom exporter', () => {

--- a/packages/node/lambda-otel-lite/package-lock.json
+++ b/packages/node/lambda-otel-lite/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dev7a/lambda-otel-lite",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@dev7a/otlp-stdout-span-exporter": "^0.1.0",
+        "@dev7a/otlp-stdout-span-exporter": "^0.10.1",
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/core": "^1.19.0",
-        "@opentelemetry/resources": "^1.19.0",
+        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/resources": "^1.30.1",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/sdk-trace-node": "^1.30.1"
       },
@@ -581,21 +581,21 @@
       }
     },
     "node_modules/@dev7a/otlp-stdout-span-exporter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dev7a/otlp-stdout-span-exporter/-/otlp-stdout-span-exporter-0.1.0.tgz",
-      "integrity": "sha512-7wewPpmXdCrAiJOQmgSMW1SnGNK+OHfu45CLtgeoMY4llR1yzYrg0JpygLCAAD59a7p8SwOEi1PR+vWns+WAcA==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dev7a/otlp-stdout-span-exporter/-/otlp-stdout-span-exporter-0.10.1.tgz",
+      "integrity": "sha512-nB4ss0KetVtemsrFrC4tNuVVNBw2xilAwS28OHMZ+wFuw4pzbNG9mtWql3hWF1eFqUA5KB/wcPDY2yKXHHtynw==",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/core": "^1.27.0",
+        "@opentelemetry/core": "^1.30.1",
         "@opentelemetry/otlp-transformer": "^0.57.0",
-        "@opentelemetry/sdk-trace-base": "^1.27.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.0"
       },
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.8.0"
+        "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/api-logs": {
@@ -631,6 +631,52 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
+      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/resources": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
+      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
+      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-logs": {
       "version": "0.57.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.0.tgz",
@@ -646,6 +692,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
+      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-metrics": {
@@ -664,6 +725,21 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
+    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
+      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.0.tgz",
@@ -672,6 +748,21 @@
       "dependencies": {
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/resources": "1.30.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
+      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -1263,9 +1354,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -1292,21 +1383,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/propagator-jaeger": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.30.1.tgz",
@@ -1322,28 +1398,13 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
@@ -1370,37 +1431,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-node": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.30.1.tgz",
@@ -1413,21 +1443,6 @@
         "@opentelemetry/propagator-jaeger": "1.30.1",
         "@opentelemetry/sdk-trace-base": "1.30.1",
         "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [
@@ -58,10 +58,10 @@
     "test:watch": "jest -c jest.config.ts --watch"
   },
   "dependencies": {
-    "@dev7a/otlp-stdout-span-exporter": "^0.1.0",
+    "@dev7a/otlp-stdout-span-exporter": "^0.10.1",
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.19.0",
-    "@opentelemetry/resources": "^1.19.0",
+    "@opentelemetry/core": "^1.30.1",
+    "@opentelemetry/resources": "^1.30.1",
     "@opentelemetry/sdk-trace-base": "^1.30.1",
     "@opentelemetry/sdk-trace-node": "^1.30.1"
   },

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/init.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/init.ts
@@ -2,6 +2,8 @@ import { Resource } from '@opentelemetry/resources';
 import { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
+import { propagation, TextMapPropagator } from '@opentelemetry/api';
+import { CompositePropagator } from '@opentelemetry/core';
 import { state } from '../state';
 import { LambdaSpanProcessor } from './processor';
 import { TelemetryCompletionHandler } from './completion';
@@ -141,6 +143,9 @@ export function getLambdaResource(): Resource {
  * @param options.spanProcessors - Array of SpanProcessor implementations to use.
  *                                If not provided, defaults to LambdaSpanProcessor
  *                                with OTLPStdoutSpanExporter.
+ * @param options.propagators - Array of TextMapPropagator implementations to use.
+ *                             If not provided, the default propagators from the SDK will be used
+ *                             (W3C Trace Context and W3C Baggage).
  *
  * @returns Object containing:
  *   - tracer: Tracer instance for manual instrumentation
@@ -168,30 +173,16 @@ export function getLambdaResource(): Resource {
  * });
  * ```
  *
- * Custom configuration:
+ * Custom configuration with propagators:
  * ```typescript
- * const resource = new Resource({
- *   'service.version': '1.0.0',
- *   'deployment.environment': 'production'
- * });
- *
- * const processor = new BatchSpanProcessor(
- *   new OTLPTraceExporter({
- *     url: 'https://your-collector:4318/v1/traces'
- *   })
- * );
- *
+ * import { W3CTraceContextPropagator } from '@opentelemetry/core';
+ * import { B3Propagator } from '@opentelemetry/propagator-b3';
+ * 
  * const { tracer, completionHandler } = initTelemetry({
- *   resource,
- *   spanProcessors: [processor]
- * });
- *
- * // Then create the traced handler
- * export const handler = createTracedHandler(completionHandler, {
- *   name: 'my-handler'
- * }, async (event, context, span) => {
- *   // Add attributes to the handler's span
- *   span.setAttribute('request.id', context.awsRequestId);
+ *   propagators: [
+ *     new W3CTraceContextPropagator(),
+ *     new B3Propagator(),
+ *   ]
  * });
  * ```
  *
@@ -212,9 +203,20 @@ export function getLambdaResource(): Resource {
 export function initTelemetry(options?: {
   resource?: Resource;
   spanProcessors?: SpanProcessor[];
+  propagators?: TextMapPropagator[];
 }): { tracer: Tracer; completionHandler: TelemetryCompletionHandler } {
   // Setup resource
   const baseResource = options?.resource || getLambdaResource();
+
+  // Setup propagators if provided
+  if (options?.propagators) {
+    // Create a composite propagator and set it as the global propagator
+    const compositePropagator = new CompositePropagator({
+      propagators: options.propagators,
+    });
+    propagation.setGlobalPropagator(compositePropagator);
+    logger.debug(`Set custom propagators: ${options.propagators.map(p => p.constructor.name).join(', ')}`);
+  }
 
   // Setup processors with compression level support
   const processors = options?.spanProcessors || [

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/init.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/init.ts
@@ -177,7 +177,7 @@ export function getLambdaResource(): Resource {
  * ```typescript
  * import { W3CTraceContextPropagator } from '@opentelemetry/core';
  * import { B3Propagator } from '@opentelemetry/propagator-b3';
- * 
+ *
  * const { tracer, completionHandler } = initTelemetry({
  *   propagators: [
  *     new W3CTraceContextPropagator(),
@@ -215,7 +215,9 @@ export function initTelemetry(options?: {
       propagators: options.propagators,
     });
     propagation.setGlobalPropagator(compositePropagator);
-    logger.debug(`Set custom propagators: ${options.propagators.map(p => p.constructor.name).join(', ')}`);
+    logger.debug(
+      `Set custom propagators: ${options.propagators.map((p) => p.constructor.name).join(', ')}`
+    );
   }
 
   // Setup processors with compression level support

--- a/packages/node/lambda-otel-lite/src/version.ts
+++ b/packages/node/lambda-otel-lite/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const VERSION = "0.10.0";
+export const VERSION = "0.10.1";

--- a/packages/node/lambda-otel-lite/src/version.ts
+++ b/packages/node/lambda-otel-lite/src/version.ts
@@ -1,2 +1,2 @@
 // This file is auto-generated. Do not edit manually.
-export const VERSION = "0.10.1";
+export const VERSION = '0.10.1';


### PR DESCRIPTION
This pull request includes several updates to the `lambda-otel-lite` package, focusing on adding support for custom context propagators, updating dependencies, and enhancing tests. Below is a summary of the most important changes:

### New Features:
* Added support for custom context propagators via the `propagators` option in `initTelemetry` and included documentation and examples for using custom propagators. [[1]](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR8-R19) [[2]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR146-R148) [[3]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baL171-R185) [[4]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR206-R220)

### Dependency Updates:
* Updated dependencies in `package.json` and `package-lock.json`:
  - `@dev7a/otlp-stdout-span-exporter` from ^0.1.0 to ^0.10.1
  - `@opentelemetry/core` from ^1.19.0 to ^1.30.1
  - `@opentelemetry/resources` from ^1.19.0 to ^1.30.1 [[1]](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L61-R64) [[2]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L3-R15) [[3]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L584-R598) [[4]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821R634-R679) [[5]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821R697-R711) [[6]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821R728-R742) [[7]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821R760-R774) [[8]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L1266-R1359) [[9]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L1295-L1309) [[10]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L1325-R1407) [[11]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L1373-L1403) [[12]](diffhunk://#diff-deedc6fe2e0127e4af407830792f849f1df7dd5663d6a78533a33149e7cc9821L1424-L1438)

### Tests:
* Enhanced tests to verify the initialization of telemetry with custom propagators by adding a new test case in `init.test.ts`.

### Changelog:
* Updated `CHANGELOG.md` to document the changes in version 0.10.1, including the addition of custom context propagator support and dependency updates.