### PR TITLE
Log exporter for otlp-stdout-span-exporter

### DIFF
--- a/forwarders/otlp-stdout-logs-processor/processor/src/main.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/main.rs
@@ -25,8 +25,8 @@ use lambda_otlp_forwarder::{
 };
 use otlp_sigv4_client::SigV4ClientBuilder;
 use otlp_stdout_span_exporter::ExporterOutput;
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 
 use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 
@@ -40,41 +40,47 @@ fn convert_log_event(event: &LogEntry) -> Result<TelemetryData> {
     let record = &event.message;
 
     tracing::debug!("Received log record: {}", record);
-    
+
     // Parse the JSON into a serde_json::Value first
     let json_value: Value = serde_json::from_str(record)
         .with_context(|| format!("Failed to parse log record as JSON: {}", record))?;
-    
+
     // Extract fields from the JSON, handling different field names and versions
-    let version = json_value.get("__otel_otlp_stdout")
+    let version = json_value
+        .get("__otel_otlp_stdout")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
-        
-    let source = json_value.get("source")
+
+    let source = json_value
+        .get("source")
         .and_then(Value::as_str)
         .map(ToString::to_string)
         .unwrap_or_else(|| "unknown".to_string());
-        
-    let endpoint = json_value.get("endpoint")
+
+    let endpoint = json_value
+        .get("endpoint")
         .and_then(Value::as_str)
         .unwrap_or("http://localhost:4318/v1/traces");
-        
-    let method = json_value.get("method")
+
+    let method = json_value
+        .get("method")
         .and_then(Value::as_str)
         .unwrap_or("POST");
-        
+
     // Check both kebab-case and snake_case variants for content type
-    let content_type = json_value.get("content-type")
+    let content_type = json_value
+        .get("content-type")
         .or_else(|| json_value.get("content_type"))
         .and_then(Value::as_str)
         .unwrap_or("application/x-protobuf");
-        
+
     // Same for content encoding
-    let content_encoding = json_value.get("content-encoding")
+    let content_encoding = json_value
+        .get("content-encoding")
         .or_else(|| json_value.get("content_encoding"))
         .and_then(Value::as_str)
         .unwrap_or("gzip");
-    
+
     // Extract headers if present
     let mut headers = HashMap::new();
     if let Some(headers_obj) = json_value.get("headers").and_then(Value::as_object) {
@@ -84,17 +90,19 @@ fn convert_log_event(event: &LogEntry) -> Result<TelemetryData> {
             }
         }
     }
-    
+
     // Get payload and base64 flag
-    let payload = json_value.get("payload")
+    let payload = json_value
+        .get("payload")
         .and_then(Value::as_str)
         .map(ToString::to_string)
         .unwrap_or_default();
-        
-    let base64 = json_value.get("base64")
+
+    let base64 = json_value
+        .get("base64")
         .and_then(Value::as_bool)
         .unwrap_or(true);
