### PR TITLE
Release rust lambda-otel-lite v0.10.2

### DIFF
--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2025-03-15
+### Added
+- Support for controlling the fmt layer through the `LAMBDA_TRACING_ENABLE_FMT_LAYER` environment variable
+- Added tests to verify environment variable handling for the fmt layer configuration
+
+### Changed
+- Updated the `TelemetryConfig::default()` implementation to read from environment variables
+- Changed the `ApplicationLogLevel` from DEBUG to INFO in the example template.yaml
+- Enhanced documentation with more detailed examples and explanations
+- Improved example template configuration with better descriptions and properties
 
 ## [0.10.1] - 2025-03-11
 ### Fixed

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/lambda-otel-lite/examples/template.yaml
+++ b/packages/rust/lambda-otel-lite/examples/template.yaml
@@ -12,7 +12,7 @@ Globals:
     Runtime: provided.al2023
     LoggingConfig:
       LogFormat: JSON
-      ApplicationLogLevel: DEBUG
+      ApplicationLogLevel: INFO
       SystemLogLevel: INFO
   
 


### PR DESCRIPTION
This pull request includes several important updates and improvements to the `lambda-otel-lite` package. The changes mainly focus on adding new features, updating configurations, enhancing documentation, and improving example templates.

### Notable Changes:

#### New Features:
- Added support for controlling the `fmt` layer through the `LAMBDA_TRACING_ENABLE_FMT_LAYER` environment variable.
- Introduced tests to verify the handling of the `fmt` layer configuration via environment variables.

#### Configuration Updates:
- Updated the `TelemetryConfig::default()` implementation to read from environment variables, enabling the `fmt` layer based on the `LAMBDA_TRACING_ENABLE_FMT_LAYER` variable.
- Changed the `ApplicationLogLevel` from DEBUG to INFO in the `template.yaml` file and example templates. [[1]](diffhunk://#diff-b760c127f868a8fd9ee7f973e59c411b481942f9208e7dd0ecd8500e2158843dL15-R15) [[2]](diffhunk://#diff-186498266ac8e953c6310f423de26221c85a117655d116518dd6abf581d93900R8-R17)

#### Documentation Enhancements:
- Enhanced the documentation with more detailed examples and explanations, including a comprehensive overview of example setups and function structures. [[1]](diffhunk://#diff-68258a5ce53039552875a9bb15327caffd282685148f51debaa23687a5084321L3-R14) [[2]](diffhunk://#diff-68258a5ce53039552875a9bb15327caffd282685148f51debaa23687a5084321R91-R191)

#### Example Template Improvements:
- Improved example template configurations with better descriptions and properties, including updates to the `HandlerExample` and `TowerExample` sections. [[1]](diffhunk://#diff-68258a5ce53039552875a9bb15327caffd282685148f51debaa23687a5084321R27-R35) [[2]](diffhunk://#diff-68258a5ce53039552875a9bb15327caffd282685148f51debaa23687a5084321R52-R61)

#### Version Update:
- Bumped the package version from `0.10.1` to `0.10.2` in the `Cargo.toml` file.