### PR TITLE
release: rust/lambda-otel-lite v0.13.0

### DIFF
--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2025-03-28
+### Added
+- Added ability to programmatically set the processor mode via `TelemetryConfig.processor_mode`
+- Added `ProcessorMode::resolve()` method to handle both environment variable and programmatic configuration
+- Environment variable `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE` still takes precedence over programmatic setting
+
 ## [0.11.4] - 2025-03-26
 ### Changed
 - Updated dependencies to use workspace references for better consistency and maintainability

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.11.4"
+version = "0.13.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -14,12 +14,13 @@ categories = ["development-tools::debugging", "web-programming::http-server"]
 exclude = ["examples/"]
 
 [dependencies]
+otlp-stdout-span-exporter = { version = "0.13.0" }
+
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 tokio.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
-otlp-stdout-span-exporter = { version = "0.11.1" }
 opentelemetry-aws.workspace = true
 urlencoding.workspace = true
 lambda_runtime.workspace = true

--- a/packages/rust/lambda-otel-lite/PUBLISHING.md
+++ b/packages/rust/lambda-otel-lite/PUBLISHING.md
@@ -27,6 +27,7 @@ Before publishing a new version of `lambda-otel-lite`, ensure all these items ar
 - [ ] `CHANGELOG.md` is updated
 - [ ] Feature flags are documented
 - [ ] All public APIs have usage examples
+- [ ] All environment variables are documented
 
 ## Code Quality
 - [ ] All tests pass (`cargo test`)
@@ -47,20 +48,31 @@ Before publishing a new version of `lambda-otel-lite`, ensure all these items ar
 - [ ] Git tags are ready to be created
 - [ ] `.gitignore` is up-to-date
 
+## Version Management
+- [ ] Update version in `Cargo.toml` only (or in workspace Cargo.toml if using workspace version)
+- [ ] This is the single source of truth for the version
+
 ## Publishing Steps
 1. Update version in `Cargo.toml`
 2. Update `CHANGELOG.md`
-3. Format code: `cargo fmt`
-4. Run format check: `cargo fmt --check`
-5. Run clippy: `cargo clippy -- -D warnings`
-6. Run tests: `cargo test`
-7. Run doc tests: `cargo test --doc`
-8. Build in release mode: `cargo build --release`
-9. Verify documentation: `cargo doc --no-deps`
-10. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
-11. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
-12. Create a Pull Request to merge your changes to the main branch
-13. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
+3. Run quality checks:
+   ```bash
+   cargo fmt
+   cargo fmt --check
+   cargo clippy -- -D warnings
+   cargo test
+   cargo test --doc
+   ```
+4. Build in release mode:
+   ```bash
+   cargo build --release
+   cargo doc --no-deps
+   cargo package # Verify package contents
+   ```
+5. Create a branch for the release following the pattern `release/rust/<package-name>-v<version>`
+6. Commit changes to the release branch and push to GitHub, with a commit message of `release: rust/lambda-otel-lite v<version>`
+7. Create a Pull Request to merge your changes to the main branch
+8. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing
 - [ ] Verify package installation works: `cargo add lambda-otel-lite`
@@ -82,7 +94,6 @@ Before publishing a new version of `lambda-otel-lite`, ensure all these items ar
 - MSRV compatibility issues
 
 ## Notes
-- Always use `cargo package` first to verify the package contents
 - Test the package with different feature combinations
 - Consider cross-platform compatibility
 - Test with the minimum supported Rust version

--- a/packages/rust/lambda-otel-lite/README.md
+++ b/packages/rust/lambda-otel-lite/README.md
@@ -696,6 +696,28 @@ The library uses environment variables for configuration, with a clear precedenc
 - `LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE`: Maximum spans to queue (default: 2048)
 - `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE`: Maximum batch size (default: 512)
 
+You can also set the processor mode programmatically through the `TelemetryConfig`:
+
+```rust,no_run
+use lambda_otel_lite::{init_telemetry, TelemetryConfig, ProcessorMode};
+use lambda_runtime::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let config = TelemetryConfig::builder()
+        .processor_mode(ProcessorMode::Async)
+        .build();
+
+    let (_, completion_handler) = init_telemetry(config).await?;
+    
+    // Use the tracer and completion handler as usual
+    
+    Ok(())
+}
+```
+
+Note that the environment variable `LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE` will always take precedence over the programmatic setting if both are specified.
+
 ### Resource Configuration
 
 - `OTEL_SERVICE_NAME`: Service name for spans (falls back to `AWS_LAMBDA_FUNCTION_NAME`)

