### PR TITLE
feat: add Rust Lambda functions for OpenTelemetry benchmarks

### DIFF
--- a/benchmark/functions/rust/grpc/Cargo.toml
+++ b/benchmark/functions/rust/grpc/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "benchmark-functions-rust-grpc"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio.workspace = true
+serde_json.workspace = true
+lambda_runtime.workspace = true
+tracing.workspace = true
+aws_lambda_events.workspace = true
+lambda-otel-lite.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp = {workspace = true, default-features = false, features = ["grpc-tonic", "gzip-tonic"] }
+opentelemetry_sdk.workspace = true
+serde.workspace = true
+reqwest.workspace = true
+tracing-subscriber.workspace = true
+opentelemetry-aws = "0.16.0"
+[[bin]]
+name = "basic-rust-grpc"
+path = "src/main.rs"
+
+
+

--- a/benchmark/functions/rust/grpc/src/main.rs
+++ b/benchmark/functions/rust/grpc/src/main.rs
@@ -1,0 +1,178 @@
+use lambda_runtime::{
+    layers::{OpenTelemetryFaasTrigger, OpenTelemetryLayer as OtelLayer},
+    tracing::Span, service_fn, Error, LambdaEvent, Runtime
+};
+use opentelemetry::{global, propagation::TextMapPropagator, trace::TracerProvider};
+use opentelemetry_aws::trace::XrayPropagator;
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig, Protocol};
+use opentelemetry_sdk::{runtime, trace::{self, SdkTracerProvider}, propagation::TraceContextPropagator};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use tracing::{info, instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::prelude::*;
+
+/// Recursively create a tree of spans to measure OpenTelemetry overhead.
+///
+/// Args:
+///     depth: Current depth level (decrements towards 0)
+///     iterations: Number of spans to create at each level
+#[instrument(skip_all, level = "info")]
+fn process_level(depth: u32, iterations: u32) {
+    if depth == 0 {
+        return;
+    }
+
+    for i in 0..iterations {
+        let span_name = format!("operation_depth_{}_iter_{}", depth, i);
+        let span = tracing::info_span!("span", otel.name = span_name);
+        
+        let _enter = span.enter();
+        
+        let current_span = tracing::Span::current();
+        current_span.set_attribute("depth", depth as i64);
+        current_span.set_attribute("iteration", i as i64);
+        
+        // Recursive call to create the tree
+        process_level(depth - 1, iterations);
+        
+        info!("process-level-complete");
+    }
+}
+
+/// Extract trace context from event headers if present
+fn extract_context(event: &Value) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    
+    // Try to extract headers from API Gateway or ALB event format
+    if let Some(headers_obj) = event.get("headers").and_then(|h| h.as_object()) {
+        for (key, value) in headers_obj {
+            if let Some(val_str) = value.as_str() {
+                headers.insert(key.to_lowercase(), val_str.to_string());
+            }
+        }
+    }
+        
+    // If trace ID still not found in headers, check environment variable
+    if !headers.contains_key("x-amzn-trace-id") {
+        if let Ok(trace_id) = std::env::var("_X_AMZN_TRACE_ID") {
+            if !trace_id.is_empty() {
+                headers.insert("x-amzn-trace-id".to_string(), trace_id);
+            }
+        }
+    }
+    
+    
+    headers
+}
+
+/// Lambda handler that creates a tree of spans based on input parameters.
+///
+/// This handler generates a tree of OpenTelemetry spans to measure overhead
+/// and performance characteristics. It also handles trace context propagation
+/// from the incoming event JSON.
+///
+/// Args:
+///     event: Lambda event containing depth and iterations as JSON properties
+///     context: Lambda context (not used)
+///
+/// Returns:
+///     JSON response containing the benchmark parameters and completion status
+async fn handler(
+    event: LambdaEvent<Value>,
+) -> Result<Value, Error> {
+    // Extract trace context from headers
+    let headers = extract_context(&event.payload);
+    
+    // Create a HashMap-based extractor for the propagator
+    struct Extractor<'a>(&'a HashMap<String, String>);
+    
+    impl<'a> opentelemetry::propagation::Extractor for Extractor<'a> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).map(|v| v.as_str())
+        }
+        
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(|k| k.as_str()).collect()
+        }
+    }
+    
+    // First try to extract context using the propagator
+    let span = Span::current();
+    
+    global::get_text_map_propagator(|propagator| {
+        // Extract and set parent context
+        let parent_context = propagator.extract(&Extractor(&headers));
+        span.set_parent(parent_context);
+    });
+    
+    // Set span kind to SERVER like in the example
+    span.record("otel.kind", "SERVER");
+
+    let benchmark_event = event.payload;
+    
+    // Extract depth with fallback to 3
+    let depth = benchmark_event.get("depth")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .unwrap_or(3);
+    
+    // Extract iterations with fallback to 4
+    let iterations = benchmark_event.get("iterations")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .unwrap_or(4);
+
+    // Create the tree of spans
+    process_level(depth, iterations);
+
+    // Return a successful response with benchmark parameters
+    Ok(json!({
+        "message": "Benchmark complete",
+        "depth": depth,
+        "iterations": iterations
+    }))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Configure propagators - first set up a combined propagator for both W3C and X-Ray
+    let w3c_propagator = TraceContextPropagator::new();
+    let xray_propagator = XrayPropagator::default();
+    
+    // Use a composite propagator that tries W3C first, then X-Ray
+    global::set_text_map_propagator(opentelemetry::propagation::TextMapCompositePropagator::new(vec![
+        Box::new(w3c_propagator),
+        Box::new(xray_propagator),
+    ]));
+    
+    // Set up OpenTelemetry OTLP exporter for HTTP
+    let batch_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()?;
+    
+    // Set up the tracer provider with the OTLP exporter
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(batch_exporter)
+        .build();
+    
+    // Set up link between OpenTelemetry and tracing crate
+    tracing_subscriber::registry()
+        .with(tracing_opentelemetry::OpenTelemetryLayer::new(
+            tracer_provider.tracer("benchmark-execution"),
+        ))
+        .init();
+    
+    // Initialize the Lambda runtime and add OpenTelemetry tracing
+    let runtime = Runtime::new(service_fn(handler)).layer(
+        // Create a tracing span for each Lambda invocation
+        OtelLayer::new(|| {
+            // Make sure that the trace is exported before the Lambda runtime is frozen
+            let _ = tracer_provider.force_flush();
+        })
+        // Set the "faas.trigger" attribute of the span
+        .with_trigger(OpenTelemetryFaasTrigger::Http),
+    );
+    
+    runtime.run().await
+}

