### PR TITLE
release node lambda-otel-lite v0.11.3

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] - 2025-03-25
+
+### Fixed
+- Package release fix to ensure all required files are included in the release
+- No functional changes from 0.11.2
+
 ## [0.11.2] - 2025-03-25
 
 ### Added

--- a/packages/node/lambda-otel-lite/README.md
+++ b/packages/node/lambda-otel-lite/README.md
@@ -22,6 +22,7 @@ By leveraging Lambda's execution lifecycle and providing multiple processing mod
   - [Custom configuration with custom resource attributes](#custom-configuration-with-custom-resource-attributes)
   - [Custom configuration with custom span processors](#custom-configuration-with-custom-span-processors)
   - [Custom configuration with context propagators](#custom-configuration-with-context-propagators)
+  - [Custom configuration with ID generator](#custom-configuration-with-id-generator)
   - [Library specific Resource Attributes](#library-specific-resource-attributes)
 - [Event Extractors](#event-extractors)
   - [Automatic Attributes extraction](#automatic-attributes-extraction)
@@ -295,6 +296,26 @@ By default, OpenTelemetry Node.js uses W3C Trace Context and W3C Baggage propaga
 You can provide multiple propagators, and they will be combined into a composite propagator. The order matters - propagators are applied in the order they are provided.
 
 > **Note:** The OpenTelemetry SDK also supports configuring propagators via the `OTEL_PROPAGATORS` environment variable. If set, this environment variable takes precedence over programmatic configuration. See the [OpenTelemetry JavaScript documentation](https://opentelemetry.io/docs/languages/js/propagation/) for more details.
+
+### Custom configuration with ID generator
+
+```typescript
+import { initTelemetry } from '@dev7a/lambda-otel-lite';
+import { AWSXRayIdGenerator } from '@opentelemetry/id-generator-aws-xray';
+
+// Initialize with X-Ray compatible ID generator
+const { tracer, completionHandler } = initTelemetry({
+  idGenerator: new AWSXRayIdGenerator()
+});
+```
+
+By default, OpenTelemetry uses a random ID generator that creates W3C-compatible trace and span IDs. The `idGenerator` parameter allows you to customize the ID generation strategy. This is particularly useful when you need to integrate with AWS X-Ray, which requires a specific ID format.
+
+To use the X-Ray ID generator, you'll need to install the OpenTelemetry X-Ray ID generator package:
+
+```bash
+npm install --save @opentelemetry/id-generator-aws-xray
+```
 
 ### Library specific Resource Attributes
 

--- a/packages/node/lambda-otel-lite/__tests__/test_exports.ts
+++ b/packages/node/lambda-otel-lite/__tests__/test_exports.ts
@@ -19,8 +19,12 @@ describe('Package exports', () => {
     expect(packageJson.exports['./telemetry'].types).toBe('./dist/telemetry/index.d.ts');
     expect(packageJson.exports['./telemetry'].default).toBe('./dist/telemetry/index.js');
 
-    expect(packageJson.exports['./extractors'].types).toBe('./dist/internal/telemetry/extractors.d.ts');
-    expect(packageJson.exports['./extractors'].default).toBe('./dist/internal/telemetry/extractors.js');
+    expect(packageJson.exports['./extractors'].types).toBe(
+      './dist/internal/telemetry/extractors.d.ts'
+    );
+    expect(packageJson.exports['./extractors'].default).toBe(
+      './dist/internal/telemetry/extractors.js'
+    );
   });
 
   it('should have extractors directory in source', () => {
@@ -33,15 +37,15 @@ describe('Package exports', () => {
   it('should expose all necessary extractors from the source files', async () => {
     // Import directly from source files which are available during tests
     const extractorsModule = await import('../src/extractors/index');
-    
+
     const expectedExports = [
       'apiGatewayV1Extractor',
       'apiGatewayV2Extractor',
       'albExtractor',
       'defaultExtractor',
-      'TriggerType'
+      'TriggerType',
     ];
-    
+
     for (const exportName of expectedExports) {
       expect(extractorsModule).toHaveProperty(exportName);
     }

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
This pull request includes updates to the `lambda-otel-lite` package, with changes to the changelog, documentation, tests, and package version. The most important changes are summarized below:

### Changelog Update:
* Added a new release entry for version 0.11.3, which includes a package release fix to ensure all required files are included in the release. There are no functional changes from version 0.11.2.

### Documentation Update:
* Added a new section in the README for custom configuration with an ID generator, including an example of how to use the AWS X-Ray ID generator. [[1]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddR25) [[2]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddR300-R319)

### Testing Update:
* Reformatted the `test_exports.ts` file for better readability by breaking long lines into multiple lines.
* Added a missing comma in the `expectedExports` array in the `test_exports.ts` file.

### Package Version Update:
* Updated the package version in `package.json` from 0.11.2 to 0.11.3.