### PR TITLE
release: node/otlp-stdout-span-exporter v0.13.0

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2025-04-14
+
+### Added
+- Added optional `level` field in the output for easier filtering in log aggregation systems
+- Added `LogLevel` enum with `Debug`, `Info`, `Warn`, and `Error` variants
+- Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` environment variable to set the log level
+- Added support for named pipe output as an alternative to stdout
+- Added `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variable to control output type ("pipe" or "stdout")
+- Added comprehensive tests for log level and named pipe output features
+
+### Changed
+- Named pipe output uses a fixed path at `/tmp/otlp-stdout-span-exporter.pipe` for consistency
+- Improved error handling with fallback to stdout when pipe is unavailable
+
 ## [0.11.0] - 2024-11-17
 
 ### Changed

--- a/packages/node/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/node/otlp-stdout-span-exporter/PUBLISHING.md
@@ -48,9 +48,13 @@ Before publishing a new version of `@dev7a/otlp-stdout-span-exporter`, ensure al
 3. Run linting: `npm run lint`
 4. Run tests: `npm test`
 5. Build package: `npm run build` (this will automatically generate the version.ts file)
-6. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
-7. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
-7. Tagging and publishing is done automatically by the CI pipeline
+6. **Create and switch to a release branch** following the pattern `release/<rust|node|python|>/<package-name>-v<version>`
+   - Example: `git checkout -b release/node/otlp-stdout-span-exporter-v0.13.0`
+7. **Commit all changes to the release branch**
+   - Example: `git add . && git commit -m "release node otlp-stdout-span-exporter v0.13.0"`
+8. Push the release branch to GitHub
+   - Example: `git push origin release/node/otlp-stdout-span-exporter-v0.13.0`
+9. Tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing
 - [ ] Verify package installation works: `npm install @dev7a/otlp-stdout-span-exporter`

--- a/packages/node/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/node/otlp-stdout-span-exporter/PUBLISHING.md
@@ -51,7 +51,7 @@ Before publishing a new version of `@dev7a/otlp-stdout-span-exporter`, ensure al
 6. **Create and switch to a release branch** following the pattern `release/<rust|node|python|>/<package-name>-v<version>`
    - Example: `git checkout -b release/node/otlp-stdout-span-exporter-v0.13.0`
 7. **Commit all changes to the release branch**
-   - Example: `git add . && git commit -m "release node otlp-stdout-span-exporter v0.13.0"`
+   - Example: `git add . && git commit -m "release: node/otlp-stdout-span-exporter v0.13.0"`
 8. Push the release branch to GitHub
    - Example: `git push origin release/node/otlp-stdout-span-exporter-v0.13.0`
 9. Tagging and publishing is done automatically by the CI pipeline

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -14,7 +14,8 @@ A Node.js span exporter that writes OpenTelemetry spans to stdout, using a custo
     "custom-header": "value"
   },
   "payload": "<base64-encoded-gzipped-protobuf>",
-  "base64": true
+  "base64": true,
+  "level": "DEBUG"
 }
 ```
 
@@ -29,6 +30,8 @@ Outputting telemetry data in this format directly to stdout makes the library ea
 - Applies GZIP compression with configurable levels
 - Detects service name from environment variables
 - Supports custom headers via environment variables
+- Supports log level for filtering in log aggregation systems
+- Supports writing to stdout or named pipe
 - Consistent JSON output format
 - Zero external HTTP dependencies
 - Lightweight and fast
@@ -49,10 +52,22 @@ You can create a simple tracer provider with the BatchSpanProcessor and the OTLP
 import { trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
+import { OTLPStdoutSpanExporter, LogLevel, OutputType } from '@dev7a/otlp-stdout-span-exporter';
 
-// Initialize the exporter
+// Initialize the exporter with default options (stdout output)
 const exporter = new OTLPStdoutSpanExporter({ gzipLevel: 6 });
+
+// Or with log level for filtering
+const debugExporter = new OTLPStdoutSpanExporter({ 
+  gzipLevel: 6,
+  logLevel: LogLevel.Debug
+});
+
+// Or with named pipe output
+const pipeExporter = new OTLPStdoutSpanExporter({
+  outputType: OutputType.Pipe  // Will write to /tmp/otlp-stdout-span-exporter.pipe
+});
+
 // Use batching processor for efficiency
 const processor = new BatchSpanProcessor(exporter);
 // Create a tracer provider
@@ -82,6 +97,28 @@ interface OTLPStdoutSpanExporterConfig {
   // GZIP compression level (0-9, where 0 is no compression and 9 is maximum compression)
   // Defaults to 6 if not specified
   gzipLevel?: number;
+  
+  // Log level for filtering in log aggregation systems
+  // If not specified, no level field will be included in the output
+  logLevel?: LogLevel;
+  
+  // Output type (stdout or pipe)
+  // Defaults to OutputType.Stdout if not specified
+  outputType?: OutputType;
+}
+
+// Available log levels
+enum LogLevel {
+  Debug = "DEBUG",
+  Info = "INFO",
+  Warn = "WARN",
+  Error = "ERROR"
+}
+
+// Available output types
+enum OutputType {
+  Stdout = "stdout",
+  Pipe = "pipe"
 }
 ```
 
