### PR TITLE
Fix/collector telemetry logging

### DIFF
--- a/forwarders/otlp-stdout-logs-processor/processor/Cargo.toml
+++ b/forwarders/otlp-stdout-logs-processor/processor/Cargo.toml
@@ -6,10 +6,6 @@ authors.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
-[[bin]]
-name = "lambda_otlp_forwarder"
-path = "src/main.rs"
-
 [dependencies]
 tokio.workspace = true
 serde_json.workspace = true
@@ -36,10 +32,13 @@ aws_lambda_events = { version = "0.16.0", features = ["cloudwatch_logs", "kinesi
 regex = "1.11.1"
 opentelemetry-proto = "0.28.0"
 prost = "0.13.5"
-cached = { version = "0.55.1", features = ["default", "async"] }
 
 [dev-dependencies]
 wiremock = "0.6"
 mockito = "1.2"
 chrono = "0.4.39"
 tokio = { version = "1.0", features = ["full"] }
+
+[[bin]]
+name = "stdout_processor"
+path = "src/main.rs"

--- a/forwarders/otlp-stdout-logs-processor/processor/Cargo.toml
+++ b/forwarders/otlp-stdout-logs-processor/processor/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 rust-version.workspace = true
 
 [[bin]]
-name = "log_processor"
-path = "src/log_processor.rs"
+name = "lambda_otlp_forwarder"
+path = "src/main.rs"
 
 [dependencies]
 tokio.workspace = true
@@ -36,6 +36,7 @@ aws_lambda_events = { version = "0.16.0", features = ["cloudwatch_logs", "kinesi
 regex = "1.11.1"
 opentelemetry-proto = "0.28.0"
 prost = "0.13.5"
+cached = { version = "0.55.1", features = ["default", "async"] }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/forwarders/otlp-stdout-logs-processor/processor/src/app_state.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/app_state.rs
@@ -35,4 +35,4 @@ impl AppState {
             region,
         })
     }
-} 
+}

--- a/forwarders/otlp-stdout-logs-processor/processor/src/wrappers.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/wrappers.rs
@@ -18,13 +18,13 @@ impl SpanAttributesExtractor for KinesisEventWrapper {
     fn extract_span_attributes(&self) -> SpanAttributes {
         let mut attributes: HashMap<String, Value> = HashMap::new();
         let records = &self.0.records;
-        
+
         // Add attributes from the Kinesis event
         attributes.insert(
             "forwarder.events.count".to_string(),
             Value::I64(records.len() as i64),
         );
-        
+
         if let Some(first_record) = records.first() {
             if let Some(event_source) = &first_record.event_source {
                 attributes.insert(
@@ -50,7 +50,7 @@ impl SpanAttributesExtractor for LogsEventWrapper {
     fn extract_span_attributes(&self) -> SpanAttributes {
         let mut attributes: HashMap<String, Value> = HashMap::new();
         let log_data = self.0.aws_logs.data.clone();
-        
+
         // Add attributes from the LogsEvent
         attributes.insert(
             "forwarder.log_group".to_string(),
@@ -67,4 +67,4 @@ impl SpanAttributesExtractor for LogsEventWrapper {
             .attributes(attributes)
             .build()
     }
-} 
+}

--- a/forwarders/otlp-stdout-logs-processor/template.yaml
+++ b/forwarders/otlp-stdout-logs-processor/template.yaml
@@ -34,7 +34,7 @@ Resources:
     Metadata:
       BuildMethod: rust-cargolambda
       BuildProperties:
-        Binary: log_processor
+        Binary: stdout_processor
     Properties:
       FunctionName: !Ref AWS::StackName
       Description: !Sub 'Processes logs from AWS Account ${AWS::AccountId}'


### PR DESCRIPTION
This pull request includes significant changes to the `forwarders/otlp-stdout-logs-processor` project, focusing on improving concurrency, adding new features, and enhancing logging. The most important changes include replacing `OnceLock` with `Mutex` for better concurrency, adding a new `stdout_processor` binary, and enhancing logging for better traceability.

Concurrency improvements:
* [`forwarders/otlp-stdout-logs-processor/processor/src/collectors.rs`](diffhunk://#diff-49e2488e5f8e868b66c3bfe69c2f7c733a3460ac90562175712427e82c2bc248L16-R24): Replaced `OnceLock` with `Mutex` to allow safe concurrent access to the collectors cache. [[1]](diffhunk://#diff-49e2488e5f8e868b66c3bfe69c2f7c733a3460ac90562175712427e82c2bc248L16-R24) [[2]](diffhunk://#diff-49e2488e5f8e868b66c3bfe69c2f7c733a3460ac90562175712427e82c2bc248L118-R203) [[3]](diffhunk://#diff-49e2488e5f8e868b66c3bfe69c2f7c733a3460ac90562175712427e82c2bc248L331-R356)

New features:
* [`forwarders/otlp-stdout-logs-processor/processor/Cargo.toml`](diffhunk://#diff-919684487ca64ad16dfc9b3de6c8155c8fa7f9906466e7c45aabbeef5d0faaecR41-R44): Added a new binary `stdout_processor` to the project.
* [`forwarders/otlp-stdout-logs-processor/processor/src/main.rs`](diffhunk://#diff-f8864a8ee1da74969f6526fd58d66f8023d84429e3b1a60b33310c507324cdd5L17-R28): Renamed from `log_processor.rs` and updated to support the new binary. [[1]](diffhunk://#diff-f8864a8ee1da74969f6526fd58d66f8023d84429e3b1a60b33310c507324cdd5L17-R28) [[2]](diffhunk://#diff-f8864a8ee1da74969f6526fd58d66f8023d84429e3b1a60b33310c507324cdd5L77-R75) [[3]](diffhunk://#diff-f8864a8ee1da74969f6526fd58d66f8023d84429e3b1a60b33310c507324cdd5L119-R121) [[4]](diffhunk://#diff-f8864a8ee1da74969f6526fd58d66f8023d84429e3b1a60b33310c507324cdd5L137)

Logging enhancements:
* [`forwarders/otlp-stdout-logs-processor/processor/src/collectors.rs`](diffhunk://#diff-49e2488e5f8e868b66c3bfe69c2f7c733a3460ac90562175712427e82c2bc248L205-R266): Added detailed logging to trace collector exclusion and endpoint construction.
* [`forwarders/otlp-stdout-logs-processor/processor/src/processing.rs`](diffhunk://#diff-8457ea4e114d4081a5825191262d8a7213cb7740b3237a88623338a2083ad092R124-R128): Improved logging for telemetry processing to provide better traceability. [[1]](diffhunk://#diff-8457ea4e114d4081a5825191262d8a7213cb7740b3237a88623338a2083ad092R124-R128) [[2]](diffhunk://#diff-8457ea4e114d4081a5825191262d8a7213cb7740b3237a88623338a2083ad092L136-R154) [[3]](diffhunk://#diff-8457ea4e114d4081a5825191262d8a7213cb7740b3237a88623338a2083ad092R166-R169)

These changes aim to enhance the overall performance, maintainability, and observability of the project.