--- a/packages/rust/lambda-otel-lite/examples/template.yaml
+++ b/packages/rust/lambda-otel-lite/examples/template.yaml
@@ -54,6 +54,11 @@ Resources:
       Environment:
         Variables:
           LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: async
+          OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL: DEBUG
+          OTLP_STDOUT_KINESIS_STREAM_NAME: !ImportValue serverless-otlp-forwarder-kinesis-processor:otlp-stream-name
+      Policies:
+        - KinesisCrudPolicy:
+            StreamName: !ImportValue serverless-otlp-forwarder-kinesis-processor:otlp-stream-name
 
 Outputs:
   HandlerExampleFunctionUrl:


### PR DESCRIPTION
This pull request to `packages/rust/lambda-otel-lite` includes several updates, primarily focusing on adding new features, improving configuration options, and enhancing logging. The most important changes include adding the ability to programmatically set the processor mode, updating the version and dependencies, and improving the documentation and publishing process.

### New Features and Configuration:

* Added the ability to programmatically set the processor mode via `TelemetryConfig.processor_mode` and introduced the `ProcessorMode::resolve()` method to handle both environment variable and programmatic configuration (`CHANGELOG.md`, `README.md`, `mode.rs`, `telemetry.rs`). [[1]](diffhunk://#diff-186498266ac8e953c6310f423de26221c85a117655d116518dd6abf581d93900R10-R15) [[2]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aR699-R720) [[3]](diffhunk://#diff-4b0db740b218f785c7cb763ed18e6b8334cc42227e983cf4b2a091965ea9ea87R1-R7) [[4]](diffhunk://#diff-4b0db740b218f785c7cb763ed18e6b8334cc42227e983cf4b2a091965ea9ea87L36-R54) [[5]](diffhunk://#diff-4b0db740b218f785c7cb763ed18e6b8334cc42227e983cf4b2a091965ea9ea87L51-R70) [[6]](diffhunk://#diff-4b0db740b218f785c7cb763ed18e6b8334cc42227e983cf4b2a091965ea9ea87R82-R125) [[7]](diffhunk://#diff-4b0db740b218f785c7cb763ed18e6b8334cc42227e983cf4b2a091965ea9ea87L107-R198) [[8]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6R214) [[9]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6R307-R314)

### Version and Dependencies:

* Updated the version in `Cargo.toml` to `0.13.0` and added new dependency versions (`Cargo.toml`). [[1]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L3-R3) [[2]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8R17-L22)

### Documentation and Publishing:

* Enhanced the `PUBLISHING.md` file to include additional steps and checks for version management and environment variable documentation (`PUBLISHING.md`). [[1]](diffhunk://#diff-ea2bff3bedf3b0ab3b13846b626165934ccb1d0f06f015c1cf900433c3370a12R30) [[2]](diffhunk://#diff-ea2bff3bedf3b0ab3b13846b626165934ccb1d0f06f015c1cf900433c3370a12R51-R75) [[3]](diffhunk://#diff-ea2bff3bedf3b0ab3b13846b626165934ccb1d0f06f015c1cf900433c3370a12L85)

### Logging Enhancements:

* Introduced module-specific loggers and replaced `tracing::debug` and `tracing::warn` with the new logger in various modules (`propagation.rs`, `telemetry.rs`). [[1]](diffhunk://#diff-02458cee97a66282ad1f7bf069a708dc3db0d111e20f99df553fa7b6a074346aR6-R15) [[2]](diffhunk://#diff-02458cee97a66282ad1f7bf069a708dc3db0d111e20f99df553fa7b6a074346aL72-R75) [[3]](diffhunk://#diff-02458cee97a66282ad1f7bf069a708dc3db0d111e20f99df553fa7b6a074346aL81-R84) [[4]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6L95-R97) [[5]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6R114-R116) [[6]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6L178-R191) [[7]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6L375-R394)

### Example and Template Updates:

* Updated the example template to include new environment variables (`examples/template.yaml`).