@@ -90,7 +127,7 @@ The exporter follows a strict configuration precedence:
 2. Constructor parameters in config object
 3. Default values (lowest precedence)
 
-This means that if the `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL` environment variable is set, it will always take precedence over the configuration in the constructor.
+This means that if any of the environment variables are set, they will always take precedence over the configuration in the constructor.
 
 ### Environment Variables
 
@@ -101,6 +138,8 @@ The exporter respects the following environment variables:
 - `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (which take precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9). Defaults to 6. Takes precedence over the constructor parameter if set.
+- `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL`: Log level for filtering (debug, info, warn, error). If set, adds a `level` field to the output.
+- `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE`: Output type ("pipe" or "stdout"). Defaults to "stdout". If set to "pipe", writes to `/tmp/otlp-stdout-span-exporter.pipe`.
 
 >[!NOTE]
 >For security best practices, avoid including authentication credentials or sensitive information in headers. The serverless-otlp-forwarder infrastructure is designed to handle authentication at the destination, rather than embedding credentials in your telemetry data.
@@ -122,7 +161,8 @@ The exporter writes JSON objects to stdout with the following structure:
     "custom-header": "value"
   },
   "base64": true,
-  "payload": "<base64-encoded-gzipped-protobuf>"
+  "payload": "<base64-encoded-gzipped-protobuf>",
+  "level": "INFO"
 }
 ```
 
@@ -135,6 +175,13 @@ The exporter writes JSON objects to stdout with the following structure:
 - `headers` is the headers defined in the `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TRACES_HEADERS` environment variables.
 - `payload` is the base64-encoded, gzipped, Protobuf-serialized span data in OTLP format.
 - `base64` is a boolean flag to indicate if the payload is base64-encoded (always `true`).
+- `level` is the log level (only present if configured via constructor or environment variable).
+
+## Named Pipe Output
+
+When configured to use named pipe output (either via constructor or environment variable), the exporter will write to `/tmp/otlp-stdout-span-exporter.pipe` instead of stdout. This can be useful in environments where you want to process the telemetry data with a separate process.
+
+If the pipe doesn't exist or can't be written to, the exporter will automatically fall back to stdout with a warning.
 
 ## License
 
