### PR TITLE
release python lambda-otel-lite v0.12.0

### DIFF
--- a/packages/python/lambda-otel-lite/CHANGELOG.md
+++ b/packages/python/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2025-03-24
+
+### Added
+- Support for custom ID generators via the `id_generator` parameter in `init_telemetry`
+- Documentation and examples for using AWS X-Ray compatible ID generators
+
 ## [0.11.0] - 2025-03-18
 
 ### Added

--- a/packages/python/lambda-otel-lite/README.md
+++ b/packages/python/lambda-otel-lite/README.md
@@ -22,6 +22,7 @@ By leveraging Lambda's execution lifecycle and providing multiple processing mod
   - [Custom configuration with custom resource attributes](#custom-configuration-with-custom-resource-attributes)
   - [Custom configuration with custom span processors](#custom-configuration-with-custom-span-processors)
   - [Custom configuration with context propagators](#custom-configuration-with-context-propagators)
+  - [Custom configuration with ID generator](#custom-configuration-with-id-generator)
   - [Library specific Resource Attributes](#library-specific-resource-attributes)
 - [Event Extractors](#event-extractors)
   - [Automatic Attributes extraction](#automatic-attributes-extraction)
@@ -289,6 +290,26 @@ By default, OpenTelemetry Python uses W3C Trace Context and W3C Baggage propagat
 You can provide multiple propagators, and they will be combined into a composite propagator. The order matters - propagators are applied in the order they are provided.
 
 > **Note:** The OpenTelemetry SDK also supports configuring propagators via the `OTEL_PROPAGATORS` environment variable. If set, this environment variable takes precedence over programmatic configuration. See the [OpenTelemetry Python documentation](https://opentelemetry.io/docs/languages/python/instrumentation/) for more details.
+
+### Custom configuration with ID generator
+
+```python
+from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
+from lambda_otel_lite import init_telemetry
+
+# Initialize with X-Ray compatible ID generator
+tracer, completion_handler = init_telemetry(
+    id_generator=AwsXRayIdGenerator()
+)
+```
+
+By default, OpenTelemetry uses a random ID generator that creates W3C-compatible trace and span IDs. The `id_generator` parameter allows you to customize the ID generation strategy. This is particularly useful when you need to integrate with AWS X-Ray, which requires a specific ID format.
+
+To use the X-Ray ID generator, you'll need to install the AWS X-Ray SDK for OpenTelemetry:
+
+```bash
+pip install opentelemetry-sdk-extension-aws
+```
 
 ### Library specific Resource Attributes
 

--- a/packages/python/lambda-otel-lite/pyproject.toml
+++ b/packages/python/lambda-otel-lite/pyproject.toml
@@ -8,7 +8,7 @@ path = "src/lambda_otel_lite/version.py"
 
 [project]
 name = "lambda_otel_lite"
-version = "0.11.0"
+version = "0.12.0"
 description = "Lightweight OpenTelemetry instrumentation for AWS Lambda"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/python/lambda-otel-lite/src/lambda_otel_lite/telemetry.py
+++ b/packages/python/lambda-otel-lite/src/lambda_otel_lite/telemetry.py
@@ -13,6 +13,7 @@ from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.propagators.textmap import TextMapPropagator
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.id_generator import IdGenerator
 from otlp_stdout_span_exporter import OTLPStdoutSpanExporter
 
 from . import ProcessorMode, __version__, processor_mode
@@ -119,6 +120,7 @@ def init_telemetry(
     resource: Resource | None = None,
     span_processors: Sequence[SpanProcessor] | None = None,
     propagators: Sequence[TextMapPropagator] | None = None,
+    id_generator: IdGenerator | None = None,
 ) -> tuple[trace.Tracer, TelemetryCompletionHandler]:
     """Initialize OpenTelemetry with manual OTLP stdout configuration.
 
@@ -135,6 +137,8 @@ def init_telemetry(
             global propagators (W3C TraceContext and Baggage) will be used. If provided,
             these propagators will be combined into a composite propagator and set as the
             global propagator.
+        id_generator: Optional ID generator. If None, the default W3C-compatible ID generator
+            will be used. Set to an XRayIdGenerator instance to use X-Ray compatible IDs.
 
     Returns:
         Tuple containing:
@@ -154,7 +158,7 @@ def init_telemetry(
         )
 
     # Create tracer provider
-    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider = TracerProvider(resource=resource, id_generator=id_generator)
 
     # Setup processors with environment variables having precedence
     if span_processors is None:


### PR DESCRIPTION
This pull request introduces support for custom ID generators in the `lambda-otel-lite` package, along with associated documentation and version updates. The most important changes include adding the `id_generator` parameter to the `init_telemetry` function, updating the documentation, and adding tests for the new functionality.

Support for custom ID generators:

* [`packages/python/lambda-otel-lite/src/lambda_otel_lite/telemetry.py`](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647R123): Added the `id_generator` parameter to the `init_telemetry` function and updated the `TracerProvider` initialization to use the provided ID generator. [[1]](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647R123) [[2]](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647R140-R141) [[3]](diffhunk://#diff-c1cdecd0d4dbd084a18cefc24333eb43808caa045a2f359596ad7c9143f4f647L157-R161)
* [`packages/python/lambda-otel-lite/tests/test_telemetry.py`](diffhunk://#diff-a64136389cf15ddc43e8a2f0236ff367204bcce0ac192047c199556ae6a37871R172-R227): Added a test case to verify telemetry initialization with a custom ID generator.

Documentation updates:

* [`packages/python/lambda-otel-lite/README.md`](diffhunk://#diff-9d6f9c13d260b813f84c220d196b2815ec788d94496e21a8a72ba05f5ef61699R25): Added a section on custom configuration with an ID generator, including an example of using the AWS X-Ray ID generator. [[1]](diffhunk://#diff-9d6f9c13d260b813f84c220d196b2815ec788d94496e21a8a72ba05f5ef61699R25) [[2]](diffhunk://#diff-9d6f9c13d260b813f84c220d196b2815ec788d94496e21a8a72ba05f5ef61699R294-R313)

Version updates:

* [`packages/python/lambda-otel-lite/pyproject.toml`](diffhunk://#diff-53fa277f7b8898f8cc036b22cb6133c3cc5d36d0246d9a0c29f84b75e9801a61L11-R11): Updated the version from `0.11.0` to `0.12.0`.
* [`packages/python/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-0255a9d95a4789e536efd018d471d0d9540ba1e008ff7386e9f648124b36f1e9R8-R13): Added an entry for version `0.12.0`, detailing the new support for custom ID generators and related documentation.