### PR TITLE
release rust lambda-otel-lite v0.11.1

### DIFF
--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2025-03-22
+### Fixed
+- Fixed service name fallback logic in resource.rs to properly use AWS_LAMBDA_FUNCTION_NAME when OTEL_SERVICE_NAME is not defined, and fall back to "unknown_service" if neither is available
+
 ## [0.11.0] - 2025-03-19
 ### Added
 - Added module for centralized constants to ensure consistency across the codebase

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This pull request includes several changes to the `lambda-otel-lite` package. The most important changes are the addition of fallback logic for setting the service name, updating the package version, and importing a new module for default constants.

### Fixes and Improvements:

* **Service Name Fallback Logic**:
  - Updated `get_lambda_resource` function to include fallback logic for setting the service name. It now checks for `OTEL_SERVICE_NAME`, falls back to `AWS_LAMBDA_FUNCTION_NAME`, and defaults to "unknown_service" if neither is available (`packages/rust/lambda-otel-lite/src/resource.rs`).

* **Version Update**:
  - Updated the package version from `0.11.0` to `0.11.1` in the `Cargo.toml` file (`packages/rust/lambda-otel-lite/Cargo.toml`).

* **Changelog Update**:
  - Added a new entry for version `0.11.1` in the `CHANGELOG.md` file, documenting the fix for the service name fallback logic (`packages/rust/lambda-otel-lite/CHANGELOG.md`).

* **Import Defaults Module**:
  - Added an import for the `defaults` module from `constants` in the `resource.rs` file to support the new fallback logic (`packages/rust/lambda-otel-lite/src/resource.rs`).