@@ -144,4 +191,4 @@ MIT
 
 - [GitHub](https://github.com/dev7a/serverless-otlp-forwarder) - The main project repository for the Serverless OTLP Forwarder project
 - [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/python/otlp-stdout-span-exporter) | [PyPI](https://pypi.org/project/otlp-stdout-span-exporter/) - The Python version of this exporter
-- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/rust/otlp-stdout-span-exporter) | [crates.io](https://crates.io/crates/otlp-stdout-span-exporter) - The Rust version of this exporter 
+- [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/rust/otlp-stdout-span-exporter) | [crates.io](https://crates.io/crates/otlp-stdout-span-exporter) - The Rust version of this exporter

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -1,5 +1,7 @@
 # Node.js OTLP Stdout Span Exporter
 
+[![npm version](https://img.shields.io/npm/v/@dev7a/otlp-stdout-span-exporter.svg)](https://www.npmjs.com/package/@dev7a/otlp-stdout-span-exporter)
+
 A Node.js span exporter that writes OpenTelemetry spans to stdout, using a custom serialization format that embeds the spans serialized as OTLP protobuf in the `payload` field. The message envelope carries metadata about the spans, such as the service name, the OTLP endpoint, and the HTTP method:
 
 ```json

--- a/packages/node/otlp-stdout-span-exporter/examples/simple-stdout-hello.ts
+++ b/packages/node/otlp-stdout-span-exporter/examples/simple-stdout-hello.ts
@@ -10,18 +10,22 @@
 import { trace, Span } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { OTLPStdoutSpanExporter } from '../src';
+import { LogLevel, OTLPStdoutSpanExporter, OutputType } from '../src';
 
 function initTracer(): NodeTracerProvider {
-  // Initialize the exporter
-  const exporter = new OTLPStdoutSpanExporter();
-  // Use batching processor for efficiency
-  const processor = new BatchSpanProcessor(exporter);
   // Create a tracer provider
   const provider = new NodeTracerProvider(
     {
       // Register the exporter with the provider
-      spanProcessors: [processor]
+      spanProcessors: [
+        new BatchSpanProcessor(new OTLPStdoutSpanExporter(
+          {
+            gzipLevel: 9,
+            logLevel: LogLevel.Info,
+            outputType: OutputType.Stdout,
+          }
+        ))
+      ]
     }
   );
 
@@ -31,18 +35,18 @@ function initTracer(): NodeTracerProvider {
   return provider;
 }
 
-async function main() {
+async function main(): Promise<void> {
   // Initialize tracing
   const provider = initTracer();
   const tracer = trace.getTracer('example/simple');
 
   // Create a parent span using the correct pattern
   await tracer.startActiveSpan('parent-operation', async (parentSpan: Span) => {
-    console.log('Doing work...');
+    parentSpan.addEvent('Doing work...');
 
     // Create a nested child span
     await tracer.startActiveSpan('child-operation', async (childSpan: Span) => {
-      console.log('Doing more work...');
+      childSpan.addEvent('Doing more work...');
       childSpan.end();
     });
 

--- a/packages/node/otlp-stdout-span-exporter/package-lock.json
+++ b/packages/node/otlp-stdout-span-exporter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.1.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dev7a/otlp-stdout-span-exporter",
-      "version": "0.1.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/core": "^1.30.1",
@@ -231,27 +231,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
+      "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -500,15 +500,15 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -544,9 +544,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.11.0",
+  "version": "0.13.0",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `@dev7a/otlp-stdout-span-exporter` package. The key changes include adding support for log levels and named pipe output, updating documentation, and modifying the publishing process.

### New Features:
* Added optional `level` field in the output for easier filtering in log aggregation systems.
* Introduced `LogLevel` enum with `Debug`, `Info`, `Warn`, and `Error` variants.
* Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` environment variable to set the log level.
* Added support for named pipe output as an alternative to stdout.
* Added `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variable to control output type ("pipe" or "stdout").

### Documentation Updates:
* Updated `README.md` to include new configuration options for log level and output type. [[1]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L17-R18) [[2]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752R33-R34) [[3]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L52-R70) [[4]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752R100-R121) [[5]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L93-R130) [[6]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752R141-R142) [[7]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752L125-R165) [[8]](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752R178-R184)
* Added version `0.13.0` details to `CHANGELOG.md`.
* Updated `PUBLISHING.md` with new release branch naming and publishing instructions.

### Code Changes:
* Updated example file `simple-stdout-hello.ts` to demonstrate new log level and output type features. [[1]](diffhunk://#diff-7f0424f9d0ef31a3f2ac8d472c8f1030431fa0d3567a083694b82619e87686a7L13-R28) [[2]](diffhunk://#diff-7f0424f9d0ef31a3f2ac8d472c8f1030431fa0d3567a083694b82619e87686a7L34-R49)
* Modified `package.json` and `package-lock.json` to reflect the new version `0.13.0`. [[1]](diffhunk://#diff-de9bcc5499221be2efd6fb53ecc3d3967208154d47830f6f69e94693d1ffafbeL3-R3) [[2]](diffhunk://#diff-c903540f5ea1d7cc1f6420e898e456f34965e8a2ea69a7a3961aa671c5ea4a22L3-R9) [[3]](diffhunk://#diff-c903540f5ea1d7cc1f6420e898e456f34965e8a2ea69a7a3961aa671c5ea4a22L234-R254) [[4]](diffhunk://#diff-c903540f5ea1d7cc1f6420e898e456f34965e8a2ea69a7a3961aa671c5ea4a22L503-R511) [[5]](diffhunk://#diff-c903540f5ea1d7cc1f6420e898e456f34965e8a2ea69a7a3961aa671c5ea4a22L547-R549)

### Testing:
* Added comprehensive tests for log level and named pipe output features. [[1]](diffhunk://#diff-0b74609b17a83ab78303de879512381862895897acb22edf246633a8c5c497d0L5-R9) [[2]](diffhunk://#diff-0b74609b17a83ab78303de879512381862895897acb22edf246633a8c5c497d0R25-R34) [[3]](diffhunk://#diff-0b74609b17a83ab78303de879512381862895897acb22edf246633a8c5c497d0R59-R60)