### PR TITLE
refactor: improve code formatting in forwarders processors

### DIFF
--- a/forwarders/experimental/aws-span-processor/processor/src/main.rs
+++ b/forwarders/experimental/aws-span-processor/processor/src/main.rs
@@ -15,23 +15,18 @@
 mod otlp;
 
 use anyhow::Result;
-use aws_lambda_events::event::cloudwatch_logs::LogEntry;
-use lambda_runtime::{
-    tower::ServiceBuilder,
-    Error as LambdaError, LambdaEvent, Runtime,
-};
-use std::sync::Arc;
 use aws_credential_types::provider::ProvideCredentials;
+use aws_lambda_events::event::cloudwatch_logs::LogEntry;
 use lambda_otlp_forwarder::{
     collectors::Collectors, processing::process_telemetry_batch, telemetry::TelemetryData,
-    LogsEventWrapper, AppState,
+    AppState, LogsEventWrapper,
 };
+use lambda_runtime::{tower::ServiceBuilder, Error as LambdaError, LambdaEvent, Runtime};
 use otlp_sigv4_client::SigV4ClientBuilder;
 use serde_json::Value as JsonValue;
+use std::sync::Arc;
 
-use lambda_otel_lite::{
-    init_telemetry, OtelTracingLayer, TelemetryConfig,
-};
+use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 
 use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::trace::BatchSpanProcessor;
@@ -77,7 +72,7 @@ async fn function_handler(
 
     let log_group = &event.payload.0.aws_logs.data.log_group;
     let log_events = &event.payload.0.aws_logs.data.log_events;
-    
+
     // Convert all events to TelemetryData (sequentially)
     let telemetry_records = log_events
         .iter()
@@ -315,7 +310,7 @@ mod tests {
         assert_eq!(telemetry.source, "aws/spans");
         assert_eq!(telemetry.content_type, "application/x-protobuf");
         assert_eq!(telemetry.content_encoding, None);
-        
+
         // Verify the payload is not empty
         assert!(!telemetry.payload.is_empty());
     }


### PR DESCRIPTION
This pull request includes several changes to improve code formatting and organization in the AWS span processor and OTLP stdout Kinesis processor. The most important changes include reordering imports, adding context to error handling, and improving code readability in various functions and tests.

Code formatting and organization:

* [`forwarders/experimental/aws-span-processor/processor/src/main.rs`](diffhunk://#diff-493c80d2cb992c9473291c405f1d15148f59245a83eec18a54e7ac02536bf444L18-R29): Reordered imports for better readability and consistency.
* [`forwarders/experimental/otlp-stdout-kinesis-processor/processor/src/main.rs`](diffhunk://#diff-d30b18f90993c20bb490bacd86509cb7a97e47d7acd4cb775787bea6b6a3a049L18-R31): Reordered imports and improved code formatting in various functions. [[1]](diffhunk://#diff-d30b18f90993c20bb490bacd86509cb7a97e47d7acd4cb775787bea6b6a3a049L18-R31) [[2]](diffhunk://#diff-d30b18f90993c20bb490bacd86509cb7a97e47d7acd4cb775787bea6b6a3a049L85-R81) [[3]](diffhunk://#diff-d30b18f90993c20bb490bacd86509cb7a97e47d7acd4cb775787bea6b6a3a049L129-R125) [[4]](diffhunk://#diff-d30b18f90993c20bb490bacd86509cb7a97e47d7acd4cb775787bea6b6a3a049L147) [[5]](diffhunk://#diff-d30b18f90993c20bb490bacd86509cb7a97e47d7acd4cb775787bea6b6a3a049L237-R231)

Error handling improvements:

* [`forwarders/experimental/aws-span-processor/processor/src/otlp.rs`](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955R1-L13): Added context to error handling using `anyhow::Context` to provide more informative error messages.

Code readability improvements:

* [`forwarders/experimental/aws-span-processor/processor/src/otlp.rs`](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955L84-R84): Improved code readability by adjusting indentation and formatting in functions and tests. [[1]](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955L84-R84) [[2]](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955L271-R278) [[3]](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955L299-R328) [[4]](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955L366-R394) [[5]](diffhunk://#diff-e2d7f48d9ab7590e1fa0ccac5925113f41e5d50a0815d78353cb552bf1a1b955L518-R545)