### PR TITLE
Refactor/forwarders

### DIFF
--- a/forwarders/experimental/aws-span-processor/processor/Cargo.toml
+++ b/forwarders/experimental/aws-span-processor/processor/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 opentelemetry-proto.workspace = true
 prost.workspace = true
 aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }
+
 [[bin]]
 name = "span_processor"
 path = "src/main.rs"

--- a/forwarders/experimental/aws-span-processor/processor/Cargo.toml
+++ b/forwarders/experimental/aws-span-processor/processor/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "aws-span-processor"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-lambda-otlp-forwarder = { path = "../../../otlp-stdout-logs-processor/processor" }
+serverless-otlp-forwarder.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
-aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }
 lambda_runtime.workspace = true
 reqwest.workspace = true
 tracing.workspace = true
@@ -23,7 +22,7 @@ aws-credential-types.workspace = true
 serde_json.workspace = true
 opentelemetry-proto.workspace = true
 prost.workspace = true
-
+aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }
 [[bin]]
 name = "span_processor"
 path = "src/main.rs"

--- a/forwarders/experimental/aws-span-processor/processor/src/main.rs
+++ b/forwarders/experimental/aws-span-processor/processor/src/main.rs
@@ -17,13 +17,13 @@ mod otlp;
 use anyhow::Result;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_lambda_events::event::cloudwatch_logs::LogEntry;
+use lambda_runtime::{tower::ServiceBuilder, Error as LambdaError, LambdaEvent, Runtime};
+use otlp_sigv4_client::SigV4ClientBuilder;
+use serde_json::Value as JsonValue;
 use serverless_otlp_forwarder::{
     collectors::Collectors, processing::process_telemetry_batch, telemetry::TelemetryData,
     AppState, LogsEventWrapper,
 };
-use lambda_runtime::{tower::ServiceBuilder, Error as LambdaError, LambdaEvent, Runtime};
-use otlp_sigv4_client::SigV4ClientBuilder;
-use serde_json::Value as JsonValue;
 use std::sync::Arc;
 
 use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};

--- a/forwarders/experimental/aws-span-processor/processor/src/main.rs
+++ b/forwarders/experimental/aws-span-processor/processor/src/main.rs
@@ -17,7 +17,7 @@ mod otlp;
 use anyhow::Result;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_lambda_events::event::cloudwatch_logs::LogEntry;
-use lambda_otlp_forwarder::{
+use serverless_otlp_forwarder::{
     collectors::Collectors, processing::process_telemetry_batch, telemetry::TelemetryData,
     AppState, LogsEventWrapper,
 };

--- a/forwarders/experimental/aws-span-processor/samconfig.toml
+++ b/forwarders/experimental/aws-span-processor/samconfig.toml
@@ -11,9 +11,7 @@ capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
   "CollectorsSecretsKeyPrefix=serverless-otlp-forwarder/keys",
   "CollectorsCacheTtlSeconds=300",
-  "SpanLogGroupName=aws/spans",
-  "VpcId=",
-  "SubnetIds="
+  "SpanLogGroupName=aws/spans"
 ]
 image_repositories = []
 