--- a/benchmark/functions/rust/http/Cargo.toml
+++ b/benchmark/functions/rust/http/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "benchmark-functions-rust-http"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio.workspace = true
+serde_json.workspace = true
+lambda_runtime.workspace = true
+tracing.workspace = true
+aws_lambda_events.workspace = true
+lambda-otel-lite.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
+serde.workspace = true
+reqwest.workspace = true
+tracing-subscriber.workspace = true
+opentelemetry-aws = "0.16.0"
+[[bin]]
+name = "basic-rust-http"
+path = "src/main.rs"
+
+
+

--- a/benchmark/functions/rust/http/src/main.rs
+++ b/benchmark/functions/rust/http/src/main.rs
@@ -1,0 +1,178 @@
+use lambda_runtime::{
+    layers::{OpenTelemetryFaasTrigger, OpenTelemetryLayer as OtelLayer},
+    tracing::Span, service_fn, Error, LambdaEvent, Runtime
+};
+use opentelemetry::{global, propagation::TextMapPropagator, trace::TracerProvider};
+use opentelemetry_aws::trace::XrayPropagator;
+use opentelemetry_otlp::{WithExportConfig, WithHttpConfig, Protocol};
+use opentelemetry_sdk::{runtime, trace::{self, SdkTracerProvider}, propagation::TraceContextPropagator};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use tracing::{info, instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::prelude::*;
+
+/// Recursively create a tree of spans to measure OpenTelemetry overhead.
+///
+/// Args:
+///     depth: Current depth level (decrements towards 0)
+///     iterations: Number of spans to create at each level
+#[instrument(skip_all, level = "info")]
+fn process_level(depth: u32, iterations: u32) {
+    if depth == 0 {
+        return;
+    }
+
+    for i in 0..iterations {
+        let span_name = format!("operation_depth_{}_iter_{}", depth, i);
+        let span = tracing::info_span!("span", otel.name = span_name);
+        
+        let _enter = span.enter();
+        
+        let current_span = tracing::Span::current();
+        current_span.set_attribute("depth", depth as i64);
+        current_span.set_attribute("iteration", i as i64);
+        
+        // Recursive call to create the tree
+        process_level(depth - 1, iterations);
+        
+        info!("process-level-complete");
+    }
+}
+
+/// Extract trace context from event headers if present
+fn extract_context(event: &Value) -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+    
+    // Try to extract headers from API Gateway or ALB event format
+    if let Some(headers_obj) = event.get("headers").and_then(|h| h.as_object()) {
+        for (key, value) in headers_obj {
+            if let Some(val_str) = value.as_str() {
+                headers.insert(key.to_lowercase(), val_str.to_string());
+            }
+        }
+    }
+        
+    // If trace ID still not found in headers, check environment variable
+    if !headers.contains_key("x-amzn-trace-id") {
+        if let Ok(trace_id) = std::env::var("_X_AMZN_TRACE_ID") {
+            if !trace_id.is_empty() {
+                headers.insert("x-amzn-trace-id".to_string(), trace_id);
+            }
+        }
+    }
+    
+    
+    headers
+}
+
+/// Lambda handler that creates a tree of spans based on input parameters.
+///
+/// This handler generates a tree of OpenTelemetry spans to measure overhead
+/// and performance characteristics. It also handles trace context propagation
+/// from the incoming event JSON.
+///
+/// Args:
+///     event: Lambda event containing depth and iterations as JSON properties
+///     context: Lambda context (not used)
+///
+/// Returns:
+///     JSON response containing the benchmark parameters and completion status
+async fn handler(
+    event: LambdaEvent<Value>,
+) -> Result<Value, Error> {
+    // Extract trace context from headers
+    let headers = extract_context(&event.payload);
+    
+    // Create a HashMap-based extractor for the propagator
+    struct Extractor<'a>(&'a HashMap<String, String>);
+    
+    impl<'a> opentelemetry::propagation::Extractor for Extractor<'a> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).map(|v| v.as_str())
+        }
+        
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(|k| k.as_str()).collect()
+        }
+    }
+    
+    // First try to extract context using the propagator
+    let span = Span::current();
+    
+    global::get_text_map_propagator(|propagator| {
+        // Extract and set parent context
+        let parent_context = propagator.extract(&Extractor(&headers));
+        span.set_parent(parent_context);
+    });
+    
+    // Set span kind to SERVER like in the example
+    span.record("otel.kind", "SERVER");
+
+    let benchmark_event = event.payload;
+    
+    // Extract depth with fallback to 3
+    let depth = benchmark_event.get("depth")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .unwrap_or(3);
+    
+    // Extract iterations with fallback to 4
+    let iterations = benchmark_event.get("iterations")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .unwrap_or(4);
+
+    // Create the tree of spans
+    process_level(depth, iterations);
+
+    // Return a successful response with benchmark parameters
+    Ok(json!({
+        "message": "Benchmark complete",
+        "depth": depth,
+        "iterations": iterations
+    }))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Configure propagators - first set up a combined propagator for both W3C and X-Ray
+    let w3c_propagator = TraceContextPropagator::new();
+    let xray_propagator = XrayPropagator::default();
+    
+    // Use a composite propagator that tries W3C first, then X-Ray
+    global::set_text_map_propagator(opentelemetry::propagation::TextMapCompositePropagator::new(vec![
+        Box::new(w3c_propagator),
+        Box::new(xray_propagator),
+    ]));
+    
+    // Set up OpenTelemetry OTLP exporter for HTTP
+    let batch_exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .build()?;
+    
+    // Set up the tracer provider with the OTLP exporter
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_batch_exporter(batch_exporter)
+        .build();
+    
+    // Set up link between OpenTelemetry and tracing crate
+    tracing_subscriber::registry()
+        .with(tracing_opentelemetry::OpenTelemetryLayer::new(
+            tracer_provider.tracer("benchmark-execution"),
+        ))
+        .init();
+    
+    // Initialize the Lambda runtime and add OpenTelemetry tracing
+    let runtime = Runtime::new(service_fn(handler)).layer(
+        // Create a tracing span for each Lambda invocation
+        OtelLayer::new(|| {
+            // Make sure that the trace is exported before the Lambda runtime is frozen
+            let _ = tracer_provider.force_flush();
+        })
+        // Set the "faas.trigger" attribute of the span
+        .with_trigger(OpenTelemetryFaasTrigger::Http),
+    );
+    
+    runtime.run().await
+}

