### PR TITLE
remove redundant resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,6 @@ members = [
     "packages/rust/lambda-otel-lite/examples"
 ]
 
-resolver = "2"
-
 [workspace.package]
 version = "0.9.0"
 edition = "2021"


### PR DESCRIPTION
`resolver = "2"` is implicit when `edition = "2021"` or higher.

![image](https://github.com/user-attachments/assets/53d5d5f0-ce3e-4a5b-832b-f07aca1993b8)
