### PR TITLE
release node otlp-stdout-span-exporter v0.11.0

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2024-11-17
+
+### Changed
+- Modified configuration value precedence to ensure environment variables always take precedence over constructor parameters
+- Improved error handling for invalid environment variable values
+- Enhanced documentation to clearly explain configuration precedence rules
+
 ## [0.10.1] - 2025-03-05
 
 ### Added

--- a/packages/node/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/node/otlp-stdout-span-exporter/PUBLISHING.md
@@ -49,6 +49,7 @@ Before publishing a new version of `@dev7a/otlp-stdout-span-exporter`, ensure al
 4. Run tests: `npm test`
 5. Build package: `npm run build` (this will automatically generate the version.ts file)
 6. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
+7. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
 7. Tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -80,12 +80,17 @@ tracer.startActiveSpan('my-operation', span => {
 ```typescript
 interface OTLPStdoutSpanExporterConfig {
   // GZIP compression level (0-9, where 0 is no compression and 9 is maximum compression)
-  // Defaults to 6 or value from OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL
+  // Defaults to 6 if not specified
   gzipLevel?: number;
 }
 ```
 
-The explicit configuration via code will override any environment variable setting.
+The exporter follows a strict configuration precedence:
+1. Environment variables (highest precedence)
+2. Constructor parameters in config object
+3. Default values (lowest precedence)
+
+This means that if the `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable is set, it will always take precedence over the configuration in the constructor.
 
 ### Environment Variables
 
@@ -95,11 +100,10 @@ The exporter respects the following environment variables:
 - `AWS_LAMBDA_FUNCTION_NAME`: Fallback service name (if `OTEL_SERVICE_NAME` not set)
 - `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (which take precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
-- `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9). Defaults to 6.
+- `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9). Defaults to 6. Takes precedence over the constructor parameter if set.
 
 >[!NOTE]
 >For security best practices, avoid including authentication credentials or sensitive information in headers. The serverless-otlp-forwarder infrastructure is designed to handle authentication at the destination, rather than embedding credentials in your telemetry data.
-
 
 ## Output Format
 

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/node/otlp-stdout-span-exporter/src/__tests__/otlp_stdout_span_exporter.test.ts
+++ b/packages/node/otlp-stdout-span-exporter/src/__tests__/otlp_stdout_span_exporter.test.ts
@@ -105,7 +105,7 @@ describe('OTLPStdoutSpanExporter', () => {
     });
   });
 
-  it('should use explicit config over environment variable for compression level', () => {
+  it('should use environment variable over explicit config for compression level', () => {
     process.env.OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL = '3';
     const _exporter = new OTLPStdoutSpanExporter({ gzipLevel: 8 });
     const spans: ReadableSpan[] = [];
@@ -113,7 +113,7 @@ describe('OTLPStdoutSpanExporter', () => {
     _exporter.export(spans, (_result) => {
       expect(zlib.gzipSync).toHaveBeenCalledWith(
         expect.any(Buffer),
-        expect.objectContaining({ level: 8 })
+        expect.objectContaining({ level: 3 })
       );
     });
   });


### PR DESCRIPTION
This pull request includes several changes to the `@dev7a/otlp-stdout-span-exporter` package, focusing on improving configuration precedence, updating documentation, and refining error handling. The most important changes are summarized below:

### Configuration Precedence and Error Handling:

* Modified the configuration value precedence to ensure environment variables always take precedence over constructor parameters. Enhanced error handling for invalid environment variable values. [[1]](diffhunk://#diff-98d7656b1775668a361eb259643823fb60356e4f05cc19ce00f0d804403e6012R8-R14) [[2]](diffhunk://#diff-0b74609b17a83ab78303de879512381862895897acb22edf246633a8c5c497d0L108-R116) [[3]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821L82-L108)

### Documentation Updates:

* Updated the `README.md` to clearly explain the configuration precedence rules and the default values for the GZIP compression level. [[1]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L83-R93) [[2]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L98-L103)
* Enhanced documentation in the `CHANGELOG.md` to reflect the changes in configuration precedence and error handling.

### Version Update:

* Updated the package version in `package.json` from `0.10.1` to `0.11.0` to reflect the new changes.

### Publishing Instructions:

* Added a step in the `PUBLISHING.md` to commit changes to the release branch and push to GitHub with a specific commit message format.

### Code Refactoring:

* Simplified the configuration logic in `otlp_stdout_span_exporter.ts` to ensure proper precedence of environment variables over constructor parameters. [[1]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821L13-R19) [[2]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821R36-R40) [[3]](diffhunk://#diff-d6a5b3bd2fc0e553dfdf7d0767e4f582b05299acec680509bf03f06c6a7eb821L65-R72)