--- a/benchmark/functions/rust/stdout/Cargo.toml
+++ b/benchmark/functions/rust/stdout/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "benchmark-functions-rust-stdout"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tokio.workspace = true
+serde_json.workspace = true
+lambda_runtime.workspace = true
+tracing.workspace = true
+aws_lambda_events.workspace = true
+lambda-otel-lite.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
+serde.workspace = true
+[[bin]]
+name = "basic-rust-stdout"
+path = "src/main.rs"

--- a/benchmark/functions/rust/stdout/src/main.rs
+++ b/benchmark/functions/rust/stdout/src/main.rs
@@ -1,0 +1,85 @@
+use lambda_otel_lite::{create_traced_handler, init_telemetry, TelemetryConfig};
+use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
+use tracing::{info, instrument};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use serde_json::{json, Value};
+
+/// Recursively create a tree of spans to measure OpenTelemetry overhead.
+///
+/// Args:
+///     depth: Current depth level (decrements towards 0)
+///     iterations: Number of spans to create at each level
+#[instrument(skip_all, level = "info")]
+fn process_level(depth: u32, iterations: u32) {
+    if depth == 0 {
+        return;
+    }
+
+    for i in 0..iterations {
+        let span_name = format!("operation_depth_{}_iter_{}", depth, i);
+        let span = tracing::info_span!("span", otel.name = span_name);
+        
+        let _enter = span.enter();
+        
+        let current_span = tracing::Span::current();
+        current_span.set_attribute("depth", depth as i64);
+        current_span.set_attribute("iteration", i as i64);
+        
+        // Recursive call to create the tree
+        process_level(depth - 1, iterations);
+        
+        info!("process-level-complete");
+    }
+}
+
+/// Lambda handler that creates a tree of spans based on input parameters.
+///
+/// This handler generates a tree of OpenTelemetry spans to measure overhead
+/// and performance characteristics. It also handles trace context propagation
+/// from the incoming event JSON.
+///
+/// Args:
+///     event: Lambda event containing depth and iterations as JSON properties
+///     context: Lambda context (not used)
+///
+/// Returns:
+///     JSON response containing the benchmark parameters and completion status
+async fn handler(
+    event: LambdaEvent<Value>,
+) -> Result<Value, Error> {
+    let benchmark_event = event.payload;
+    
+    // Extract depth with fallback to 3
+    let depth = benchmark_event.get("depth")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .unwrap_or(3);
+    
+    // Extract iterations with fallback to 4
+    let iterations = benchmark_event.get("iterations")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32)
+        .unwrap_or(4);
+
+    // Create the tree of spans
+    process_level(depth, iterations);
+
+    // Return a successful response with benchmark parameters
+    Ok(json!({
+        "message": "Benchmark complete",
+        "depth": depth,
+        "iterations": iterations
+    }))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Initialize telemetry with default config
+    let (_, completion_handler) = init_telemetry(TelemetryConfig::default()).await?;
+
+    // Create the traced handler with the benchmark name
+    let handler = create_traced_handler("benchmark-execution", completion_handler, handler);
+
+    // Use it directly with the runtime
+    Runtime::new(service_fn(handler)).run().await
+}

