### PR TITLE
Release python lambda-otel-lite 0.10.1

### DIFF
--- a/packages/python/lambda-otel-lite/CHANGELOG.md
+++ b/packages/python/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2025-03-11
+
+### Added
+- Support for custom context propagators via the `propagators` parameter in `init_telemetry`
+- Added tests for custom propagator functionality
+
 ## [0.10.0] - 2025-03-08
 
 ### Changed

--- a/packages/python/lambda-otel-lite/examples/README.md
+++ b/packages/python/lambda-otel-lite/examples/README.md
@@ -1,0 +1,106 @@
+# Examples
+
+This directory contains examples demonstrating how to use `lambda-otel-lite` in AWS Lambda functions. The examples showcase integration patterns and observability best practices.
+
+## Template Structure
+
+The `template.yaml` provides a Lambda function with Python 3.13 runtime:
+
+```yaml
+Handler:
+  Type: AWS::Serverless::Function
+  Properties:
+    CodeUri: handler/
+    Handler: app.handler
+    Runtime: python3.13
+    Environment:
+      Variables:
+        LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: async
+```
+
+This configuration:
+- Uses the standard Python Lambda runtime
+- Enables async processing mode for optimal performance
+- Includes a Function URL for easy testing
+
+## Global Configuration
+
+The template includes global settings for all functions:
+
+```yaml
+Globals:
+  Function:
+    MemorySize: 128
+    Timeout: 30
+    Architectures:
+      - arm64
+    LoggingConfig:
+      LogFormat: JSON
+```
+
+These settings:
+- Use ARM64 architecture for better cost/performance
+- Configure JSON logging for better integration with log processors
+- Set appropriate memory and timeout values
+
+## Deployment
+
+### Prerequisites
+1. AWS SAM CLI installed
+2. AWS credentials configured
+3. Python 3.13 or later
+
+### Deploy with SAM
+
+1. Build the functions:
+```bash
+sam build
+```
+
+2. Deploy to AWS:
+```bash
+sam deploy --guided
+```
+
+During the guided deployment, you'll be prompted for:
+- Stack name
+- AWS Region
+- Confirmation of IAM role creation
+- Function URL authorization settings
+
+### Testing the Deployment
+
+After deployment, you can test the function using its URL and curl:
+
+```bash
+curl <HandlerFunctionUrl>
+```
+
+The function will:
+1. Generate OpenTelemetry traces
+2. Output OTLP-formatted spans to CloudWatch logs
+3. Be compatible with the serverless-otlp-forwarder
+
+## Function Structure
+
+The example function demonstrates:
+1. Initialization of telemetry
+2. Usage of the traced handler decorator
+3. Event attribute extraction
+4. Proper error handling and span status setting
+
+Key files:
+- `handler/app.py` - Main handler implementation
+- `handler/requirements.txt` - Dependencies
+
+## Viewing Traces
+
+The traces will be available in your configured OpenTelemetry backend when using the [serverless-otlp-forwarder](https://github.com/dev7a/serverless-otlp-forwarder)
+
+For setup instructions and configuration options, see the [serverless-otlp-forwarder documentation](https://github.com/dev7a/serverless-otlp-forwarder).
+
+## Additional Resources
+
+- [Main lambda-otel-lite Documentation](../README.md)
+- [AWS SAM Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html)
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)

--- a/packages/python/lambda-otel-lite/pyproject.toml
+++ b/packages/python/lambda-otel-lite/pyproject.toml
@@ -8,7 +8,7 @@ path = "src/lambda_otel_lite/version.py"
 
 [project]
 name = "lambda_otel_lite"
-version = "0.10.0"
+version = "0.10.1"
 description = "Lightweight OpenTelemetry instrumentation for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,9 +26,9 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "opentelemetry-api>=1.29.0",
-    "opentelemetry-sdk>=1.29.0",
-    "otlp-stdout-span-exporter>=0.1.2",
+    "opentelemetry-api>=1.30.0",
+    "opentelemetry-sdk>=1.30.0",
+    "otlp-stdout-span-exporter>=0.10.0",
 ]
 
 [project.urls]
@@ -44,7 +44,7 @@ dev = [
 ]
 
 otlp-http = [
-    "opentelemetry-exporter-otlp-proto-http>=1.29.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This pull request includes several changes to the `lambda-otel-lite` project, focusing on adding support for custom context propagators, updating dependencies, and including new examples for usage. Below are the most important changes:

### New Features:
* Added support for custom context propagators via the `propagators` parameter in the `init_telemetry` function. [[1]](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647R205) [[2]](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647R218-R221) [[3]](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647R231-R239)
* Included tests for the custom propagator functionality to ensure proper integration.

### Documentation:
* Added a new section in `examples/README.md` to demonstrate how to use `lambda-otel-lite` in AWS Lambda functions, including integration patterns and observability best practices.

### Dependency Updates:
* Updated project dependencies in `pyproject.toml` to use newer versions of `opentelemetry-api`, `opentelemetry-sdk`, and `otlp-stdout-span-exporter`. [[1]](diffhunk://#diff-53fa277f7b8898f8cc036b22cb6133c3cc5d36d0246d9a0c29f84b75e9801a61L29-R31) [[2]](diffhunk://#diff-53fa277f7b8898f8cc036b22cb6133c3cc5d36d0246d9a0c29f84b75e9801a61L47-R47)

### Version Bump:
* Bumped the project version from `0.10.0` to `0.10.1` in `pyproject.toml` to reflect the new changes and features.

### Changelog:
* Updated the `CHANGELOG.md` to document the new features and changes for version `0.10.1`.…el-lite