### PR TITLE
fix error in lambda function response

### DIFF
--- a/packages/rust/lambda-otel-lite/examples/tower/main.rs
+++ b/packages/rust/lambda-otel-lite/examples/tower/main.rs
@@ -64,6 +64,7 @@ async fn handler(event: LambdaEvent<ApiGatewayV2httpRequest>) -> Result<Value, E
             Ok(serde_json::json!({
                 "statusCode": 200,
                 "body": format!("Hello from request {}", request_id)
+                "headers": { "Content-Type": "text/plain" },
             }))
         }
         Err(ErrorType::Expected) => {


### PR DESCRIPTION
## Problem Description

When accessing the AWS Lambda function endpoint through a browser, we encountered inconsistent behavior:

- **Firefox**: Displayed a JSON parsing error
  ```
  SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
  ```
- **Chrome**: Successfully displayed the raw text response without errors

## Root Cause Analysis

The Lambda function was returning a plain text response but without specifying the `Content-Type` header. This caused browsers to handle the response differently:

1. **Firefox**: Attempted to parse the response as JSON (since it was viewing the JSON tab) and failed because it was plain text
2. **Chrome**: Was more lenient and simply displayed the raw text without attempting to parse it

## Solution

Before:

![image](https://github.com/user-attachments/assets/f71e3a81-e0fb-4c56-abfa-9d3e444ab9fb)


After:

![image](https://github.com/user-attachments/assets/a88fb491-1c6a-49bc-8b5c-4e7937a45c57)