--- a/benchmark/template.yaml
+++ b/benchmark/template.yaml
@@ -25,6 +25,8 @@ Mappings:
       otel: 'arn:aws:lambda:us-east-1:184161586896:layer:opentelemetry-nodejs-0_10_0:1'
       collector: 'arn:aws:lambda:us-east-1:184161586896:layer:opentelemetry-collector-arm64-0_13_0:1'
       appsignals: 'arn:aws:lambda:us-east-1:615299751070:layer:AWSOpenTelemetryDistroJs:6'
+    rust:
+      collector: 'arn:aws:lambda:us-east-1:184161586896:layer:opentelemetry-collector-arm64-0_13_0:1'
 
 Globals:
   Function:
@@ -46,10 +48,10 @@ Globals:
         OTEL_LOGS_EXPORTER: none
         OTEL_TRACES_SAMPLER: always_on
         OTEL_LAMBDA_DISABLE_AWS_CONTEXT_PROPAGATION: true
-        # the node otel sdk at least supports enabling specific instrumentations, so we can just provide a list of enabled ones
+        # the node otel sdk supports enabling specific instrumentations, so we can just provide a list of enabled ones
         OTEL_NODE_ENABLED_INSTRUMENTATIONS: aws-sdk,aws-lambda,http
         # the python otel sdk doesn't support enabling specific instrumentations, just providing a list of disabled ones, 
