### PR TITLE
release node lambda-otel-lite v0.11.2

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2025-03-25
+
+### Added
+- Support for custom ID generators via the `idGenerator` option in `initTelemetry`
+- Added AWS X-Ray compatible ID generator documentation and examples
+- Comprehensive test coverage for ID generator functionality
+
+### Changed
+- Updated documentation to include X-Ray integration examples
+- Removed deprecated environment variable reference from examples documentation
+
 ## [0.11.1] - 2025-03-22
 
 ### Fixed

--- a/packages/node/lambda-otel-lite/examples/README.md
+++ b/packages/node/lambda-otel-lite/examples/README.md
@@ -187,7 +187,6 @@ The examples respect the following environment variables:
 - `OTEL_SERVICE_NAME`: Service name for spans
 - `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE`: Processing mode (sync/async/finalize)
 - `NODE_OPTIONS`: Used to load the extension
-- `LAMBDA_TRACING_ENABLE_FMT_LAYER`: Enable console output (default: false)
 
 ## Deployment
 

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
This pull request includes several changes to add support for custom ID generators in the `lambda-otel-lite` package, along with updates to documentation and tests. The most important changes include adding the `idGenerator` option to `initTelemetry`, updating the test suite to cover this new functionality, and updating the documentation to reflect these changes.

### Support for custom ID generators:

* [`packages/node/lambda-otel-lite/src/internal/telemetry/init.ts`](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR54-R56): Added the `idGenerator` option to the `initTelemetry` function to allow custom ID generators, such as AWS X-Ray compatible ID generators. [[1]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR54-R56) [[2]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR97-R105) [[3]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR124) [[4]](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baR150)

### Test coverage:

* [`packages/node/lambda-otel-lite/__tests__/test_init.ts`](diffhunk://#diff-c3f6106afee006d52c676c7b98d7121d361893fedf7b80281fe3caa8baaf7cd6R136-R197): Added a new test to verify that telemetry can be initialized with a custom ID generator, including checks for trace and span ID generation.

### Documentation updates:

* [`packages/node/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR10-R20): Updated the changelog to include the new version `0.11.2` and detailed the addition of custom ID generator support and related documentation.
* [`packages/node/lambda-otel-lite/examples/README.md`](diffhunk://#diff-76e06a7b5b6044246b6bee4cdd0ed57f14557733c5bde4e7fcc93c488f934f56L190): Removed a deprecated environment variable reference from the examples documentation.

### Additional changes:

* [`packages/node/lambda-otel-lite/package.json`](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3): Updated the package version to `0.11.2`.
* [`packages/node/lambda-otel-lite/src/internal/telemetry/init.ts`](diffhunk://#diff-76a27bbd9a88291b658226c6a2f1ba27ebe4acd0bf04682df64de7b0ce9918baL2-R2): Imported the `IdGenerator` from `@opentelemetry/sdk-trace-base` to support the new functionality.