--- a/forwarders/experimental/aws-span-processor/samconfig.toml
+++ b/forwarders/experimental/aws-span-processor/samconfig.toml
@@ -8,6 +8,12 @@ resolve_s3 = true
 s3_prefix = "aws-span-processor"
 region = "us-east-1"
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "CollectorsSecretsKeyPrefix=\"serverless-otlp-forwarder/keys\" CollectorsCacheTtlSeconds=\"300\" SpanLogGroupName=\"aws/spans\" VpcId=\"\" SubnetIds=\"\""
+parameter_overrides = [
+  "CollectorsSecretsKeyPrefix=serverless-otlp-forwarder/keys",
+  "CollectorsCacheTtlSeconds=300",
+  "SpanLogGroupName=aws/spans",
+  "VpcId=",
+  "SubnetIds="
+]
 image_repositories = []
 

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/example/app.py
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/example/app.py
@@ -1,0 +1,86 @@
+"""
+Simple Hello World Lambda function using lambda-otel-lite.
+
+This example demonstrates basic OpenTelemetry setup with lambda-otel-lite.
+It creates spans for each invocation and logs the event payload using span events.
+"""
+
+import json
+import random
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.trace import StatusCode
+
+from lambda_otel_lite import (
+    api_gateway_v2_extractor,
+    create_traced_handler,
+    init_telemetry,
+)
+
+# Initialize telemetry once at module load
+tracer, completion_handler = init_telemetry()
+
+# Create a traced handler with configuration
+traced = create_traced_handler(
+    name="simple-handler",
+    completion_handler=completion_handler,
+    attributes_extractor=api_gateway_v2_extractor,
+)
+
+
+def nested_function(event: dict[str, Any]) -> str:
+    """Simple nested function that creates its own span.
+
+    This function demonstrates how to create a child span from the current context.
+    The span will automatically become a child of the currently active span.
+    """
+    # Create a child span - it will automatically use the active span as parent
+    with tracer.start_as_current_span("nested_function") as span:
+        span.add_event("Nested function called")
+        if event.get("rawPath") == "/error":
+            # simulate a random error
+            r = random.random()
+            if r < 0.25:
+                raise ValueError("expected error")
+            elif r < 0.5:
+                raise RuntimeError("unexpected error")
+        return "success"
+
+
+@traced
+def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Lambda handler function.
+
+    This example shows how to:
+    1. Use the traced decorator for automatic span creation
+    2. Access the current span via OpenTelemetry API
+    3. Create child spans for nested operations
+    4. Add custom attributes and events
+    """
+    current_span = trace.get_current_span()
+    request_id = context.aws_request_id
+    current_span.add_event(
+        "handling request",
+        {
+            "event": json.dumps(event)
+        },
+    )
+    current_span.set_attribute("request.id", request_id)
+
+    try:
+        nested_function(event)
+        # Return a simple response
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"message": f"Hello from request {request_id}"}),
+        }
+    except ValueError as e:
+        current_span.record_exception(e)
+        current_span.set_status(StatusCode.ERROR, str(e))
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"message": str(e)}),
+        }
+    except RuntimeError:
+        raise

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/example/requirements.txt
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/example/requirements.txt
@@ -1,0 +1,1 @@
+lambda_otel_lite>=0.12.0

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/layer/Cargo.toml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/layer/Cargo.toml
@@ -1,10 +1,18 @@
 [package]
 name = "otlp-stdout-kinesis-extension-layer"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 authors.workspace = true
 license.workspace = true
 description = "OpenTelemetry Lambda extension for sending otlp data to Kinesis"
+
+[[bin]]
+name = "otlp-stdout-kinesis-extension-layer-arm64"
+path = "src/main.rs"
+
+[[bin]]
+name = "otlp-stdout-kinesis-extension-layer-amd64" 
+path = "src/main.rs"
 
 [dependencies]
 tokio.workspace = true
@@ -13,3 +21,5 @@ aws-config.workspace = true
 aws-sdk-kinesis.workspace = true
 lambda-extension.workspace = true
 uuid.workspace = true
+serde_json.workspace = true
+chrono.workspace = true

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/layer/Makefile
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/layer/Makefile
@@ -3,8 +3,17 @@
 # The extension is used to capture and process Lambda telemetry events
 
 
-build-StdoutKinesisOTLPLayer:
-	@echo "Building Rust extension layer"
-	@cargo lambda build --release --extension --arm64
+build-ExtensionLayerARM64:
+	@echo "Building Rust extension layer for ARM64"
+	@cargo lambda build --release --extension --arm64 --bin otlp-stdout-kinesis-extension-layer-arm64
 	@echo "Copying extension layer to artifacts directory"
-	@cp "$(shell cargo metadata --format-version=1 | jq -r '.target_directory')/lambda/extensions/otlp-stdout-kinesis-extension-layer" "$(ARTIFACTS_DIR)"
+	@mkdir -p "$(ARTIFACTS_DIR)/extensions"
+	@cp "$(shell cargo metadata --format-version=1 | jq -r '.target_directory')/lambda/extensions/otlp-stdout-kinesis-extension-layer-arm64" "$(ARTIFACTS_DIR)/extensions/"
+	@chmod +x "$(ARTIFACTS_DIR)/extensions/otlp-stdout-kinesis-extension-layer-arm64"
+build-ExtensionLayerAMD64:
+	@echo "Building Rust extension layer for AMD64"
+	@cargo lambda build --release --extension --x86-64 --bin otlp-stdout-kinesis-extension-layer-amd64
+	@echo "Copying extension layer to artifacts directory"
+	@mkdir -p "$(ARTIFACTS_DIR)/extensions"
+	@cp "$(shell cargo metadata --format-version=1 | jq -r '.target_directory')/lambda/extensions/otlp-stdout-kinesis-extension-layer-amd64" "$(ARTIFACTS_DIR)/extensions/"	
+	@chmod +x "$(ARTIFACTS_DIR)/extensions/otlp-stdout-kinesis-extension-layer-amd64"

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/layer/src/main.rs
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/layer/src/main.rs
@@ -1,49 +1,81 @@
 use aws_sdk_kinesis::primitives::Blob;
 use aws_sdk_kinesis::Client as KinesisClient;
 use lambda_extension::{
-    service_fn, tracing, Error, Extension, LambdaTelemetry, LambdaTelemetryRecord, SharedService,
+    service_fn, tracing, Error, Extension, LambdaTelemetry, LambdaTelemetryRecord, LogBuffering, SharedService,
+    LambdaEvent, NextEvent
 };
 use std::env;
 use std::sync::Arc;
 use uuid::Uuid;
+use aws_sdk_kinesis::types::PutRecordsRequestEntry;
+use tokio::sync::Mutex;
+use serde_json::json;
 
 // Kinesis limit for a single record
 const MAX_RECORD_SIZE_BYTES: usize = 1_048_576; // 1MB per record
+const ENV_VAR_STREAM_NAME: &str = "OTLP_STDOUT_KINESIS_STREAM_NAME";
+const RECORD_PREFIX: &str = r#"{"__otel_otlp_stdout":"#;
+
+// Default buffering values
+const DEFAULT_BUFFER_TIMEOUT_MS: u32 = 100;
+const DEFAULT_BUFFER_MAX_BYTES: usize = 256 * 1024; // 256KB
+const DEFAULT_BUFFER_MAX_ITEMS: usize = 1000;
+
+// Environment variable names for buffering config
+const ENV_VAR_BUFFER_TIMEOUT_MS: &str = "OTLP_STDOUT_KINESIS_BUFFER_TIMEOUT_MS";
+const ENV_VAR_BUFFER_MAX_BYTES: &str = "OTLP_STDOUT_KINESIS_BUFFER_MAX_BYTES";
+const ENV_VAR_BUFFER_MAX_ITEMS: &str = "OTLP_STDOUT_KINESIS_BUFFER_MAX_ITEMS";
 
 #[derive(Debug)]
-struct ExtensionConfig {
+struct Config {
     kinesis_stream_name: String,
+    buffer_timeout_ms: u32,
+    buffer_max_bytes: usize,
+    buffer_max_items: usize,
 }
 
-impl ExtensionConfig {
+impl Config {
     fn from_env() -> Result<Self, Error> {
+        // Parse required stream name
+        let kinesis_stream_name = env::var(ENV_VAR_STREAM_NAME)
+            .map_err(|e| Error::from(format!(
+                "Failed to get stream name: {}. Make sure to set the {} environment variable.", e, ENV_VAR_STREAM_NAME
+            )))?;
+        
+        // Parse optional buffering config with defaults
+        let buffer_timeout_ms = env::var(ENV_VAR_BUFFER_TIMEOUT_MS)
+            .map(|v| v.parse::<u32>().unwrap_or(DEFAULT_BUFFER_TIMEOUT_MS))
+            .unwrap_or(DEFAULT_BUFFER_TIMEOUT_MS);
+            
+        let buffer_max_bytes = env::var(ENV_VAR_BUFFER_MAX_BYTES)
+            .map(|v| v.parse::<usize>().unwrap_or(DEFAULT_BUFFER_MAX_BYTES))
+            .unwrap_or(DEFAULT_BUFFER_MAX_BYTES);
+            
+        let buffer_max_items = env::var(ENV_VAR_BUFFER_MAX_ITEMS)
+            .map(|v| v.parse::<usize>().unwrap_or(DEFAULT_BUFFER_MAX_ITEMS))
+            .unwrap_or(DEFAULT_BUFFER_MAX_ITEMS);
+        
+        tracing::debug!(
+            "Configuration: buffer_timeout_ms={}, buffer_max_bytes={}, buffer_max_items={}",
+            buffer_timeout_ms, buffer_max_bytes, buffer_max_items
+        );
+        
         Ok(Self {
-            kinesis_stream_name: env::var("OTLP_STDOUT_KINESIS_STREAM_NAME")
-                .map_err(|e| Error::from(format!("Failed to get stream name: {}", e)))?,
+            kinesis_stream_name,
+            buffer_timeout_ms,
+            buffer_max_bytes,
+            buffer_max_items,
         })
     }
 }
 
-struct TelemetryHandler {
-    kinesis_client: Arc<KinesisClient>,
-    stream_name: String,
+#[derive(Default)]
+struct KinesisBatch {
+    records: Vec<PutRecordsRequestEntry>,
 }
 
-impl TelemetryHandler {
-    async fn new() -> Result<Self, Error> {
-        let config = ExtensionConfig::from_env()?;
-
-        let aws_config = aws_config::from_env().load().await;
-
-        let kinesis_client = Arc::new(KinesisClient::new(&aws_config));
-
-        Ok(Self {
-            kinesis_client,
-            stream_name: config.kinesis_stream_name,
-        })
-    }
-
-    async fn send_record(&self, record: String) -> Result<(), Error> {
+impl KinesisBatch {
+    fn add_record(&mut self, record: String) -> Result<(), Error> {
         if record.len() > MAX_RECORD_SIZE_BYTES {
             tracing::warn!(
                 "Record size {} bytes exceeds maximum size of {} bytes, skipping",
@@ -53,45 +85,208 @@ impl TelemetryHandler {
             return Ok(());
         }
 
-        self.kinesis_client
-            .put_record()
-            .stream_name(&self.stream_name)
+        match PutRecordsRequestEntry::builder()
             .data(Blob::new(record))
             .partition_key(Uuid::new_v4().to_string())
+            .build() {
+                Ok(entry) => {
+                    self.records.push(entry);
+                    Ok(())
+                },
+                Err(e) => {
+                    tracing::error!("Failed to build Kinesis record entry: {}", e);
+                    Err(Error::from(e))
+                }
+            }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.records.clear();
+    }
+}
+
+// Application state
+struct AppState {
+    kinesis_client: KinesisClient,
+    stream_name: String,
+    batch: Mutex<KinesisBatch>,
+}
+
+impl AppState {
+    async fn flush_batch(&self) -> Result<(), Error> {
+        let mut batch = self.batch.lock().await;
+        if batch.is_empty() {
+            return Ok(());
+        }
+
+        tracing::debug!("Sending batch of {} records to Kinesis", batch.records.len());
+        
+        let result = self.kinesis_client
+            .put_records()
+            .stream_name(&self.stream_name)
+            .set_records(Some(batch.records.clone()))
             .send()
             .await
-            .map_err(|e| Error::from(format!("Failed to send record to Kinesis: {}", e)))?;
+            .map_err(|e| {
+                tracing::error!("Kinesis batch error: {}", e);
+                Error::from(format!("Failed to send records to Kinesis: {}", e))
+            })?;
 
+        // Check if any records failed
+        let failed_count = result.failed_record_count.unwrap_or(0);
+        if failed_count > 0 {
+            tracing::warn!("Failed to put {} records", failed_count);
+            
+            // Log details of failed records
+            let records = result.records();
+            for (i, record) in records.iter().enumerate() {
+                if let Some(error_code) = &record.error_code {
+                    tracing::warn!("Record {} failed with error: {} - {}", 
+                        i, 
+                        error_code, 
+                        record.error_message.as_deref().unwrap_or("No error message"));
+                }
+            }
+        } else {
+            tracing::debug!("Successfully sent all records to Kinesis");
+        }
+
+        batch.clear();
         Ok(())
     }
+}
+
+fn json_log(event_type: &str, record: &serde_json::Value, timestamp: &str) {
+    // Add type and timestamp to the JSON
+    let log_data = json!({
+        "timestamp": timestamp,
+        "level": "INFO",
+        "type": event_type,
+        "record": record
+    });
+    // Print the formatted JSON
+    println!("{}", serde_json::to_string(&log_data).unwrap_or_else(|_| String::from("{}")));
+}
+
+async fn telemetry_handler(events: Vec<LambdaTelemetry>, state: Arc<AppState>) -> Result<(), Error> {
+    for event in events {
+        // Use the event's timestamp for all logging
+        let timestamp = event.time.to_rfc3339();
+        
+        match event.record {
+            LambdaTelemetryRecord::Function(record) => {
+                // Process OTLP records for batching
+                if record.starts_with(RECORD_PREFIX) {
+                    let mut batch = state.batch.lock().await;
+                    batch.add_record(record)?;
+                }
+                // Skip other function logs
+            },
+            LambdaTelemetryRecord::PlatformInitStart { .. } => {
+                let record = serde_json::to_value(&event.record)
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                json_log("platform.initStart", &record, &timestamp);
+            },
+            LambdaTelemetryRecord::PlatformRuntimeDone { .. } => {
+                let record = serde_json::to_value(&event.record)
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                json_log("platform.runtimeDone", &record, &timestamp);
+            },
+            LambdaTelemetryRecord::PlatformReport { .. } => {
+                let record = serde_json::to_value(&event.record)
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                json_log("platform.report", &record, &timestamp);
+            },
+            LambdaTelemetryRecord::PlatformInitReport { .. } => {
+                let record = serde_json::to_value(&event.record)
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                json_log("platform.initReport", &record, &timestamp);
+            },
+            LambdaTelemetryRecord::PlatformLogsDropped { .. } => {
+                let record = serde_json::to_value(&event.record)
+                    .unwrap_or_else(|_| serde_json::json!({}));
+                // Use a different level for warnings
+                let log_data = json!({
+                    "timestamp": timestamp,
+                    "level": "WARN",
+                    "type": "platform.logsDropped",
+                    "record": record
+                });
+                println!("{}", serde_json::to_string_pretty(&log_data).unwrap_or_else(|_| String::from("{}")));
+            },
+            // Skip all other record types
+            _ => {}
+        }
+    }
+    
+    Ok(())
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing::init_default_subscriber();
-    tracing::info!("Starting Rust extension");
+    tracing::debug!("Starting OTLP Stdout Kinesis Extension");
 
-    let handler = Arc::new(TelemetryHandler::new().await?);
-    let handler_clone = handler.clone();
+    // Load configuration
+    let config = Config::from_env()?;
+    
+    // Initialize AWS services
+    let aws_config = aws_config::from_env().load().await;
+    let kinesis_client = KinesisClient::new(&aws_config);
+    
+    // Create app state with batch buffer
+    let app_state = Arc::new(AppState {
+        kinesis_client,
+        stream_name: config.kinesis_stream_name,
+        batch: Mutex::new(KinesisBatch::default()),
+    });
+    
+    let telemetry_state = app_state.clone();
+    let events_state = app_state.clone();
+    
+    // Create telemetry handler function
+    let handler_fn = move |events: Vec<LambdaTelemetry>| {
+        let state = telemetry_state.clone();
+        async move { telemetry_handler(events, state).await }
+    };
 
-    let telemetry_processor =
-        SharedService::new(service_fn(move |events: Vec<LambdaTelemetry>| {
-            let handler = handler_clone.clone();
-            async move {
-                for event in events {
-                    if let LambdaTelemetryRecord::Function(record) = event.record {
-                        if record.starts_with(r#"{"__otel_otlp_stdout":"#) {
-                            handler.send_record(record).await?;
-                        }
+    // Create events processor to handle INVOKE/SHUTDOWN
+    let events_processor = service_fn(|event: LambdaEvent| {
+        let state = events_state.clone();
+        async move {
+            match event.next {
+                NextEvent::Invoke(_) => {
+                    tracing::debug!("Received INVOKE event, flushing batched records");
+                    if let Err(e) = state.flush_batch().await {
+                        tracing::error!("Error flushing batch on INVOKE: {}", e);
                     }
                 }
-                Ok::<(), Error>(())
+                NextEvent::Shutdown(_) => {
+                    tracing::info!("Received SHUTDOWN event, ensuring all records are flushed");
+                    if let Err(e) = state.flush_batch().await {
+                        tracing::error!("Error flushing batch on SHUTDOWN: {}", e);
+                    }
+                }
             }
-        }));
+            Ok::<(), Error>(())
+        }
+    });
 
+    // Create and run extension with both processors
     Extension::new()
-        .with_telemetry_processor(telemetry_processor)
-        .with_telemetry_types(&["function"])
+        .with_events(&["INVOKE", "SHUTDOWN"])
+        .with_events_processor(events_processor)
+        .with_telemetry_processor(SharedService::new(service_fn(handler_fn)))
+        .with_telemetry_types(&["function", "platform"])
+        .with_telemetry_buffering(LogBuffering {
+            timeout_ms: config.buffer_timeout_ms as usize,
+            max_bytes: config.buffer_max_bytes,
+            max_items: config.buffer_max_items,
+        })
         .run()
         .await?;
 

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/samconfig.toml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/samconfig.toml
@@ -1,11 +1,15 @@
 version = 0.1
+
+[default.global.parameters]
+stack_name = "otlp-stdout-kinesis-extension"
+beta_features = "yes"
+
 [default.build.parameters]
 build_in_source = true
 
 [default.deploy.parameters]
-stack_name = "kinesis-extension"
 resolve_s3 = true
-s3_prefix = "kinesis-extension"
+s3_prefix = "otlp-stdout-kinesis-extension"
 region = "us-east-1"
 capabilities = "CAPABILITY_IAM"
 image_repositories = []

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/extension/template.yaml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/extension/template.yaml
@@ -4,13 +4,51 @@ Transform: AWS::Serverless-2016-10-31
 Description: AWS Lambda Extension that forwards OTLP records to OpenTelemetry collectors
 
 Resources:
-  StdoutKinesisOTLPLayer:
+  ExtensionLayerARM64:
     Type: AWS::Serverless::LayerVersion
     Metadata:
       BuildMethod: makefile
       BuildArchitecture: arm64
     Properties:
-      LayerName: !Sub '${AWS::StackName}-rust-extension'
+      RetentionPolicy: Retain
+      LayerName: !Sub '${AWS::StackName}-layer-arm64'
       ContentUri: layer/
       CompatibleArchitectures:
         - arm64
+      CompatibleRuntimes:
+        - python3.13
+
+  ExtensionLayerAMD64:
+    Type: AWS::Serverless::LayerVersion
+    Metadata:
+      BuildMethod: makefile
+      BuildArchitecture: arm64
+    Properties:
+      RetentionPolicy: Retain
+      LayerName: !Sub '${AWS::StackName}-layer-amd64'
+      ContentUri: layer/
+      CompatibleArchitectures:
+        - x86_64
+
+  ExampleFunctionARM64:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub '${AWS::StackName}-function-arm64'
+      CodeUri: example/
+      Handler: app.handler
+      Runtime: python3.13
+      Tracing: Active
+      Architectures:
+        - arm64
+      LoggingConfig:
+        LogFormat: JSON
+        ApplicationLogLevel: INFO
+        SystemLogLevel: WARN
+      Layers:
+        - !Ref ExtensionLayerARM64
+      Environment:
+        Variables:
+          OTLP_STDOUT_KINESIS_STREAM_NAME: !ImportValue serverless-otlp-forwarder-kinesis-processor:otlp-stream-name
+      Policies:
+        - KinesisCrudPolicy:
+            StreamName: !ImportValue serverless-otlp-forwarder-kinesis-processor:otlp-stream-name

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/processor/Cargo.toml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/processor/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "otlp-stdout-kinesis-processor"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-lambda-otlp-forwarder = { path = "../../../otlp-stdout-logs-processor/processor" }
+serverless-otlp-forwarder.workspace = true
 tokio.workspace = true
 anyhow.workspace = true
 lambda_runtime.workspace = true
@@ -17,6 +17,7 @@ lambda-otel-lite.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true
 otlp-sigv4-client.workspace = true
+otlp-stdout-span-exporter.workspace = true
 aws-config.workspace = true
 aws-credential-types.workspace = true
 serde_json.workspace = true
@@ -28,3 +29,7 @@ base64.workspace = true
 flate2.workspace = true
 prost.workspace = true
 opentelemetry-proto.workspace = true 
+
+[[bin]]
+name = "kinesis_processor"
+path = "src/main.rs"

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/processor/src/main.rs
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/processor/src/main.rs
@@ -19,7 +19,7 @@ use lambda_runtime::{tower::ServiceBuilder, Error as LambdaError, LambdaEvent, R
 use std::sync::Arc;
 
 use aws_credential_types::provider::ProvideCredentials;
-use lambda_otlp_forwarder::{
+use serverless_otlp_forwarder::{
     collectors::Collectors,
     processing::process_telemetry_batch,
     span_compactor::{compact_telemetry_payloads, SpanCompactionConfig},
@@ -27,25 +27,40 @@ use lambda_otlp_forwarder::{
     AppState, KinesisEventWrapper,
 };
 use otlp_sigv4_client::SigV4ClientBuilder;
+use otlp_stdout_span_exporter::ExporterOutput;
 
 use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 
 use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::trace::BatchSpanProcessor;
+use aws_lambda_events::event::kinesis::KinesisEventRecord;
 
 /// Convert a Kinesis record into TelemetryData
 fn convert_kinesis_record(
-    record: &aws_lambda_events::event::kinesis::KinesisEventRecord,
+    record: &KinesisEventRecord,
 ) -> Result<TelemetryData> {
-    let data = String::from_utf8(record.kinesis.data.0.clone())
+    let kinesis_record = &String::from_utf8(record.kinesis.data.to_vec())
         .context("Failed to decode Kinesis record data as UTF-8")?;
 
-    // Parse as a standard LogRecord
-    let log_record = serde_json::from_str(&data)
-        .with_context(|| format!("Failed to parse Kinesis record: {}", data))?;
+    tracing::debug!("Received Kinesis record: {}", kinesis_record);
+    
+    // Parse the JSON into a serde_json::Value first
+    let record: ExporterOutput = match serde_json::from_str(kinesis_record) {
+        Ok(output) => output,
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "Failed to parse Kinesis record as JSON: {} - Error details: {}",
+                kinesis_record,
+                err
+            ));
+        }
+    };
 
-    // Convert to TelemetryData (will be in uncompressed protobuf format)
-    TelemetryData::from_log_record(log_record)
+    tracing::debug!("Successfully parsed Kinesis record with version: {}", record.version);
+
+    // Convert to TelemetryData (input may be compressed and base64 encoded, 
+    // but output will be uncompressed protobuf format ready for compaction)
+    TelemetryData::from_log_record(record)
 }
 
 async fn function_handler(
@@ -192,30 +207,14 @@ mod tests {
         general_purpose::STANDARD.encode(compressed_bytes)
     }
 
-    #[test]
-    fn test_convert_kinesis_record() {
+    // Helper function to create a test Kinesis record
+    fn create_test_kinesis_record(payload_json: serde_json::Value) -> KinesisEventRecord {
         use aws_lambda_events::encodings::SecondTimestamp;
         use chrono::{TimeZone, Utc};
-        use serde_json::json;
 
-        // Create a valid test record with properly formatted payload
-        let log_record = json!({
-            "__otel_otlp_stdout": "0.2.2",
-            "source": "test-service",
-            "endpoint": "http://example.com",
-            "method": "POST",
-            "payload": create_test_payload(),
-            "headers": {
-                "content-type": "application/x-protobuf"
-            },
-            "content-type": "application/x-protobuf",
-            "content-encoding": "gzip",
-            "base64": true
-        });
+        let record_str = serde_json::to_string(&payload_json).unwrap();
 
-        let record_str = serde_json::to_string(&log_record).unwrap();
-
-        let record = KinesisEventRecord {
+        KinesisEventRecord {
             kinesis: KinesisRecord {
                 data: aws_lambda_events::encodings::Base64Data(record_str.as_bytes().to_vec()),
                 partition_key: "test-key".to_string(),
@@ -235,7 +234,29 @@ mod tests {
             ),
             event_version: Some("1.0".to_string()),
             invoke_identity_arn: Some("arn:aws:iam::123456789012:role/test-role".to_string()),
-        };
+        }
+    }
+
+    #[test]
+    fn test_convert_kinesis_record() {
+        use serde_json::json;
+
+        // Create a valid test record with properly formatted payload
+        let log_record = json!({
+            "__otel_otlp_stdout": "0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": create_test_payload(),
+            "headers": {
+                "content-type": "application/x-protobuf"
+            },
+            "content-type": "application/x-protobuf",
+            "content-encoding": "gzip",
+            "base64": true
+        });
+
+        let record = create_test_kinesis_record(log_record);
 
         let result = convert_kinesis_record(&record);
         if let Err(e) = &result {
@@ -281,5 +302,214 @@ mod tests {
 
         let result = convert_kinesis_record(&record);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_convert_uncompressed_payload() {
+        use serde_json::json;
+        use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+        
+        // Create a simple uncompressed protobuf payload
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans: vec![Span {
+                        name: "test-span".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        
+        // Convert to protobuf bytes without compression
+        let proto_bytes = request.encode_to_vec();
+        
+        // Base64 encode the uncompressed bytes
+        let uncompressed_payload = general_purpose::STANDARD.encode(&proto_bytes);
+        
+        // Create the log record
+        let log_record = json!({
+            "__otel_otlp_stdout": "0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": uncompressed_payload,
+            "headers": {
+                "content-type": "application/x-protobuf"
+            },
+            "content-type": "application/x-protobuf",
+            "content-encoding": "identity", // indicates no compression
+            "base64": true
+        });
+        
+        let record = create_test_kinesis_record(log_record);
+        
+        let result = convert_kinesis_record(&record);
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        assert_eq!(telemetry.source, "test-service");
+        assert_eq!(telemetry.content_type, "application/x-protobuf");
+        assert_eq!(telemetry.content_encoding, None); // No compression
+        
+        // Verify we can decode the payload
+        let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
+        assert_eq!(decoded.resource_spans.len(), 1);
+        
+        // Verify the span content is preserved
+        let span = &decoded.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(span.name, "test-span");
+    }
+    
+    #[test]
+    fn test_convert_json_payload() {
+        use serde_json::json;
+        
+        // Create a JSON payload (not protobuf)
+        let json_payload = json!({
+            "resourceSpans": [{
+                "scopeSpans": [{
+                    "spans": [{
+                        "name": "json-test-span"
+                    }]
+                }]
+            }]
+        });
+        
+        let json_bytes = serde_json::to_vec(&json_payload).unwrap();
+        let encoded_json = general_purpose::STANDARD.encode(&json_bytes);
+        
+        // Create the log record with JSON content type
+        let log_record = json!({
+            "__otel_otlp_stdout": "0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": encoded_json,
+            "headers": {
+                "content-type": "application/json"
+            },
+            "content-type": "application/json",
+            "content-encoding": "identity",
+            "base64": true
+        });
+        
+        let record = create_test_kinesis_record(log_record);
+        
+        let result = convert_kinesis_record(&record);
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        assert_eq!(telemetry.content_type, "application/x-protobuf"); // Should be converted to protobuf
+        
+        // Verify we can decode the converted payload as protobuf
+        let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
+        assert_eq!(decoded.resource_spans.len(), 1);
+        
+        // Verify the span content is preserved after JSON->protobuf conversion
+        let span = &decoded.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(span.name, "json-test-span");
+    }
+    
+    #[test]
+    fn test_base64_payload_integrity() {
+        use serde_json::json;
+        use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+        
+        // Create test data with specific identifiable content
+        let test_span_name = "unique-identifier-span-name-123";
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans: vec![Span {
+                        name: test_span_name.to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        
+        // Convert to protobuf bytes
+        let proto_bytes = request.encode_to_vec();
+        
+        // Compress with gzip
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&proto_bytes).unwrap();
+        let compressed_bytes = encoder.finish().unwrap();
+        
+        // Base64 encode
+        let encoded_payload = general_purpose::STANDARD.encode(&compressed_bytes);
+        
+        // Create the log record
+        let log_record = json!({
+            "__otel_otlp_stdout": "0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": encoded_payload,
+            "headers": {
+                "content-type": "application/x-protobuf"
+            },
+            "content-type": "application/x-protobuf",
+            "content-encoding": "gzip",
+            "base64": true
+        });
+        
+        let record = create_test_kinesis_record(log_record);
+        
+        // Process through our conversion function
+        let result = convert_kinesis_record(&record);
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        
+        // Decode the output payload
+        let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
+        
+        // Verify the data integrity - the unique span name should be preserved
+        assert_eq!(decoded.resource_spans.len(), 1);
+        let output_span = &decoded.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(output_span.name, test_span_name);
+    }
+    
+    #[test]
+    fn test_non_base64_payload() {
+        use serde_json::json;
+        
+        // Create a plain text payload that is not base64 encoded
+        let plain_text = "This is a test payload that is not base64 encoded";
+        
+        // Create the log record with base64 flag set to false
+        let log_record = json!({
+            "__otel_otlp_stdout": "0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": plain_text,
+            "headers": {
+                "content-type": "text/plain"
+            },
+            "content-type": "text/plain",
+            "content-encoding": "identity",
+            "base64": false
+        });
+        
+        let record = create_test_kinesis_record(log_record);
+        
+        let result = convert_kinesis_record(&record);
+        // This should process without error even though it's not a protobuf format
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        // The content type would still be set to protobuf as that's our standard format
+        assert_eq!(telemetry.content_type, "application/x-protobuf");
+        
+        // Note: We can't easily verify the payload content here as it would be
+        // treated as raw bytes, not proper protobuf. In a real scenario, this would
+        // likely cause problems later, but our conversion function doesn't validate this.
     }
 }

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/samconfig.toml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/samconfig.toml
@@ -12,8 +12,6 @@ capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
   "CollectorsSecretsKeyPrefix=serverless-otlp-forwarder/keys",
   "CollectorsCacheTtlSeconds=300",
-  "SubnetIds=",
-  "VpcId=",
   "KinesisStreamMode=PROVISIONED",
   "ShardCount=1"
 ]

--- a/forwarders/experimental/otlp-stdout-kinesis-processor/template.yaml
+++ b/forwarders/experimental/otlp-stdout-kinesis-processor/template.yaml
@@ -53,8 +53,10 @@ Resources:
     Type: AWS::Serverless::Function
     Metadata:
       BuildMethod: rust-cargolambda
+      BuildProperties:
+        Binary: kinesis_processor
     Properties:
-      FunctionName: !Ref 'AWS::StackName'
+      FunctionName: !Ref AWS::StackName
       Description: !Sub 'Processes OTLP data from Kinesis stream in AWS Account ${AWS::AccountId}'
       CodeUri: processor/
       Handler: bootstrap
@@ -133,3 +135,8 @@ Outputs:
     Condition: HasVpcConfig
     Value: !Ref KinesisProcessorSecurityGroup
 
+  KinesisStreamName:
+    Description: Name of the Kinesis stream
+    Value: !Ref OtlpKinesisStream
+    Export:
+      Name: !Sub '${AWS::StackName}:otlp-stream-name'

--- a/forwarders/otlp-stdout-logs-processor/config/.gitignore
+++ b/forwarders/otlp-stdout-logs-processor/config/.gitignore
@@ -1,0 +1,1 @@
+collector.yaml

--- a/forwarders/otlp-stdout-logs-processor/config/Makefile
+++ b/forwarders/otlp-stdout-logs-processor/config/Makefile
@@ -1,0 +1,4 @@
+build-CollectorConfiglLayer:
+	@echo "Copying collector.yaml to artifacts directory"
+	@cp collector.yaml  "$(ARTIFACTS_DIR)"/collector.yaml
+

--- a/forwarders/otlp-stdout-logs-processor/config/collector.example.yaml
+++ b/forwarders/otlp-stdout-logs-processor/config/collector.example.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "localhost:4317"
+      http:
+        endpoint: "localhost:4318"
+
+exporters:
+  otlp/traces:
+    endpoint: https://your-otlp-endpoint.com
+    headers:
+      your-api-key-header: <your-api-key>
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/traces]
+  telemetry:
+    metrics:
+      address: localhost:8888

--- a/forwarders/otlp-stdout-logs-processor/processor/Cargo.toml
+++ b/forwarders/otlp-stdout-logs-processor/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "lambda-otlp-forwarder"
-version = "0.1.0"
+name = "serverless-otlp-forwarder"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -40,5 +40,5 @@ chrono = "0.4.39"
 tokio = { version = "1.0", features = ["full"] }
 
 [[bin]]
-name = "stdout_processor"
+name = "logs_processor"
 path = "src/main.rs"

--- a/forwarders/otlp-stdout-logs-processor/processor/src/collectors.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/collectors.rs
@@ -39,6 +39,9 @@ pub struct Collector {
     /// Optional regex pattern to exclude certain log groups
     #[serde(default, deserialize_with = "deserialize_regex")]
     pub exclude: Option<Regex>,
+    /// Optional flag to disable the collector without removing it
+    #[serde(default)]
+    pub disabled: bool,
 }
 
 fn deserialize_regex<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>
@@ -160,16 +163,24 @@ impl Collectors {
         );
         tracing::debug!("Checking against {} collectors", cache.inner.items.len());
 
+        // Filter and transform collectors
         let result = cache
             .inner
             .items
             .iter()
             .filter_map(|collector| {
                 tracing::debug!(
-                    "Collector: {}, endpoint: {}",
+                    "Collector: {}, endpoint: {}, disabled: {}",
                     collector.name,
-                    collector.endpoint
+                    collector.endpoint,
+                    collector.disabled
                 );
+
+                // Skip disabled collectors
+                if collector.disabled {
+                    tracing::debug!("Collector {} is disabled, skipping", collector.name);
+                    return None;
+                }
 
                 if collector.should_exclude(source) {
                     tracing::debug!("Collector {} excluding source {}", collector.name, source);
@@ -188,6 +199,7 @@ impl Collectors {
                             endpoint,
                             auth: collector.auth.clone(),
                             exclude: collector.exclude.clone(),
+                            disabled: collector.disabled,
                         }))
                     }
                     Err(e) => {
@@ -202,7 +214,17 @@ impl Collectors {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        tracing::info!("Sending telemetry to {} collectors", result.len());
+        // If there are no collectors to send to, log a warning but don't return an error
+        if result.is_empty() {
+            tracing::warn!(
+                "No collectors available to send data to for source: {}, endpoint: {}",
+                source,
+                original_endpoint
+            );
+        } else {
+            tracing::info!("Sending telemetry to {} collectors", result.len());
+        }
+        
         Ok(result)
     }
 }
@@ -346,18 +368,25 @@ async fn fetch_collectors(client: &SecretsManagerClient) -> Result<Vec<Collector
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::*;
-    use std::sync::Once;
+    use std::cell::RefCell;
 
-    static INIT: Once = Once::new();
+    thread_local! {
+        static TEST_COLLECTOR: RefCell<Option<Collector>> = const { RefCell::new(None) };
+    }
 
     /// Initialize collectors with test data
     pub fn init_test_collectors(collector: Collector) {
-        INIT.call_once(|| {
+        TEST_COLLECTOR.with(|cell| {
+            *cell.borrow_mut() = Some(collector.clone());
+        });
+        
+        // If collectors are not initialized, do it now
+        if !Collectors::is_initialized() {
             let collectors = Collectors::new(vec![collector]);
             let cache = CollectorsCache::new(collectors);
             let mutex_cache = Arc::new(Mutex::new(cache));
             let _ = COLLECTORS.set(mutex_cache);
-        });
+        }
     }
 }
 
@@ -378,6 +407,25 @@ mod tests {
         });
         let collector: Collector = serde_json::from_value(valid_json).unwrap();
         assert_eq!(collector.auth, Some("x-api-key=your-api-key".to_string()));
+        assert!(!collector.disabled); // Default value
+
+        // Collector with disabled flag set
+        let disabled_json = json!({
+            "name": "disabled-collector",
+            "endpoint": "https://collector.example.com",
+            "disabled": true
+        });
+        let collector: Collector = serde_json::from_value(disabled_json).unwrap();
+        assert!(collector.disabled);
+
+        // Collector with disabled flag explicitly set to false
+        let enabled_json = json!({
+            "name": "enabled-collector",
+            "endpoint": "https://collector.example.com",
+            "disabled": false
+        });
+        let collector: Collector = serde_json::from_value(enabled_json).unwrap();
+        assert!(!collector.disabled);
 
         // Valid collector without auth
         let valid_no_auth = json!({
@@ -413,6 +461,7 @@ mod tests {
             endpoint: "https://collector.example.com".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
 
         // Test with simple path
@@ -427,6 +476,7 @@ mod tests {
             endpoint: "https://collector.example.com/base".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
         let result = collector_with_path
             .construct_signal_endpoint("https://original.com/v1/traces")
@@ -439,6 +489,7 @@ mod tests {
             endpoint: "https://collector.example.com/".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
         let result = collector_with_slash
             .construct_signal_endpoint("https://original.com/v1/traces")
@@ -451,6 +502,7 @@ mod tests {
             endpoint: "not a url".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
         assert!(collector
             .construct_signal_endpoint("https://original.com/v1/traces")
@@ -461,6 +513,7 @@ mod tests {
             endpoint: "https://collector.example.com".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
         assert!(collector.construct_signal_endpoint("not a url").is_err());
     }
@@ -474,6 +527,7 @@ mod tests {
             endpoint: "https://collector.example.com".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         }]);
 
         let cache = CollectorsCache::new(collectors);
@@ -557,6 +611,7 @@ mod tests {
             endpoint: "https://collector1.example.com".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
 
         let collector2 = Collector {
@@ -564,6 +619,7 @@ mod tests {
             endpoint: "https://collector2.example.com".to_string(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
 
         // Create a cache with just collector1

--- a/forwarders/otlp-stdout-logs-processor/processor/src/collectors.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/collectors.rs
@@ -224,7 +224,7 @@ impl Collectors {
         } else {
             tracing::info!("Sending telemetry to {} collectors", result.len());
         }
-        
+
         Ok(result)
     }
 }
@@ -379,7 +379,7 @@ pub(crate) mod test_utils {
         TEST_COLLECTOR.with(|cell| {
             *cell.borrow_mut() = Some(collector.clone());
         });
-        
+
         // If collectors are not initialized, do it now
         if !Collectors::is_initialized() {
             let collectors = Collectors::new(vec![collector]);

--- a/forwarders/otlp-stdout-logs-processor/processor/src/headers.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/headers.rs
@@ -34,7 +34,9 @@ impl LogRecordHeaders {
     /// Adds headers from the log record itself.
     /// This includes both custom headers and content-type/encoding headers.
     pub fn with_log_record(mut self, log_record: &ExporterOutput) -> Result<Self> {
-        self.extract_headers(&log_record.headers)?;
+        if let Some(headers) = &log_record.headers {
+            self.extract_headers(headers)?;
+        }
         self.add_content_headers(log_record)?;
         Ok(self)
     }
@@ -134,11 +136,11 @@ impl LogRecordHeaders {
     fn add_content_headers(&mut self, log_record: &ExporterOutput) -> Result<()> {
         self.0.insert(
             HeaderName::from_static(CONTENT_TYPE_HEADER),
-            HeaderValue::from_str(log_record.content_type)?,
+            HeaderValue::from_str(&log_record.content_type)?,
         );
         self.0.insert(
             HeaderName::from_static(CONTENT_ENCODING_HEADER),
-            HeaderValue::from_str(log_record.content_encoding)?,
+            HeaderValue::from_str(&log_record.content_encoding)?,
         );
         Ok(())
     }
@@ -156,21 +158,22 @@ mod tests {
     use aws_credential_types::Credentials;
     use std::collections::HashMap;
 
-    fn create_test_log_record() -> ExporterOutput<'static> {
+    fn create_test_log_record() -> ExporterOutput {
         let mut headers = HashMap::new();
         headers.insert("x-custom-header".to_string(), "custom-value".to_string());
         headers.insert("x-another-header".to_string(), "another-value".to_string());
 
         ExporterOutput {
-            version: "test",
+            version: "test".to_string() ,
             source: "test-source".to_string(),
-            endpoint: "http://example.com",
-            method: "POST",
-            content_type: "application/json",
-            content_encoding: "gzip",
-            headers,
+            endpoint: "http://example.com".to_string(),
+            method: "POST".to_string(),
+            content_type: "application/json".to_string(),
+            content_encoding: "gzip".to_string(),
+            headers: Some(headers),
             payload: "test-payload".to_string(),
             base64: true,
+            level: Some("info".to_string()),
         }
     }
 
@@ -296,15 +299,16 @@ mod tests {
         headers.insert("invalid header name".to_string(), "value".to_string());
 
         let log_record = ExporterOutput {
-            version: "test",
+            version: "test".to_string(),
             source: "test-source".to_string(),
-            endpoint: "http://example.com",
-            method: "POST",
-            content_type: "application/json",
-            content_encoding: "gzip",
-            headers,
+            endpoint: "http://example.com".to_string(),
+            method: "POST".to_string(),
+            content_type: "application/json".to_string(),
+            content_encoding: "gzip".to_string(),
+            headers: Some(headers),
             payload: "test-payload".to_string(),
             base64: true,
+            level: Some("info".to_string()),
         };
 
         let result = LogRecordHeaders::default().with_log_record(&log_record);
@@ -319,15 +323,16 @@ mod tests {
         headers.insert("x-test".to_string(), "invalid\u{0000}value".to_string());
 
         let log_record = ExporterOutput {
-            version: "test",
+            version: "test".to_string(),
             source: "test-source".to_string(),
-            endpoint: "http://example.com",
-            method: "POST",
-            content_type: "application/json",
-            content_encoding: "gzip",
-            headers,
+            endpoint: "http://example.com".to_string(),
+            method: "POST".to_string(),
+            content_type: "application/json".to_string(),
+            content_encoding: "gzip".to_string(),
+            headers: Some(headers),
             payload: "test-payload".to_string(),
             base64: true,
+            level: Some("info".to_string()),
         };
 
         let result = LogRecordHeaders::default().with_log_record(&log_record);

--- a/forwarders/otlp-stdout-logs-processor/processor/src/headers.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/headers.rs
@@ -164,7 +164,7 @@ mod tests {
         headers.insert("x-another-header".to_string(), "another-value".to_string());
 
         ExporterOutput {
-            version: "test".to_string() ,
+            version: "test".to_string(),
             source: "test-source".to_string(),
             endpoint: "http://example.com".to_string(),
             method: "POST".to_string(),

--- a/forwarders/otlp-stdout-logs-processor/processor/src/headers.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/headers.rs
@@ -239,6 +239,7 @@ mod tests {
             endpoint: "http://example.com".to_string(),
             auth: Some("x-api-key=test-key".to_string()),
             exclude: None,
+            disabled: false,
         };
 
         let headers = LogRecordHeaders::default()
@@ -261,6 +262,7 @@ mod tests {
             endpoint: "http://example.com".to_string(),
             auth: Some("sigv4".to_string()),
             exclude: None,
+            disabled: false,
         };
 
         let telemetry = create_test_telemetry();
@@ -348,6 +350,7 @@ mod tests {
             endpoint: "http://example.com".to_string(),
             auth: Some("unknown".to_string()),
             exclude: None,
+            disabled: false,
         };
 
         let result = LogRecordHeaders::default().with_collector_auth(
@@ -369,6 +372,7 @@ mod tests {
             endpoint: "http://example.com".to_string(),
             auth: Some("invalid-format".to_string()),
             exclude: None,
+            disabled: false,
         };
 
         let result = LogRecordHeaders::default().with_collector_auth(

--- a/forwarders/otlp-stdout-logs-processor/processor/src/main.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/main.rs
@@ -16,6 +16,8 @@
 use anyhow::Result;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_lambda_events::event::cloudwatch_logs::LogEntry;
+use otlp_sigv4_client::SigV4ClientBuilder;
+use otlp_stdout_span_exporter::ExporterOutput;
 use serverless_otlp_forwarder::{
     collectors::Collectors,
     processing::process_telemetry_batch,
@@ -23,8 +25,6 @@ use serverless_otlp_forwarder::{
     telemetry::TelemetryData,
     AppState, LogsEventWrapper,
 };
-use otlp_sigv4_client::SigV4ClientBuilder;
-use otlp_stdout_span_exporter::ExporterOutput;
 
 use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 
@@ -38,7 +38,7 @@ fn convert_log_event(event: &LogEntry) -> Result<TelemetryData> {
     let log_record = &event.message;
 
     tracing::debug!("Received log record: {}", log_record);
-    
+
     // Parse the JSON into a serde_json::Value first
     let record: ExporterOutput = match serde_json::from_str(log_record) {
         Ok(output) => output,
@@ -50,8 +50,11 @@ fn convert_log_event(event: &LogEntry) -> Result<TelemetryData> {
             ));
         }
     };
-    
-    tracing::debug!("Successfully parsed log record with version: {}", record.version);
+
+    tracing::debug!(
+        "Successfully parsed log record with version: {}",
+        record.version
+    );
 
     // Convert to TelemetryData (will be in uncompressed protobuf format)
     TelemetryData::from_log_record(record)
@@ -243,7 +246,7 @@ mod tests {
     #[test]
     fn test_convert_uncompressed_payload() {
         use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
-        
+
         // Create a simple uncompressed protobuf payload
         let request = ExportTraceServiceRequest {
             resource_spans: vec![ResourceSpans {
@@ -257,13 +260,13 @@ mod tests {
                 ..Default::default()
             }],
         };
-        
+
         // Convert to protobuf bytes without compression
         let proto_bytes = request.encode_to_vec();
-        
+
         // Base64 encode the uncompressed bytes
         let uncompressed_payload = general_purpose::STANDARD.encode(&proto_bytes);
-        
+
         // Create the log record
         let log_record = json!({
             "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
@@ -278,26 +281,26 @@ mod tests {
             "content-encoding": "identity", // indicates no compression
             "base64": true
         });
-        
+
         let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
-        
+
         let result = convert_log_event(&event);
         assert!(result.is_ok());
-        
+
         let telemetry = result.unwrap();
         assert_eq!(telemetry.source, "test-service");
         assert_eq!(telemetry.content_type, "application/x-protobuf");
         assert_eq!(telemetry.content_encoding, None); // No compression
-        
+
         // Verify we can decode the payload
         let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
         assert_eq!(decoded.resource_spans.len(), 1);
-        
+
         // Verify the span content is preserved
         let span = &decoded.resource_spans[0].scope_spans[0].spans[0];
         assert_eq!(span.name, "test-span");
     }
-    
+
     #[test]
     fn test_convert_json_payload() {
         // Create a JSON payload (not protobuf)
@@ -310,10 +313,10 @@ mod tests {
                 }]
             }]
         });
-        
+
         let json_bytes = serde_json::to_vec(&json_payload).unwrap();
         let encoded_json = general_purpose::STANDARD.encode(&json_bytes);
-        
+
         // Create the log record with JSON content type
         let log_record = json!({
             "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
@@ -328,28 +331,28 @@ mod tests {
             "content-encoding": "identity",
             "base64": true
         });
-        
+
         let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
-        
+
         let result = convert_log_event(&event);
         assert!(result.is_ok());
-        
+
         let telemetry = result.unwrap();
         assert_eq!(telemetry.content_type, "application/x-protobuf"); // Should be converted to protobuf
-        
+
         // Verify we can decode the converted payload as protobuf
         let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
         assert_eq!(decoded.resource_spans.len(), 1);
-        
+
         // Verify the span content is preserved after JSON->protobuf conversion
         let span = &decoded.resource_spans[0].scope_spans[0].spans[0];
         assert_eq!(span.name, "json-test-span");
     }
-    
+
     #[test]
     fn test_end_to_end_data_integrity() {
         use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
-        
+
         // Create test data with specific identifiable content
         let test_span_name = "unique-identifier-span-name-123";
         let request = ExportTraceServiceRequest {
@@ -364,18 +367,18 @@ mod tests {
                 ..Default::default()
             }],
         };
-        
+
         // Convert to protobuf bytes
         let proto_bytes = request.encode_to_vec();
-        
+
         // Compress with gzip
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
         encoder.write_all(&proto_bytes).unwrap();
         let compressed_bytes = encoder.finish().unwrap();
-        
+
         // Base64 encode
         let encoded_payload = general_purpose::STANDARD.encode(&compressed_bytes);
-        
+
         // Create the log record
         let log_record = json!({
             "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
@@ -390,24 +393,24 @@ mod tests {
             "content-encoding": "gzip",
             "base64": true
         });
-        
+
         let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
-        
+
         // Process through our conversion function
         let result = convert_log_event(&event);
         assert!(result.is_ok());
-        
+
         let telemetry = result.unwrap();
-        
+
         // Decode the output payload
         let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
-        
+
         // Verify the data integrity - the unique span name should be preserved
         assert_eq!(decoded.resource_spans.len(), 1);
         let output_span = &decoded.resource_spans[0].scope_spans[0].spans[0];
         assert_eq!(output_span.name, test_span_name);
     }
-    
+
     #[test]
     fn test_malformed_json() {
         // Test with invalid JSON
@@ -416,20 +419,20 @@ mod tests {
             timestamp: 1234567890,
             message: "This is not valid JSON".to_string(),
         };
-        
+
         let result = convert_log_event(&event);
         assert!(result.is_err());
-        
+
         // The error should contain a helpful message
         let error_msg = result.err().unwrap().to_string();
         assert!(error_msg.contains("Failed to parse log record as JSON"));
     }
-    
+
     #[test]
     fn test_non_base64_payload() {
         // Create a plain text payload that is not base64 encoded
         let plain_text = "This is a test payload that is not base64 encoded";
-        
+
         // Create the log record with base64 flag set to false
         let log_record = json!({
             "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
@@ -444,13 +447,13 @@ mod tests {
             "content-encoding": "identity",
             "base64": false
         });
-        
+
         let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
-        
+
         let result = convert_log_event(&event);
         // This should process without error even though it's not a protobuf format
         assert!(result.is_ok());
-        
+
         let telemetry = result.unwrap();
         // The content type would still be set to protobuf as that's our standard format
         assert_eq!(telemetry.content_type, "application/x-protobuf");

--- a/forwarders/otlp-stdout-logs-processor/processor/src/main.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/main.rs
@@ -13,10 +13,10 @@
 //! - Gzip compressed data
 //! - OpenTelemetry instrumentation
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_lambda_events::event::cloudwatch_logs::LogEntry;
-use lambda_otlp_forwarder::{
+use serverless_otlp_forwarder::{
     collectors::Collectors,
     processing::process_telemetry_batch,
     span_compactor::{compact_telemetry_payloads, SpanCompactionConfig},
@@ -25,8 +25,6 @@ use lambda_otlp_forwarder::{
 };
 use otlp_sigv4_client::SigV4ClientBuilder;
 use otlp_stdout_span_exporter::ExporterOutput;
-use std::collections::HashMap;
-use serde_json::Value;
 
 use lambda_otel_lite::{init_telemetry, OtelTracingLayer, TelemetryConfig};
 
@@ -37,81 +35,26 @@ use lambda_runtime::{tower::ServiceBuilder, Error as LambdaError, LambdaEvent, R
 use std::sync::Arc;
 /// Convert a CloudWatch log event into TelemetryData
 fn convert_log_event(event: &LogEntry) -> Result<TelemetryData> {
-    let record = &event.message;
+    let log_record = &event.message;
 
-    tracing::debug!("Received log record: {}", record);
+    tracing::debug!("Received log record: {}", log_record);
     
     // Parse the JSON into a serde_json::Value first
-    let json_value: Value = serde_json::from_str(record)
-        .with_context(|| format!("Failed to parse log record as JSON: {}", record))?;
-    
-    // Extract fields from the JSON, handling different field names and versions
-    let version = json_value.get("__otel_otlp_stdout")
-        .and_then(Value::as_str)
-        .unwrap_or("unknown");
-        
-    let source = json_value.get("source")
-        .and_then(Value::as_str)
-        .map(ToString::to_string)
-        .unwrap_or_else(|| "unknown".to_string());
-        
-    let endpoint = json_value.get("endpoint")
-        .and_then(Value::as_str)
-        .unwrap_or("http://localhost:4318/v1/traces");
-        
-    let method = json_value.get("method")
-        .and_then(Value::as_str)
-        .unwrap_or("POST");
-        
-    // Check both kebab-case and snake_case variants for content type
-    let content_type = json_value.get("content-type")
-        .or_else(|| json_value.get("content_type"))
-        .and_then(Value::as_str)
-        .unwrap_or("application/x-protobuf");
-        
-    // Same for content encoding
-    let content_encoding = json_value.get("content-encoding")
-        .or_else(|| json_value.get("content_encoding"))
-        .and_then(Value::as_str)
-        .unwrap_or("gzip");
-    
-    // Extract headers if present
-    let mut headers = HashMap::new();
-    if let Some(headers_obj) = json_value.get("headers").and_then(Value::as_object) {
-        for (key, value) in headers_obj {
-            if let Some(value_str) = value.as_str() {
-                headers.insert(key.clone(), value_str.to_string());
-            }
+    let record: ExporterOutput = match serde_json::from_str(log_record) {
+        Ok(output) => output,
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "Failed to parse log record as JSON: {} - Error details: {}",
+                log_record,
+                err
+            ));
         }
-    }
-    
-    // Get payload and base64 flag
-    let payload = json_value.get("payload")
-        .and_then(Value::as_str)
-        .map(ToString::to_string)
-        .unwrap_or_default();
-        
-    let base64 = json_value.get("base64")
-        .and_then(Value::as_bool)
-        .unwrap_or(true);
-    
-    // Create ExporterOutput with borrowed references where required
-    let exporter_output = ExporterOutput {
-        version,
-        source,
-        endpoint,
-        method,
-        content_type,
-        content_encoding,
-        headers,
-        payload,
-        base64,
     };
     
-    tracing::debug!("Successfully parsed log record with version: {}", version);
+    tracing::debug!("Successfully parsed log record with version: {}", record.version);
 
     // Convert to TelemetryData (will be in uncompressed protobuf format)
-    TelemetryData::from_log_record(exporter_output)
+    TelemetryData::from_log_record(record)
 }
 
 async fn function_handler(
@@ -254,6 +197,15 @@ mod tests {
         general_purpose::STANDARD.encode(compressed_bytes)
     }
 
+    // Helper function to create a test log entry
+    fn create_test_log_entry(message: String) -> LogEntry {
+        LogEntry {
+            id: "test-id".to_string(),
+            timestamp: 1234567890,
+            message,
+        }
+    }
+
     #[test]
     fn test_convert_log_event() {
         // Test standard LogRecord with valid OTLP structure
@@ -286,5 +238,221 @@ mod tests {
         assert_eq!(telemetry.source, "test-service");
         assert_eq!(telemetry.content_type, "application/x-protobuf"); // Now converted to protobuf
         assert_eq!(telemetry.content_encoding, None); // No compression at this stage
+    }
+
+    #[test]
+    fn test_convert_uncompressed_payload() {
+        use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+        
+        // Create a simple uncompressed protobuf payload
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans: vec![Span {
+                        name: "test-span".to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        
+        // Convert to protobuf bytes without compression
+        let proto_bytes = request.encode_to_vec();
+        
+        // Base64 encode the uncompressed bytes
+        let uncompressed_payload = general_purpose::STANDARD.encode(&proto_bytes);
+        
+        // Create the log record
+        let log_record = json!({
+            "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": uncompressed_payload,
+            "headers": {
+                "content-type": "application/x-protobuf"
+            },
+            "content-type": "application/x-protobuf",
+            "content-encoding": "identity", // indicates no compression
+            "base64": true
+        });
+        
+        let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
+        
+        let result = convert_log_event(&event);
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        assert_eq!(telemetry.source, "test-service");
+        assert_eq!(telemetry.content_type, "application/x-protobuf");
+        assert_eq!(telemetry.content_encoding, None); // No compression
+        
+        // Verify we can decode the payload
+        let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
+        assert_eq!(decoded.resource_spans.len(), 1);
+        
+        // Verify the span content is preserved
+        let span = &decoded.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(span.name, "test-span");
+    }
+    
+    #[test]
+    fn test_convert_json_payload() {
+        // Create a JSON payload (not protobuf)
+        let json_payload = json!({
+            "resourceSpans": [{
+                "scopeSpans": [{
+                    "spans": [{
+                        "name": "json-test-span"
+                    }]
+                }]
+            }]
+        });
+        
+        let json_bytes = serde_json::to_vec(&json_payload).unwrap();
+        let encoded_json = general_purpose::STANDARD.encode(&json_bytes);
+        
+        // Create the log record with JSON content type
+        let log_record = json!({
+            "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": encoded_json,
+            "headers": {
+                "content-type": "application/json"
+            },
+            "content-type": "application/json",
+            "content-encoding": "identity",
+            "base64": true
+        });
+        
+        let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
+        
+        let result = convert_log_event(&event);
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        assert_eq!(telemetry.content_type, "application/x-protobuf"); // Should be converted to protobuf
+        
+        // Verify we can decode the converted payload as protobuf
+        let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
+        assert_eq!(decoded.resource_spans.len(), 1);
+        
+        // Verify the span content is preserved after JSON->protobuf conversion
+        let span = &decoded.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(span.name, "json-test-span");
+    }
+    
+    #[test]
+    fn test_end_to_end_data_integrity() {
+        use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+        
+        // Create test data with specific identifiable content
+        let test_span_name = "unique-identifier-span-name-123";
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans: vec![Span {
+                        name: test_span_name.to_string(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+        
+        // Convert to protobuf bytes
+        let proto_bytes = request.encode_to_vec();
+        
+        // Compress with gzip
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&proto_bytes).unwrap();
+        let compressed_bytes = encoder.finish().unwrap();
+        
+        // Base64 encode
+        let encoded_payload = general_purpose::STANDARD.encode(&compressed_bytes);
+        
+        // Create the log record
+        let log_record = json!({
+            "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": encoded_payload,
+            "headers": {
+                "content-type": "application/x-protobuf"
+            },
+            "content-type": "application/x-protobuf",
+            "content-encoding": "gzip",
+            "base64": true
+        });
+        
+        let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
+        
+        // Process through our conversion function
+        let result = convert_log_event(&event);
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        
+        // Decode the output payload
+        let decoded = ExportTraceServiceRequest::decode(telemetry.payload.as_slice()).unwrap();
+        
+        // Verify the data integrity - the unique span name should be preserved
+        assert_eq!(decoded.resource_spans.len(), 1);
+        let output_span = &decoded.resource_spans[0].scope_spans[0].spans[0];
+        assert_eq!(output_span.name, test_span_name);
+    }
+    
+    #[test]
+    fn test_malformed_json() {
+        // Test with invalid JSON
+        let event = LogEntry {
+            id: "test-id".to_string(),
+            timestamp: 1234567890,
+            message: "This is not valid JSON".to_string(),
+        };
+        
+        let result = convert_log_event(&event);
+        assert!(result.is_err());
+        
+        // The error should contain a helpful message
+        let error_msg = result.err().unwrap().to_string();
+        assert!(error_msg.contains("Failed to parse log record as JSON"));
+    }
+    
+    #[test]
+    fn test_non_base64_payload() {
+        // Create a plain text payload that is not base64 encoded
+        let plain_text = "This is a test payload that is not base64 encoded";
+        
+        // Create the log record with base64 flag set to false
+        let log_record = json!({
+            "__otel_otlp_stdout": "otlp-stdout-span-exporter@0.2.2",
+            "source": "test-service",
+            "endpoint": "http://example.com",
+            "method": "POST",
+            "payload": plain_text,
+            "headers": {
+                "content-type": "text/plain"
+            },
+            "content-type": "text/plain",
+            "content-encoding": "identity",
+            "base64": false
+        });
+        
+        let event = create_test_log_entry(serde_json::to_string(&log_record).unwrap());
+        
+        let result = convert_log_event(&event);
+        // This should process without error even though it's not a protobuf format
+        assert!(result.is_ok());
+        
+        let telemetry = result.unwrap();
+        // The content type would still be set to protobuf as that's our standard format
+        assert_eq!(telemetry.content_type, "application/x-protobuf");
     }
 }

--- a/forwarders/otlp-stdout-logs-processor/processor/src/processing.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/processing.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use aws_credential_types::Credentials;
 use futures::future::join_all;
 use opentelemetry::trace::SpanKind;
@@ -6,6 +6,7 @@ use reqwest::{header::HeaderMap, Client as ReqwestClient};
 use tracing::{instrument, Instrument};
 
 use crate::{collectors::Collectors, headers::LogRecordHeaders, telemetry::TelemetryData};
+
 
 /// Sends telemetry data to a collector endpoint.
 /// Includes OpenTelemetry instrumentation for request tracking.
@@ -17,6 +18,8 @@ use crate::{collectors::Collectors, headers::LogRecordHeaders, telemetry::Teleme
     http.request.headers.content_type,
     http.request.headers.content_encoding,
     http.status_code,
+    error,
+    error.kind,
 ))]
 pub async fn send_telemetry(
     client: &ReqwestClient,
@@ -49,14 +52,42 @@ pub async fn send_telemetry(
         body = %base64_body,
         "Request details"
     );
-    // Send the request
-    let response = client
+    
+    // Send the request - handle errors explicitly rather than using ?
+    let response = match client
         .post(endpoint)
         .headers(headers)
         .body(telemetry.payload.clone())
         .send()
-        .await
-        .context("Failed to send POST request")?;
+        .await {
+            Ok(resp) => resp,
+            Err(e) => {
+                // Record essential error details in the span
+                current_span.record("otel.status_code", "ERROR");
+                current_span.record("error", true);
+                current_span.record("error.kind", if e.is_timeout() {
+                    "timeout"
+                } else if e.is_connect() {
+                    "connection_failed"
+                } else if e.is_request() {
+                    "request_failed"
+                } else {
+                    "network_error"
+                });
+                
+                // Log a concise error message
+                tracing::warn!(
+                    name = "error sending telemetry request",
+                    endpoint = %endpoint,
+                    error = %e,
+                    is_timeout = e.is_timeout(),
+                    is_connect = e.is_connect(),
+                    "Failed to send telemetry"
+                );
+                
+                return Err(anyhow::anyhow!("Failed to send telemetry request: {}", e));
+            }
+        };
 
     let status = response.status();
 
@@ -110,6 +141,17 @@ pub async fn process_telemetry_batch(
                 // Get all collectors with proper signal paths
                 let collectors =
                     Collectors::get_signal_endpoints(&telemetry.endpoint, &source).await?;
+
+                // If no collectors are available, log a message and return success
+                // (this is not an error condition, just means nothing needs to be done)
+                if collectors.is_empty() {
+                    tracing::info!(
+                        "No collectors available for source: {}, endpoint: {}. Skipping processing.",
+                        source,
+                        telemetry.endpoint
+                    );
+                    return Ok(());
+                }
 
                 // Create futures for sending to each collector
                 let collector_tasks: Vec<_> = collectors
@@ -216,7 +258,8 @@ pub async fn process_telemetry_batch(
         }
     }
 
-    if has_success {
+    if has_success || errors.is_empty() {
+        // Either we had a success, or we had no errors (which can happen if there were no collectors)
         Ok(())
     } else {
         let error_msg = errors
@@ -328,6 +371,7 @@ mod tests {
             endpoint: mock_server.uri(),
             auth: None,
             exclude: None,
+            disabled: false,
         };
         test_utils::init_test_collectors(collector);
 
@@ -362,6 +406,7 @@ mod tests {
             endpoint: mock_server.uri(), // Use base URI
             auth: None,
             exclude: None,
+            disabled: false,
         };
         test_utils::init_test_collectors(collector);
 
@@ -379,5 +424,44 @@ mod tests {
         let result = process_telemetry_batch(records, &client, &credentials, "us-west-2").await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_disabled_collector() {
+        let mock_server = MockServer::start().await;
+
+        // This endpoint should never be called because the collector is disabled
+        Mock::given(method("POST"))
+            .and(path("/v1/traces"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0) // Expect this endpoint to never be called
+            .mount(&mock_server)
+            .await;
+
+        // Initialize collector with the disabled flag
+        use crate::collectors::{test_utils, Collector};
+
+        let collector = Collector {
+            name: "disabled-collector".to_string(),
+            endpoint: mock_server.uri(),
+            auth: None,
+            exclude: None,
+            disabled: true,
+        };
+        test_utils::init_test_collectors(collector);
+
+        let client = setup_test_client();
+        let mut telemetry = create_test_telemetry();
+        telemetry.endpoint = format!("{}/v1/traces", mock_server.uri()); // Add signal path
+
+        let records = vec![telemetry];
+        let credentials = Credentials::new("test-key", "test-secret", None, None, "test-provider");
+
+        // Process the batch with a disabled collector
+        let result = process_telemetry_batch(records, &client, &credentials, "us-west-2").await;
+
+        // Now we expect this to succeed since we handle disabled collectors gracefully
+        // The processor should log a warning but not error
+        assert!(result.is_ok(), "Expected success when all collectors are disabled, but got error: {:?}", result);
     }
 }

--- a/forwarders/otlp-stdout-logs-processor/processor/src/telemetry.rs
+++ b/forwarders/otlp-stdout-logs-processor/processor/src/telemetry.rs
@@ -143,7 +143,7 @@ impl TelemetryData {
     }
 
     /// Creates a TelemetryData instance from a LogRecord
-    pub fn from_log_record(record: ExporterOutput<'_>) -> Result<Self> {
+    pub fn from_log_record(record: ExporterOutput) -> Result<Self> {
         // Decode base64 payload
         let raw_payload = if record.base64 {
             general_purpose::STANDARD
@@ -156,8 +156,8 @@ impl TelemetryData {
         // Convert to uncompressed protobuf format
         let protobuf_payload = Self::convert_to_protobuf(
             raw_payload,
-            record.content_type,
-            Some(record.content_encoding),
+            &record.content_type,
+            Some(&record.content_encoding),
         )?;
 
         Ok(Self {
@@ -221,15 +221,16 @@ mod tests {
     #[test]
     fn test_from_log_record() {
         let record = ExporterOutput {
-            version: "test",
+            version: "test".to_string(),
             source: "test-service".to_string(),
-            endpoint: "http://example.com",
-            method: "POST",
+            endpoint: "http://example.com".to_string(),
+            method: "POST".to_string(),
             payload: create_test_payload(),
-            headers: HashMap::new(),
-            content_type: "application/x-protobuf",
-            content_encoding: "gzip",
+            headers: Some(HashMap::new()),
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: "gzip".to_string(),
             base64: true,
+            level: Some("info".to_string()),
         };
 
         let telemetry = TelemetryData::from_log_record(record).unwrap();

--- a/forwarders/otlp-stdout-logs-processor/samconfig.toml
+++ b/forwarders/otlp-stdout-logs-processor/samconfig.toml
@@ -1,20 +1,20 @@
 version = 0.1
 
 [default.global.parameters]
-stack_name = "otlp-stdout-kinesis-processor"
+stack_name = "otlp-stdout-logs-processor"
 beta_features = "yes"
 
 [default.deploy.parameters]
 resolve_s3 = true
-s3_prefix = "otlp-stdout-kinesis-processor"
+s3_prefix = "otlp-stdout-logs-processor"
 region = "us-east-1"
 capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
   "CollectorsSecretsKeyPrefix=serverless-otlp-forwarder/keys",
   "CollectorsCacheTtlSeconds=300",
-  "SubnetIds=",
+  "RouteAllLogs=yes",
   "VpcId=",
-  "KinesisStreamMode=PROVISIONED",
-  "ShardCount=1"
+  "SubnetIds="
 ]
 image_repositories = []
+confirm_changeset = true

--- a/forwarders/otlp-stdout-logs-processor/samconfig.toml
+++ b/forwarders/otlp-stdout-logs-processor/samconfig.toml
@@ -12,9 +12,6 @@ capabilities = "CAPABILITY_IAM"
 parameter_overrides = [
   "CollectorsSecretsKeyPrefix=serverless-otlp-forwarder/keys",
   "CollectorsCacheTtlSeconds=300",
-  "RouteAllLogs=yes",
-  "VpcId=",
-  "SubnetIds="
+  "RouteAllLogs=yes"
 ]
 image_repositories = []
-confirm_changeset = true

--- a/forwarders/otlp-stdout-logs-processor/template.yaml
+++ b/forwarders/otlp-stdout-logs-processor/template.yaml
@@ -34,7 +34,7 @@ Resources:
     Metadata:
       BuildMethod: rust-cargolambda
       BuildProperties:
-        Binary: stdout_processor
+        Binary: logs_processor
     Properties:
       FunctionName: !Ref AWS::StackName
       Description: !Sub "Processes logs from AWS Account ${AWS::AccountId}"


### PR DESCRIPTION
This pull request introduces several significant changes across multiple files, primarily focusing on updating dependencies, refactoring code for better maintainability, and adding new functionality. The key changes are summarized below:

### Dependency Updates:
* Updated `Cargo.toml` files to use workspace dependencies for `serverless-otlp-forwarder`, `tokio`, `anyhow`, and others, replacing specific path-based dependencies. [[1]](diffhunk://#diff-399b0e73babbff736d84b1391422aedee1673031efecc9b7ddf7f543ba887220L3-L13) [[2]](diffhunk://#diff-9d4883846d4a58f8f5e9a7018d9ab3c751a66016cbc24542afe7d5f7e5b44671L3-R10)

### Code Refactoring:
* Refactored `main.rs` in `aws-span-processor` to replace `lambda_otlp_forwarder` with `serverless_otlp_forwarder`.
* Refactored `Makefile` and `template.yaml` to support building and deploying both ARM64 and AMD64 versions of the extension layer. [[1]](diffhunk://#diff-695820d26439b284c4097a3f2f9a61a4296b0c421a5fdb7759eae411fc918464L6-R19) [[2]](diffhunk://#diff-695ed0a608ee0e6a09501cd3be88ef24c49f499a677e1fe4957285ba7bcb9a10L7-R54)

### New Features:
* Added a new example in `app.py` demonstrating basic OpenTelemetry setup with `lambda-otel-lite`.
* Enhanced `main.rs` in the `otlp-stdout-kinesis-processor` extension to include new buffering configurations and batch processing for Kinesis records. [[1]](diffhunk://#diff-16b0a49b1b0087cb43990beec18a8eea965df059a7113d112fcf6a35eec405efL4-R78) [[2]](diffhunk://#diff-16b0a49b1b0087cb43990beec18a8eea965df059a7113d112fcf6a35eec405efL56-R289)

### Configuration Changes:
* Updated `samconfig.toml` to include new stack names and enable beta features.
* Modified `samconfig.toml` in `aws-span-processor` to use array format for `parameter_overrides`.

### Documentation:
* Added detailed comments and docstrings in `app.py` to explain the new example functionality and usage.

These changes collectively improve the maintainability, functionality, and clarity of the codebase, while also enhancing the deployment process for different architectures.