-        #so we need to list all of them (!) minus the ones we want to enable 
+        # so we need to list all of them (!) minus the ones we want to enable 
         # (also see https://github.com/aws-observability/aws-otel-python-instrumentation/blob/main/lambda-layer/src/otel-instrument)
         OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: >-
           aio-pika,aiohttp-client,aiohttp-server,aiopg,asgi,asyncio,asyncpg,boto,boto3,cassandra,celery,confluent_kafka,dbapi,django,elasticsearch,falcon,fastapi,flask,grpc_client,grpc_server,grpc_aio_client,grpc_aio_server,httpx,jinja2,kafka,logging,mysql,mysqlclient,pika,psycopg,psycopg2,pymemcache,pymongo,pymysql,pyramid,redis,remoulade,requests,sklearn,sqlalchemy,sqlite3,starlette,system_metrics,threading,tornado,tortoiseorm,urllib,wsgi
@@ -68,7 +70,6 @@ Resources:
       Handler: bootstrap
       Runtime: provided.al2023
       MemorySize: 512
-      Timeout: 10
       Tracing: Disabled
       Policies:
         - Version: '2012-10-17'
@@ -78,6 +79,59 @@ Resources:
                 - 'lambda:InvokeFunction'
               Resource: '*'
 
+  BasicRustStdoutFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: rust-cargolambda
+      BuildProperties:
+        Binary: basic-rust-stdout
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-basic-rust-stdout'
+      CodeUri: functions/rust/stdout/
+      Handler: bootstrap
+      Runtime: provided.al2023
+      Environment:
+        Variables:
+          OTEL_SERVICE_NAME: !Sub '${AWS::StackName}-basic-rust-stdout'
+
+  BasicRustHttpFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: rust-cargolambda
+      BuildProperties:
+        Binary: basic-rust-http
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-basic-rust-http'
+      CodeUri: functions/rust/http/
+      Handler: bootstrap
+      Runtime: provided.al2023
+      Environment:
+        Variables:
+          OTEL_SERVICE_NAME: !Sub '${AWS::StackName}-basic-rust-http'
+          OPENTELEMETRY_COLLECTOR_CONFIG_URI: "/opt/collector.yaml"
+      Layers:
+        - !FindInMap [LayerArns, rust, collector]
+        - !Ref CollectorConfiglLayer
+
+  BasicRustGrpcFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: rust-cargolambda
+      BuildProperties:
+        Binary: basic-rust-grpc
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-basic-rust-grpc'
+      CodeUri: functions/rust/grpc/
+      Handler: bootstrap
+      Runtime: provided.al2023
+      Environment:
+        Variables:
+          OTEL_SERVICE_NAME: !Sub '${AWS::StackName}-basic-rust-grpc'
+          OPENTELEMETRY_COLLECTOR_CONFIG_URI: "/opt/collector.yaml"
+          GRPC_GO_REQUIRE_HANDSHAKE: off
+      Layers:
+        - !FindInMap [LayerArns, rust, collector]
+        - !Ref CollectorConfiglLayer
 
   # Basic Test Node.js Functions
   BasicNodeStdoutFunction:
@@ -695,6 +749,16 @@ Resources:
       BuildMethod: makefile
 
 Outputs:
+  # Rust
+  BasicRustStdoutFunction:
+    Description: Rust OTLP Stdout Function ARN
+    Value: !GetAtt BasicRustStdoutFunction.Arn
+  BasicRustHttpFunction:
+    Description: Rust OTLP HTTP Function ARN
+    Value: !GetAtt BasicRustHttpFunction.Arn
+  BasicRustGrpcFunction:
+    Description: Rust OTLP GRPC Function ARN
+    Value: !GetAtt BasicRustGrpcFunction.Arn
   # Basic Test Function Outputs
   # Node.js
   BasicNodeStdoutFunction:


