### PR TITLE
Release/rust/otlp stdout span exporter v0.13.0

### DIFF
--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.0] - 2025-03-27
+## [0.13.0] - 2025-03-27
 
 ### Added
 - Added optional `level` field in the output for easier filtering in log aggregation systems

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2025-03-28
+
+### Added
+- Added optional `level` field in the output for easier filtering in log aggregation systems
+- Added `LogLevel` enum with `Debug`, `Info`, `Warn`, and `Error` variants
+- Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` environment variable to set the log level
+- Added builder method to set the log level programmatically
+
 ## [0.11.1] - 2025-03-26
 
 ### Changed

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LogLevel` enum with `Debug`, `Info`, `Warn`, and `Error` variants
 - Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` environment variable to set the log level
 - Added builder method to set the log level programmatically
+- Added support for configurable output destination (stdout, file, named pipe)
+- Added `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH` environment variable to control output destination
+- Added support for URI-like scheme to specify output (stdout://, file://, pipe://)
 
 ## [0.11.1] - 2025-03-26
 

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.13.0] - 2025-03-27
 
 ### Added
@@ -14,9 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `LogLevel` enum with `Debug`, `Info`, `Warn`, and `Error` variants
 - Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` environment variable to set the log level
 - Added builder method to set the log level programmatically
-- Added support for configurable output destination (stdout, file, named pipe)
-- Added `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH` environment variable to control output destination
-- Added support for URI-like scheme to specify output (stdout://, file://, pipe://)
+- Added support for named pipe output as an alternative to stdout
+- Added `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variable to control output type ("pipe" or "stdout")
+- Added builder method `pipe(bool)` to configure named pipe output programmatically
+
+### Changed
+- Named pipe output uses a fixed path at `/tmp/otlp-stdout-span-exporter.pipe` for consistency
 
 ## [0.11.1] - 2025-03-26
 

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.12.0] - 2025-03-28
+## [0.12.0] - 2025-03-27
 
 ### Added
 - Added optional `level` field in the output for easier filtering in log aggregation systems

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.11.1"
+version = "0.12.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
@@ -48,19 +48,31 @@ Before publishing a new version of `otlp-stdout-span-exporter`, ensure all these
 - [ ] Git tags are ready to be created
 - [ ] `.gitignore` is up-to-date
 
+## Version Management
+- [ ] Update version in `Cargo.toml` only (or in workspace Cargo.toml if using workspace version)
+- [ ] This is the single source of truth for the version
+
 ## Publishing Steps
-1. Update version in `Cargo.toml` (or in workspace Cargo.toml if using workspace version)
+1. Update version in `Cargo.toml`
 2. Update `CHANGELOG.md`
-3. Format code: `cargo fmt`
-4. Run format check: `cargo fmt --check`
-5. Run clippy: `cargo clippy -- -D warnings`
-6. Run tests: `cargo test`
-7. Run doc tests: `cargo test --doc`
-8. Build in release mode: `cargo build --release`
-9. Verify documentation: `cargo doc --no-deps`
-10. Create a branch for the release following the pattern `release/<rust|node|python|>/<package-name>-v<version>`
-11. Commit changes to the release branch and push to GitHub, with a commit message of `release/<rust|node|python|>/<package-name> v<version>`
-12. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
+3. Run quality checks:
+   ```bash
+   cargo fmt
+   cargo fmt --check
+   cargo clippy -- -D warnings
+   cargo test
+   cargo test --doc
+   ```
+4. Build in release mode:
+   ```bash
+   cargo build --release
+   cargo doc --no-deps
+   cargo package # Verify package contents
+   ```
+5. Create a branch for the release following the pattern `release/rust/<package-name>-v<version>`
+6. Commit changes to the release branch and push to GitHub, with a commit message of `release: rust/otlp-stdout-span-exporter v<version>`
+7. Create a Pull Request to merge your changes to the main branch
+8. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing
 - [ ] Verify package installation works: `cargo add otlp-stdout-span-exporter`
@@ -82,7 +94,6 @@ Before publishing a new version of `otlp-stdout-span-exporter`, ensure all these
 - MSRV compatibility issues
 
 ## Notes
-- Always use `cargo package` first to verify the package contents
 - Test the package with different feature combinations
 - Consider cross-platform compatibility
 - Test with the minimum supported Rust version

--- a/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/rust/otlp-stdout-span-exporter/PUBLISHING.md
@@ -58,8 +58,8 @@ Before publishing a new version of `otlp-stdout-span-exporter`, ensure all these
 7. Run doc tests: `cargo test --doc`
 8. Build in release mode: `cargo build --release`
 9. Verify documentation: `cargo doc --no-deps`
-10. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
-11. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
+10. Create a branch for the release following the pattern `release/<rust|node|python|>/<package-name>-v<version>`
+11. Commit changes to the release branch and push to GitHub, with a commit message of `release/<rust|node|python|>/<package-name> v<version>`
 12. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing

--- a/packages/rust/otlp-stdout-span-exporter/README.md
+++ b/packages/rust/otlp-stdout-span-exporter/README.md
@@ -15,7 +15,8 @@ The message envelope carries some metadata about the spans, such as the service 
     "custom-header": "value"
   },
   "payload": "<base64-encoded-gzipped-protobuf>",
-  "base64": true
+  "base64": true,
+  "level": "DEBUG"
 }
 ```
 Outputting the telemetry data in this format directly to stdout makes the library easily usable in network constrained environments, or in enviroments that are particularly sensitive to the overhead of HTTP connections, such as AWS Lambda.
@@ -92,6 +93,7 @@ The exporter respects the following environment variables:
 - `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (takes precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9, default: 6)
+- `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL`: Log level added to the output recordfor filtering (debug, info, warn, error)
 
 ## Configuration
 
@@ -115,13 +117,22 @@ export OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL=9
 The exporter provides two main ways to create and configure it:
 
 ```rust
-use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+use otlp_stdout_span_exporter::{OtlpStdoutSpanExporter, LogLevel};
 
 // Create with default options (compression level 6)
 let default_exporter = OtlpStdoutSpanExporter::default();
 
 // Create with specific compression level
 let max_compression_exporter = OtlpStdoutSpanExporter::builder().compression_level(9).build();
+
+// Create with a specific log level
+let debug_level_exporter = OtlpStdoutSpanExporter::builder().level(LogLevel::Debug).build();
+
+// Create with both compression and log level
+let configured_exporter = OtlpStdoutSpanExporter::builder()
+    .compression_level(9)
+    .level(LogLevel::Trace)
+    .build();
 ```
 
 Note that even when using these constructor parameters, environment variables will still take precedence if they are set.

--- a/packages/rust/otlp-stdout-span-exporter/README.md
+++ b/packages/rust/otlp-stdout-span-exporter/README.md
@@ -93,7 +93,8 @@ The exporter respects the following environment variables:
 - `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (takes precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9, default: 6)
-- `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL`: Log level added to the output recordfor filtering (debug, info, warn, error)
+- `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL`: Log level for filtering (debug, info, warn, error)
+- `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH`: Output destination URI (stdout://, file://, pipe://)
 
 ## Configuration
 
@@ -131,7 +132,17 @@ let debug_level_exporter = OtlpStdoutSpanExporter::builder().level(LogLevel::Deb
 // Create with both compression and log level
 let configured_exporter = OtlpStdoutSpanExporter::builder()
     .compression_level(9)
-    .level(LogLevel::Trace)
+    .level(LogLevel::Error)
+    .build();
+
+// Output to a file instead of stdout
+let file_exporter = OtlpStdoutSpanExporter::builder()
+    .output_path("file:///path/to/spans.jsonl".to_string())
+    .build();
+
+// Output to a named pipe
+let pipe_exporter = OtlpStdoutSpanExporter::builder()
+    .output_path("pipe:///tmp/spans-pipe".to_string())
     .build();
 ```
 

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
@@ -1,10 +1,17 @@
 use opentelemetry::global;
-use opentelemetry::trace::Tracer;
+use opentelemetry::trace::{Tracer, get_active_span};
+use opentelemetry::KeyValue;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+use std::collections::HashMap;
 
 fn init_tracer() -> SdkTracerProvider {
-    let exporter = OtlpStdoutSpanExporter::default();
+    let mut headers: HashMap<String, String> = HashMap::new();
+    headers.insert("test".to_string(), "test".to_string());
+    
+    let exporter = OtlpStdoutSpanExporter::builder()
+        .headers(headers)
+        .build();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .build();
@@ -18,12 +25,16 @@ async fn main() {
     let provider = init_tracer();
     let tracer = global::tracer("example/simple");
     tracer.in_span("parent-operation", |_cx| {
-        println!("Doing work...");
+        get_active_span(|span| {
+            span.add_event("Doing work".to_string(), vec![KeyValue::new("work", true)]);
+        });
 
         // Create nested spans
         tracer.in_span("child-operation", |_cx| {
-            println!("Doing more work...");
-        });
+            get_active_span(|span| {
+                span.add_event("Not doing work".to_string(), vec![KeyValue::new("work", false)]);
+            });
+            });
     });
 
     if let Err(err) = provider.force_flush() {

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
@@ -2,7 +2,7 @@ use opentelemetry::global;
 use opentelemetry::trace::{Tracer, get_active_span};
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use otlp_stdout_span_exporter::OtlpStdoutSpanExporter;
+use otlp_stdout_span_exporter::{OtlpStdoutSpanExporter, LogLevel};
 use std::collections::HashMap;
 
 fn init_tracer() -> SdkTracerProvider {
@@ -11,6 +11,7 @@ fn init_tracer() -> SdkTracerProvider {
     
     let exporter = OtlpStdoutSpanExporter::builder()
         .headers(headers)
+        .level(LogLevel::Debug)
         .build();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
@@ -1,14 +1,14 @@
 use opentelemetry::global;
-use opentelemetry::trace::{Tracer, get_active_span};
+use opentelemetry::trace::{get_active_span, Tracer};
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use otlp_stdout_span_exporter::{OtlpStdoutSpanExporter, LogLevel};
+use otlp_stdout_span_exporter::{LogLevel, OtlpStdoutSpanExporter};
 use std::collections::HashMap;
 
 fn init_tracer() -> SdkTracerProvider {
     let mut headers: HashMap<String, String> = HashMap::new();
     headers.insert("test".to_string(), "test".to_string());
-    
+
     // Create exporter with the Debug log level and named pipe output
     // You can also use environment variables:
     // OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL=debug
@@ -16,7 +16,7 @@ fn init_tracer() -> SdkTracerProvider {
     let exporter = OtlpStdoutSpanExporter::builder()
         .headers(headers)
         .level(LogLevel::Debug)
-        .pipe(true)  // Will write to /tmp/otlp-stdout-span-exporter.pipe
+        .pipe(true) // Will write to /tmp/otlp-stdout-span-exporter.pipe
         .build();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
@@ -30,7 +30,7 @@ fn init_tracer() -> SdkTracerProvider {
 async fn main() {
     eprintln!("Writing spans to /tmp/otlp-stdout-span-exporter.pipe with DEBUG level");
     eprintln!("Note: Make sure the named pipe exists (create with `mkfifo /tmp/otlp-stdout-span-exporter.pipe`)");
-    
+
     let provider = init_tracer();
     let tracer = global::tracer("example/simple");
     tracer.in_span("parent-operation", |_cx| {
@@ -41,7 +41,10 @@ async fn main() {
         // Create nested spans
         tracer.in_span("child-operation", |_cx| {
             get_active_span(|span| {
-                span.add_event("Not doing work".to_string(), vec![KeyValue::new("work", false)]);
+                span.add_event(
+                    "Not doing work".to_string(),
+                    vec![KeyValue::new("work", false)],
+                );
             });
         });
     });
@@ -49,6 +52,6 @@ async fn main() {
     if let Err(err) = provider.force_flush() {
         eprintln!("Error flushing provider: {:?}", err);
     }
-    
+
     eprintln!("Spans have been written to /tmp/otlp-stdout-span-exporter.pipe");
 }

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
@@ -9,9 +9,14 @@ fn init_tracer() -> SdkTracerProvider {
     let mut headers: HashMap<String, String> = HashMap::new();
     headers.insert("test".to_string(), "test".to_string());
     
+    // Create exporter with the Debug log level and a file output path
+    // You can also use environment variables:
+    // OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL=debug
+    // OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH=file:///path/to/output.jsonl
     let exporter = OtlpStdoutSpanExporter::builder()
         .headers(headers)
         .level(LogLevel::Debug)
+        .output_path("file:///tmp/otlp-spans.jsonl".to_string())
         .build();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
@@ -23,6 +28,8 @@ fn init_tracer() -> SdkTracerProvider {
 
 #[tokio::main]
 async fn main() {
+    println!("Writing spans to /tmp/otlp-spans.jsonl with DEBUG level");
+    
     let provider = init_tracer();
     let tracer = global::tracer("example/simple");
     tracer.in_span("parent-operation", |_cx| {
@@ -41,4 +48,6 @@ async fn main() {
     if let Err(err) = provider.force_flush() {
         println!("Error flushing provider: {:?}", err);
     }
+    
+    println!("Spans have been written to /tmp/otlp-spans.jsonl");
 }

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-stdout-hello.rs
@@ -9,14 +9,14 @@ fn init_tracer() -> SdkTracerProvider {
     let mut headers: HashMap<String, String> = HashMap::new();
     headers.insert("test".to_string(), "test".to_string());
     
-    // Create exporter with the Debug log level and a file output path
+    // Create exporter with the Debug log level and named pipe output
     // You can also use environment variables:
     // OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL=debug
-    // OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH=file:///path/to/output.jsonl
+    // OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE=pipe
     let exporter = OtlpStdoutSpanExporter::builder()
         .headers(headers)
         .level(LogLevel::Debug)
-        .output_path("file:///tmp/otlp-spans.jsonl".to_string())
+        .pipe(true)  // Will write to /tmp/otlp-stdout-span-exporter.pipe
         .build();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
@@ -28,7 +28,8 @@ fn init_tracer() -> SdkTracerProvider {
 
 #[tokio::main]
 async fn main() {
-    println!("Writing spans to /tmp/otlp-spans.jsonl with DEBUG level");
+    eprintln!("Writing spans to /tmp/otlp-stdout-span-exporter.pipe with DEBUG level");
+    eprintln!("Note: Make sure the named pipe exists (create with `mkfifo /tmp/otlp-stdout-span-exporter.pipe`)");
     
     let provider = init_tracer();
     let tracer = global::tracer("example/simple");
@@ -42,12 +43,12 @@ async fn main() {
             get_active_span(|span| {
                 span.add_event("Not doing work".to_string(), vec![KeyValue::new("work", false)]);
             });
-            });
+        });
     });
 
     if let Err(err) = provider.force_flush() {
-        println!("Error flushing provider: {:?}", err);
+        eprintln!("Error flushing provider: {:?}", err);
     }
     
-    println!("Spans have been written to /tmp/otlp-spans.jsonl");
+    eprintln!("Spans have been written to /tmp/otlp-stdout-span-exporter.pipe");
 }

--- a/packages/rust/otlp-stdout-span-exporter/src/constants.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/constants.rs
@@ -22,6 +22,9 @@ pub mod env_vars {
     
     /// Log level for exported spans
     pub const LOG_LEVEL: &str = "OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL";
+    
+    /// Output destination URI (stdout://, file://, pipe://)
+    pub const OUTPUT_PATH: &str = "OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH";
 }
 
 /// Default values for configuration parameters.
@@ -34,6 +37,9 @@ pub mod defaults {
 
     /// Default endpoint for OTLP export.
     pub const ENDPOINT: &str = "http://localhost:4318/v1/traces";
+    
+    /// Default output destination
+    pub const OUTPUT_PATH: &str = "stdout://";
 }
 
 /// Resource attribute keys used in the Lambda resource.

--- a/packages/rust/otlp-stdout-span-exporter/src/constants.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/constants.rs
@@ -19,10 +19,10 @@ pub mod env_vars {
 
     /// Trace-specific headers (takes precedence over OTLP_HEADERS).
     pub const OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
-    
+
     /// Log level for exported spans
     pub const LOG_LEVEL: &str = "OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL";
-    
+
     /// Output type ("pipe" or "stdout", defaults to "stdout")
     pub const OUTPUT_TYPE: &str = "OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE";
 }
@@ -37,7 +37,7 @@ pub mod defaults {
 
     /// Default endpoint for OTLP export.
     pub const ENDPOINT: &str = "http://localhost:4318/v1/traces";
-    
+
     /// Default output type
     pub const OUTPUT_TYPE: &str = "stdout";
 

--- a/packages/rust/otlp-stdout-span-exporter/src/constants.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/constants.rs
@@ -19,6 +19,9 @@ pub mod env_vars {
 
     /// Trace-specific headers (takes precedence over OTLP_HEADERS).
     pub const OTLP_TRACES_HEADERS: &str = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+    
+    /// Log level for exported spans
+    pub const LOG_LEVEL: &str = "OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL";
 }
 
 /// Default values for configuration parameters.

--- a/packages/rust/otlp-stdout-span-exporter/src/constants.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/constants.rs
@@ -23,8 +23,8 @@ pub mod env_vars {
     /// Log level for exported spans
     pub const LOG_LEVEL: &str = "OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL";
     
-    /// Output destination URI (stdout://, file://, pipe://)
-    pub const OUTPUT_PATH: &str = "OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_PATH";
+    /// Output type ("pipe" or "stdout", defaults to "stdout")
+    pub const OUTPUT_TYPE: &str = "OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE";
 }
 
 /// Default values for configuration parameters.
@@ -38,8 +38,11 @@ pub mod defaults {
     /// Default endpoint for OTLP export.
     pub const ENDPOINT: &str = "http://localhost:4318/v1/traces";
     
-    /// Default output destination
-    pub const OUTPUT_PATH: &str = "stdout://";
+    /// Default output type
+    pub const OUTPUT_TYPE: &str = "stdout";
+
+    /// Fixed path for named pipe
+    pub const PIPE_PATH: &str = "/tmp/otlp-stdout-span-exporter.pipe";
 }
 
 /// Resource attribute keys used in the Lambda resource.


### PR DESCRIPTION
This pull request includes several significant updates to the `otlp-stdout-span-exporter` package, focusing on adding new features, updating documentation, and improving the version management process.

### New Features:
* Added an optional `level` field in the output to facilitate easier filtering in log aggregation systems. Introduced a `LogLevel` enum with `Debug`, `Info`, `Warn`, and `Error` variants, and an environment variable `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` to set the log level.
* Added support for named pipe output as an alternative to stdout. Introduced the `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variable to control output type ("pipe" or "stdout") and a builder method `pipe(bool)` to configure named pipe output programmatically.

### Documentation Updates:
* Updated `CHANGELOG.md` to reflect the new version 0.13.0 and listed all the new features and changes.
* Enhanced `README.md` with examples and explanations of the new log level and named pipe output features. [[1]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2L18-R19) [[2]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R32) [[3]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R54-R61) [[4]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R104-R105) [[5]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R122-R157) [[6]](diffhunk://#diff-a91ef37e86447bd98d9f10b08ee859bb70e886fa256b2cd1e7eadca3ecfa7bc2R169-R170)

### Version Management:
* Updated the version in `Cargo.toml` from 0.11.1 to 0.13.0.
* Revised `PUBLISHING.md` to include steps for updating the version in `Cargo.toml` and clarified the version management process. [[1]](diffhunk://#diff-fe4801ae7489ec2a15ab811c63c3621e98b55eb2db8d55aeb1d087670394d27fR51-R75) [[2]](diffhunk://#diff-fe4801ae7489ec2a15ab811c63c3621e98b55eb2db8d55aeb1d087670394d27fL85)

### Example Code:
* Modified the example in `simple-stdout-hello.rs` to demonstrate the use of the new log level and named pipe output features. [[1]](diffhunk://#diff-54a778fe5f66ccda5e0c6dd793bf41e39b2b726acc044560e417a9faf83edbe8L2-R20) [[2]](diffhunk://#diff-54a778fe5f66ccda5e0c6dd793bf41e39b2b726acc044560e417a9faf83edbe8R31-R56)

### Constants:
* Added new constants for the log level and output type environment variables in `constants.rs`. [[1]](diffhunk://#diff-64f4151966fad2690a735e7e473eaba6291afe046777aaa948405b377d20b5c9R22-R27) [[2]](diffhunk://#diff-64f4151966fad2690a735e7e473eaba6291afe046777aaa948405b377d20b5c9R40-R45)