### PR TITLE
release rust otlp-stdout-span-exporter v0.11.1

### DIFF
--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2025-03-26
+
+### Changed
+- Updated dependencies to use workspace references for better consistency
+- Made `ExporterOutput` struct and fields public for improved API access
+- Improved test implementation using builder pattern
+
 ## [0.11.0] - 2024-03-18
 
 ### Added

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This pull request includes updates to the `otlp-stdout-span-exporter` package to improve consistency and API access, as well as enhancements to the test implementation.

### Improvements to API and consistency:

* [`packages/rust/otlp-stdout-span-exporter/CHANGELOG.md`](diffhunk://#diff-51c986c5bb8e2e0e9f9c5ecc6f5ac74d2f94a63485f77b241081dc12820081ffR10-R16): Updated dependencies to use workspace references for better consistency and made `ExporterOutput` struct and fields public for improved API access.

### Enhancements to test implementation:

* [`packages/rust/otlp-stdout-span-exporter/CHANGELOG.md`](diffhunk://#diff-51c986c5bb8e2e0e9f9c5ecc6f5ac74d2f94a63485f77b241081dc12820081ffR10-R16): Improved test implementation using the builder pattern.

### Version update:

* [`packages/rust/otlp-stdout-span-exporter/Cargo.toml`](diffhunk://#diff-139d37c5c8f0270080968f69d2217b6dc710f974739d4ef4f2b7410ce95f9ee6L3-R3): Updated version from `0.11.0` to `0.11.1`.