### PR DESCRIPTION
This pull request includes significant updates to the Rust-based benchmark functions, adding support for OpenTelemetry tracing and enhancing the AWS Lambda functions. The changes include new dependencies, handlers, and configurations for various Rust functions, as well as updates to the benchmark template to include these new functions.

### New Rust Benchmark Functions with OpenTelemetry Tracing:

* [`benchmark/functions/rust/grpc/Cargo.toml`](diffhunk://#diff-e3653b1708d8235337bc2584716b21deb465601a97052a1306e05f6961e008b4R1-R29): Added a new `benchmark-functions-rust-grpc` package with dependencies and configuration for OpenTelemetry.
* [`benchmark/functions/rust/grpc/src/main.rs`](diffhunk://#diff-e9977d8801f646f899fb83b34f98b23afbe643725cb84959a028b0c5c6be2ac5R1-R178): Implemented a Lambda handler that creates a tree of spans to measure OpenTelemetry overhead and handles trace context propagation.
* [`benchmark/functions/rust/http/Cargo.toml`](diffhunk://#diff-5f901f5b2b8e6829f51231bb01c98328e2c2acbf41739d45c40ef0a512dbf64fR1-R29): Added a new `benchmark-functions-rust-http` package with dependencies and configuration for OpenTelemetry.
* [`benchmark/functions/rust/http/src/main.rs`](diffhunk://#diff-c291c7deaaedaf73708414f8606174bdf54469b041a923f98ccf31d68ec5a5f6R1-R178): Implemented a Lambda handler similar to the gRPC function for HTTP, including span creation and trace context handling.
* [`benchmark/functions/rust/stdout/Cargo.toml`](diffhunk://#diff-a80cff0fd1f68068e32e84cc1566b2e4c54c516079e70a17e281448c1abe37a3R1-R21): Added a new `benchmark-functions-rust-stdout` package with dependencies and configuration for OpenTelemetry.
* [`benchmark/functions/rust/stdout/src/main.rs`](diffhunk://#diff-6019565d5e6e3fb2f658db3c2bd3852c904d9158fa889d3d96161e4a27c79451R1-R85): Implemented a Lambda handler that creates a tree of spans and initializes telemetry with a default configuration.

### Updates to Benchmark Template:

* [`benchmark/template.yaml`](diffhunk://#diff-5f52fb79f0b43683baf32a9cc0a26502dfc9a5cc6bc46d32b1d1dded8338410fR82-R134): Added new resources for the Rust functions, including `BasicRustStdoutFunction`, `BasicRustHttpFunction`, and `BasicRustGrpcFunction`, with appropriate environment variables and layers.

### Minor Enhancements and Fixes:

* [`benchmark/proxy/src/main.rs`](diffhunk://#diff-7da2ea0191dec2f65ec1dab80c2785cbabaa15ed25145304cbd52d74d9b91708L4-R4): Adjusted the timing of the `Instant` start and added additional logging for the response payload. [[1]](diffhunk://#diff-7da2ea0191dec2f65ec1dab80c2785cbabaa15ed25145304cbd52d74d9b91708L4-R4) [[2]](diffhunk://#diff-7da2ea0191dec2f65ec1dab80c2785cbabaa15ed25145304cbd52d74d9b91708L33-L34) [[3]](diffhunk://#diff-7da2ea0191dec2f65ec1dab80c2785cbabaa15ed25145304cbd52d74d9b91708R56-R58) [[4]](diffhunk://#diff-7da2ea0191dec2f65ec1dab80c2785cbabaa15ed25145304cbd52d74d9b91708L79-R87)
* [`benchmark/template.yaml`](diffhunk://#diff-5f52fb79f0b43683baf32a9cc0a26502dfc9a5cc6bc46d32b1d1dded8338410fR28-R29): Updated mappings and global environment variables for better clarity and functionality. [[1]](diffhunk://#diff-5f52fb79f0b43683baf32a9cc0a26502dfc9a5cc6bc46d32b1d1dded8338410fR28-R29) [[2]](diffhunk://#diff-5f52fb79f0b43683baf32a9cc0a26502dfc9a5cc6bc46d32b1d1dded8338410fL49-R51) [[3]](diffhunk://#diff-5f52fb79f0b43683baf32a9cc0a26502dfc9a5cc6bc46d32b1d1dded8338410fL71)
---
resolves #81 
