### PR TITLE
release python otlp-stdout-span-exporter v0.11.0

### DIFF
--- a/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.11.0] - 2025-03-18
+
+### Added
+- New constants module that exports `EnvVars`, `Defaults`, and `ResourceAttributes` classes
+- Improved documentation for configuration precedence rules
+- Added type hints for all constants
+
+### Changed
+- Environment variables now always take precedence over constructor parameters
+- Improved error handling for invalid configuration values
+- Enhanced input validation for environment variables
+- Updated README to document the new constants module and precedence rules
+
 ## [0.10.0] - 2025-03-05
 
 ### Changed

--- a/packages/python/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/python/otlp-stdout-span-exporter/PUBLISHING.md
@@ -67,6 +67,7 @@ This approach ensures that:
 7. Run coverage: `pytest --cov`
 8. Build package: `python -m build` (this will automatically generate the version.py file)
 9. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
+10. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
 10. Tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing

--- a/packages/python/otlp-stdout-span-exporter/README.md
+++ b/packages/python/otlp-stdout-span-exporter/README.md
@@ -74,11 +74,10 @@ with tracer.start_as_current_span("my-operation") as span:
 ```python
 OTLPStdoutSpanExporter(
     # GZIP compression level (0-9, where 0 is no compression and 9 is maximum compression)
-    # Defaults to 6 or value from OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL
+    # Will be overridden by environment variable if set
     gzip_level=9
 )
 ```
-The explicit configuration via code will override any environment variable setting.
 
 ### Environment Variables
 
@@ -89,6 +88,9 @@ The exporter respects the following environment variables:
 - `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (which take precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9). Defaults to 6.
+
+>[!IMPORTANT]
+>Environment variables always take precedence over constructor parameters. If both are specified, the environment variable value will be used.
 
 >[!NOTE]
 >For security best practices, avoid including authentication credentials or sensitive information in headers. The serverless-otlp-forwarder infrastructure is designed to handle authentication at the destination, rather than embedding credentials in your telemetry data.

--- a/packages/python/otlp-stdout-span-exporter/pyproject.toml
+++ b/packages/python/otlp-stdout-span-exporter/pyproject.toml
@@ -8,7 +8,7 @@ path = "src/otlp_stdout_span_exporter/version.py"
 
 [project]
 name = "otlp-stdout-span-exporter"
-version = "0.10.0"
+version = "0.11.0"
 description = "OpenTelemetry span exporter that writes to stdout in OTLP format"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -76,7 +76,6 @@ known-first-party = ["otlp_stdout_span_exporter"]
 minversion = "7.0"
 addopts = "-ra -q --cov=otlp_stdout_span_exporter --cov-report=term-missing"
 testpaths = ["tests"]
-asyncio_default_fixture_loop_scope = "function"
 
 [tool.mypy]
 python_version = "3.12"

--- a/packages/python/otlp-stdout-span-exporter/src/otlp_stdout_span_exporter/__init__.py
+++ b/packages/python/otlp-stdout-span-exporter/src/otlp_stdout_span_exporter/__init__.py
@@ -4,8 +4,9 @@ OpenTelemetry Stdout Span Exporter
 A span exporter that writes OpenTelemetry spans to stdout in OTLP format.
 """
 
+from .constants import EnvVars, Defaults, ResourceAttributes
 from .exporter import OTLPStdoutSpanExporter
 from .version import VERSION
 
 __version__ = VERSION
-__all__ = ["OTLPStdoutSpanExporter"]
+__all__ = ["OTLPStdoutSpanExporter", "EnvVars", "Defaults", "ResourceAttributes"]

--- a/packages/python/otlp-stdout-span-exporter/src/otlp_stdout_span_exporter/constants.py
+++ b/packages/python/otlp-stdout-span-exporter/src/otlp_stdout_span_exporter/constants.py
@@ -1,0 +1,34 @@
+"""Constants for the otlp-stdout-span-exporter package.
+
+This file centralizes all constants to ensure consistency across the codebase
+and provide a single source of truth for configuration parameters.
+"""
+
+
+class EnvVars:
+    """Environment variable names for configuration."""
+
+    # OTLP Stdout Span Exporter configuration
+    COMPRESSION_LEVEL = "OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL"
+
+    # Service name configuration
+    SERVICE_NAME = "OTEL_SERVICE_NAME"
+    AWS_LAMBDA_FUNCTION_NAME = "AWS_LAMBDA_FUNCTION_NAME"
+
+    # Headers configuration
+    OTLP_HEADERS = "OTEL_EXPORTER_OTLP_HEADERS"
+    OTLP_TRACES_HEADERS = "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
+
+
+class Defaults:
+    """Default values for configuration parameters."""
+
+    COMPRESSION_LEVEL = 6
+    SERVICE_NAME = "unknown-service"
+    ENDPOINT = "http://localhost:4318/v1/traces"
+
+
+class ResourceAttributes:
+    """Resource attribute keys used in the Lambda resource."""
+
+    COMPRESSION_LEVEL = "lambda_otel_lite.otlp_stdout_span_exporter.compression_level"


### PR DESCRIPTION
This pull request includes several significant changes to the `otlp-stdout-span-exporter` package, focusing on adding a new constants module, improving configuration handling, and enhancing documentation. Below is a summary of the most important changes:

### New Features and Enhancements:
* Added a new constants module that exports `EnvVars`, `Defaults`, and `ResourceAttributes` classes. [[1]](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R17) [[2]](diffhunk://#diff-ac25b49e75a4d28aa37ad68e4360f00a6c43d015ab2e244d37ee2e966d0039e4R1-R34)
* Improved documentation for configuration precedence rules and updated the README to reflect these changes. [[1]](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R17) [[2]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R92-R94)

### Configuration and Error Handling:
* Environment variables now always take precedence over constructor parameters, with enhanced error handling for invalid configuration values. [[1]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7L65-R101) [[2]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7L87-R120)
* Improved input validation for environment variables, including logging warnings for invalid values. [[1]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7L65-R101) [[2]](diffhunk://#diff-976743b568257a4ca28d1bce22aed0a311c39dc033151adfde9888e3a4b737d2R111-R180)

### Testing:
* Added new tests for the constants module, environment variable precedence, and invalid gzip level handling. [[1]](diffhunk://#diff-976743b568257a4ca28d1bce22aed0a311c39dc033151adfde9888e3a4b737d2R42-R60) [[2]](diffhunk://#diff-976743b568257a4ca28d1bce22aed0a311c39dc033151adfde9888e3a4b737d2R111-R180) [[3]](diffhunk://#diff-976743b568257a4ca28d1bce22aed0a311c39dc033151adfde9888e3a4b737d2L151-R230)

### Documentation:
* Updated the `CHANGELOG.md` to document the new features and changes.
* Enhanced the `PUBLISHING.md` guide to include committing changes to the release branch.

These changes improve the robustness, maintainability, and clarity of the `otlp-stdout-span-exporter` package.