-    
+
     // Create ExporterOutput with borrowed references where required
     let exporter_output = ExporterOutput {
         version,
@@ -107,7 +115,7 @@ fn convert_log_event(event: &LogEntry) -> Result<TelemetryData> {
         payload,
         base64,
     };
-    
+
     tracing::debug!("Successfully parsed log record with version: {}", version);
 
     // Convert to TelemetryData (will be in uncompressed protobuf format)

--- a/packages/rust/otlp-stdout-span-exporter/src/constants.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/constants.rs
@@ -31,6 +31,7 @@ pub mod defaults {
 
     /// Default endpoint for OTLP export.
     pub const ENDPOINT: &str = "http://localhost:4318/v1/traces";
+    pub const LOGS_ENDPOINT: &str = "http://localhost:4318/v1/logs";
 }
 
 /// Resource attribute keys used in the Lambda resource.

--- a/packages/rust/otlp-stdout-span-exporter/src/logs.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/logs.rs
@@ -1,0 +1,209 @@
+use std::{env, io::Write, sync::Arc};
+
+use bon::bon;
+use flate2::{write::GzEncoder, Compression};
+use opentelemetry_proto::{
+    tonic::collector::logs::v1::ExportLogsServiceRequest,
+    transform::{
+        common::tonic::ResourceAttributesWithSchema, logs::tonic::group_logs_by_resource_and_scope,
+    },
+};
+use opentelemetry_sdk::{
+    error::OTelSdkError,
+    logs::{LogBatch, LogExporter},
+    Resource,
+};
+
+use base64::{engine::general_purpose::STANDARD as base64_engine, Engine};
+use prost::Message;
+
+use crate::{
+    consts::{defaults, env_vars},
+    parse_headers,
+    utils::get_service_name,
+    ExporterOutput, Output, StdOutput, VERSION,
+};
+
+/// A log exporter that writes logs to stdout in OTLP format
+///
+/// This exporter implements the OpenTelemetry [`LogExporter`] trait and writes logs
+/// to stdout in OTLP format with Protobuf serialization and GZIP compression.
+///
+/// # Features
+///
+/// - Configurable GZIP compression level (0-9)
+/// - Environment variable support for service name and headers
+/// - Efficient batching of logs
+/// - Base64 encoding of compressed data
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use opentelemetry_sdk::runtime;
+/// use otlp_stdout_span_exporter::OtlpStdoutLogExporter;
+///
+/// // Create an exporter with maximum compression
+/// let exporter = OtlpStdoutLogExporter::builder()
+///     .compression_level(9)
+///     .build();
+/// ```
+#[derive(Debug)]
+pub struct OtlpStdoutLogExporter {
+    /// GZIP compression level (0-9)
+    compression_level: u8,
+    /// Output implementation (stdout or test buffer)
+    output: Arc<dyn Output>,
+    /// Optional resource to be included with all logs
+    resource: Option<Resource>,
+}
+
+impl Default for OtlpStdoutLogExporter {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+#[bon]
+impl OtlpStdoutLogExporter {
+    /// Create a new `OtlpStdoutSpanExporter` with default configuration.
+    ///
+    /// This uses a GZIP compression level of 6 unless overridden by an environment variable.
+    ///
+    /// # Compression Level
+    ///
+    /// The compression level is determined in the following order (highest to lowest precedence):
+    ///
+    /// 1. The `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable if set
+    /// 2. Default value (6)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+    ///
+    /// let exporter = OtlpStdoutSpanExporter::default();
+    /// ```
+    #[builder]
+    pub fn new(
+        compression_level: Option<u8>,
+        output: Option<Arc<dyn Output>>,
+        resource: Option<Resource>,
+    ) -> Self {
+        // Set gzip_level with proper precedence (env var > constructor param > default)
+        let compression_level = match env::var(env_vars::COMPRESSION_LEVEL) {
+            Ok(value) => match value.parse::<u8>() {
+                Ok(level) if level <= 9 => level,
+                Ok(level) => {
+                    log::warn!(
+                        "Invalid value in {}: {} (must be 0-9), using fallback",
+                        env_vars::COMPRESSION_LEVEL,
+                        level
+                    );
+                    compression_level.unwrap_or(defaults::COMPRESSION_LEVEL)
+                }
+                Err(_) => {
+                    log::warn!(
+                        "Failed to parse {}: {}, using fallback",
+                        env_vars::COMPRESSION_LEVEL,
+                        value
+                    );
+                    compression_level.unwrap_or(defaults::COMPRESSION_LEVEL)
+                }
+            },
+            Err(_) => {
+                // No environment variable, use parameter or default
+                compression_level.unwrap_or(defaults::COMPRESSION_LEVEL)
+            }
+        };
+
+        Self {
+            compression_level,
+            resource,
+            output: output.unwrap_or(Arc::new(StdOutput)),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_test_output() -> (Self, Arc<crate::TestOutput>) {
+        let output = Arc::new(crate::TestOutput::new());
+
+        // Use the standard new() method to ensure environment variables are respected
+        let exporter = Self::builder().output(output.clone()).build();
+
+        (exporter, output)
+    }
+}
+
+impl LogExporter for OtlpStdoutLogExporter {
+    /// Export logs to stdout in OTLP format
+    ///
+    /// This function:
+    /// 1. Converts logs to OTLP format
+    /// 2. Serializes them to protobuf
+    /// 3. Compresses the data with GZIP
+    /// 4. Base64 encodes the result
+    /// 5. Writes a JSON object to stdout
+    ///
+    /// # Arguments
+    ///
+    /// * `batch` - A vector of logs to export
+    ///
+    /// # Returns
+    ///
+    /// Returns a resolved future with `Ok(())` if the export was successful, or a `TraceError` if it failed
+    fn export(
+        &self,
+        batch: LogBatch<'_>,
+    ) -> impl std::future::Future<Output = Result<(), OTelSdkError>> + Send {
+        // Do all work synchronously
+        let result = (|| {
+            // Convert spans to OTLP format
+            let resource = self
+                .resource
+                .clone()
+                .unwrap_or_else(|| opentelemetry_sdk::Resource::builder_empty().build());
+            let resource_attrs = ResourceAttributesWithSchema::from(&resource);
+            let resource_logs = group_logs_by_resource_and_scope(batch, &resource_attrs);
+            let request = ExportLogsServiceRequest { resource_logs };
+
+            // Serialize to protobuf
+            let proto_bytes = request.encode_to_vec();
+
+            // Compress with GZIP
+            let mut encoder =
+                GzEncoder::new(Vec::new(), Compression::new(self.compression_level as u32));
+            encoder
+                .write_all(&proto_bytes)
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+            let compressed_bytes = encoder
+                .finish()
+                .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
+
+            // Base64 encode
+            let payload = base64_engine.encode(compressed_bytes);
+
+            // Prepare the output
+            let output_data = ExporterOutput {
+                version: VERSION,
+                source: get_service_name(),
+                endpoint: defaults::LOGS_ENDPOINT,
+                method: "POST",
+                content_type: "application/x-protobuf",
+                content_encoding: "gzip",
+                headers: parse_headers(),
+                payload,
+                base64: true,
+            };
+
+            // Write using the output implementation
+            self.output.write_line(
+                &serde_json::to_string(&output_data)
+                    .map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?,
+            )?;
+
+            Ok(())
+        })();
+
+        // Return a resolved future with the result
+        Box::pin(std::future::ready(result))
+    }
+}

--- a/packages/rust/otlp-stdout-span-exporter/src/utils.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/utils.rs
@@ -1,0 +1,54 @@
+use std::{collections::HashMap, env};
+
+use crate::consts::{defaults, env_vars};
+
+/// Get the service name from environment variables.
+///
+/// The service name is determined in the following order:
+///
+/// 1. OTEL_SERVICE_NAME
+/// 2. AWS_LAMBDA_FUNCTION_NAME
+/// 3. "unknown-service" (fallback)
+pub(crate) fn get_service_name() -> String {
+    env::var(env_vars::SERVICE_NAME)
+        .or_else(|_| env::var(env_vars::AWS_LAMBDA_FUNCTION_NAME))
+        .unwrap_or_else(|_| defaults::SERVICE_NAME.to_string())
+}
+
+/// Parse headers from environment variables
+///
+/// This function reads headers from both global and trace-specific
+/// environment variables, with trace-specific headers taking precedence.
+pub(crate) fn parse_headers() -> HashMap<String, String> {
+    let mut headers = HashMap::new();
+
+    // Parse global headers first
+    if let Ok(global_headers) = env::var("OTEL_EXPORTER_OTLP_HEADERS") {
+        parse_header_string(&global_headers, &mut headers);
+    }
+
+    // Parse trace-specific headers (these take precedence)
+    if let Ok(trace_headers) = env::var("OTEL_EXPORTER_OTLP_TRACES_HEADERS") {
+        parse_header_string(&trace_headers, &mut headers);
+    }
+
+    headers
+}
+
+/// Parse a header string in the format key1=value1,key2=value2
+///
+/// # Arguments
+///
+/// * `header_str` - The header string to parse
+/// * `headers` - The map to store parsed headers in
+pub(crate) fn parse_header_string(header_str: &str, headers: &mut HashMap<String, String>) {
+    for pair in header_str.split(',') {
+        if let Some((key, value)) = pair.split_once('=') {
+            let key = key.trim().to_lowercase();
+            // Skip content-type and content-encoding as they are fixed
+            if key != "content-type" && key != "content-encoding" {
+                headers.insert(key, value.trim().to_string());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Taking your advice to use `otlp-stdout-span-exporter` instead of `otlp-stdout-client`, it doesn't seem to support logs. 

It was pretty easy to derive a `OtlpStdoutLogExporter` from `OtlpStdoutSpanExporter`. 

Would you be open to adding this to the crate? I haven't neatened it up yet, not sure how you want it. 