### PR TITLE
Release rust otlp stdout span exporter v0.11.0

### DIFF
--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.0] - 2024-03-18
+
+### Added
+- Added centralized constants module for configuration values
+- Added builder pattern using the `bon` crate for more idiomatic configuration
+- Added comprehensive documentation about configuration precedence rules
+
+### Changed
+- [Breaking] Changed configuration precedence to follow cloud-native best practices:
+  - Environment variables now always take precedence over constructor parameters
+  - Constructor parameters take precedence over default values
+- [Breaking] Removed internal `get_compression_level_from_env` method
+- [Breaking] Replaced `with_options` method with a more idiomatic builder pattern
+- Improved error handling with better logging for invalid configuration values
+- Updated tests to verify the new precedence rules and builder pattern
+
 ## [0.10.1] - 2025-03-04
 
 ### Changed

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.10.1"
+version = "0.11.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -26,4 +26,9 @@ base64 = "0.22.1"
 flate2 = "1.0"
 prost = "0.13.4"
 doc-comment = "0.3"
+log = "0.4"
+bon = "3.5"
 
+[dev-dependencies]
+tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
+serial_test = "3.2.0"

--- a/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
@@ -58,7 +58,9 @@ Before publishing a new version of `otlp-stdout-span-exporter`, ensure all these
 7. Run doc tests: `cargo test --doc`
 8. Build in release mode: `cargo build --release`
 9. Verify documentation: `cargo doc --no-deps`
-10. Tagging and publishing is done automatically by the CI pipeline
+10. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
+11. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
+12. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing
 - [ ] Verify package installation works: `cargo add otlp-stdout-span-exporter`

--- a/packages/rust/otlp-stdout-span-exporter/README.md
+++ b/packages/rust/otlp-stdout-span-exporter/README.md
@@ -49,7 +49,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
 
 fn init_tracer() -> SdkTracerProvider {
-    let exporter = OtlpStdoutSpanExporter::new();
+    let exporter = OtlpStdoutSpanExporter::default();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .build();
@@ -93,18 +93,46 @@ The exporter respects the following environment variables:
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (takes precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9, default: 6)
 
-
-
 ## Configuration
 
-The exporter can be configured with different GZIP compression levels:
+The exporter can be configured in multiple ways, with a strict precedence order:
 
-```rust ignore
-// Create exporter with custom GZIP level (0-9)
-let exporter = OtlpStdoutSpanExporter::with_gzip_level(9);
+1. Environment variables (highest precedence)
+2. Constructor parameters (medium precedence)
+3. Default values (lowest precedence)
+
+### Using Environment Variables
+
+Environment variables always take precedence over any programmatic configuration:
+
+```bash
+# Set GZIP compression level to 9 (maximum compression)
+export OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL=9
 ```
 
-You can also configure the compression level using the `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable. The explicit configuration via code will override any environment variable setting.
+### Using default or builder methods
+
+The exporter provides two main ways to create and configure it:
+
+```rust
+use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+
+// Create with default options (compression level 6)
+let default_exporter = OtlpStdoutSpanExporter::default();
+
+// Create with specific compression level
+let max_compression_exporter = OtlpStdoutSpanExporter::builder().compression_level(9).build();
+```
+
+Note that even when using these constructor parameters, environment variables will still take precedence if they are set.
+
+## Default Values
+
+When neither environment variables nor constructor parameters are provided, the following defaults are used:
+
+- Compression level: 6 (good balance between speed and compression)
+- Service name: "unknown-service" (unless AWS_LAMBDA_FUNCTION_NAME is available)
+- Endpoint: "http://localhost:4318/v1/traces"
 
 ## Development
 

--- a/packages/rust/otlp-stdout-span-exporter/README.md
+++ b/packages/rust/otlp-stdout-span-exporter/README.md
@@ -98,7 +98,7 @@ The exporter respects the following environment variables:
 The exporter can be configured in multiple ways, with a strict precedence order:
 
 1. Environment variables (highest precedence)
-2. Constructor parameters (medium precedence)
+2. Builder methods (medium precedence)
 3. Default values (lowest precedence)
 
 ### Using Environment Variables

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
@@ -4,7 +4,7 @@ use opentelemetry_sdk::trace::SdkTracerProvider;
 use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
 
 fn init_tracer() -> SdkTracerProvider {
-    let exporter = OtlpStdoutSpanExporter::new();
+    let exporter = OtlpStdoutSpanExporter::default();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .build();

--- a/packages/rust/otlp-stdout-span-exporter/src/constants.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/constants.rs
@@ -1,0 +1,41 @@
+//! Constants for the otlp-stdout-span-exporter package.
+//!
+//! This file centralizes all constants to ensure consistency across the codebase
+//! and provide a single source of truth for configuration parameters.
+
+/// Environment variable names for configuration.
+pub mod env_vars {
+    /// GZIP compression level for OTLP stdout span exporter (0-9).
+    pub const COMPRESSION_LEVEL: &str = "OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL";
+
+    /// Service name for telemetry.
+    pub const SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
+
+    /// AWS Lambda function name (used as fallback service name).
+    pub const AWS_LAMBDA_FUNCTION_NAME: &str = "AWS_LAMBDA_FUNCTION_NAME";
+
+    /// Global headers for OTLP export.
+    pub const OTLP_HEADERS: &str = "OTEL_EXPORTER_OTLP_HEADERS";
+
+    /// Trace-specific headers (takes precedence over OTLP_HEADERS).
+    pub const OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+}
+
+/// Default values for configuration parameters.
+pub mod defaults {
+    /// Default GZIP compression level (0-9).
+    pub const COMPRESSION_LEVEL: u8 = 6;
+
+    /// Default service name if not provided.
+    pub const SERVICE_NAME: &str = "unknown-service";
+
+    /// Default endpoint for OTLP export.
+    pub const ENDPOINT: &str = "http://localhost:4318/v1/traces";
+}
+
+/// Resource attribute keys used in the Lambda resource.
+pub mod resource_attributes {
+    /// Resource attribute key for compression level.
+    pub const COMPRESSION_LEVEL: &str =
+        "lambda_otel_lite.otlp_stdout_span_exporter.compression_level";
+}


### PR DESCRIPTION
This pull request includes several significant updates to the `otlp-stdout-span-exporter` package, focusing on configuration improvements, documentation enhancements, and version updates.

### Configuration Improvements:
* Introduced a centralized constants module for configuration values in `src/constants.rs` to ensure consistency across the codebase.
* Adopted a builder pattern using the `bon` crate for more idiomatic configuration.
* Changed configuration precedence to follow cloud-native best practices, with environment variables taking precedence over constructor parameters.

### Documentation Enhancements:
* Added comprehensive documentation about configuration precedence rules in the `README.md` file.
* Improved error handling with better logging for invalid configuration values.

### Version Updates:
* Updated the package version to `0.11.0` in `Cargo.toml`.
* Added new dependencies (`log`, `bon`, `tokio`, `serial_test`) in `Cargo.toml`.

### Code Updates:
* Replaced the `OtlpStdoutSpanExporter::new()` method with `OtlpStdoutSpanExporter::default()` in both `README.md` and `examples/simple-stdout-hello.rs` for a more idiomatic approach. [[1]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2L52-R52) [[2]](diffhunk://#diff-54a778fe5f66ccda5e0c6dd793bf41e39b2b726acc044560e417a9faf83edbe8L7-R7)
* Removed the internal `get_compression_level_from_env` method and replaced the `with_options` method with the builder pattern.

### Process Updates:
* Updated the release process in `PUBLISHING.md` to include creating a release branch and committing changes before the CI pipeline handles tagging and publishing.