### PR TITLE
release: python/otlp-stdout-span-exporter v0.13.0

### DIFF
--- a/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0] - 2025-04-14
+
+### Added
+- Added `LogLevel` enum with `DEBUG`, `INFO`, `WARN`, and `ERROR` variants
+- Added optional `level` field in the output for easier filtering in log aggregation systems
+- Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` environment variable to set the log level
+- Added support for named pipe output as an alternative to stdout
+- Added `OutputType` enum with `STDOUT` and `PIPE` variants
+- Added `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variable to control output type ("pipe" or "stdout")
+- Added `Output` abstract class with implementations for stdout and named pipe
+- Added comprehensive tests for log level and named pipe output features
+
+### Changed
+- Named pipe output uses a fixed path at `/tmp/otlp-stdout-span-exporter.pipe` for consistency
+- Improved error handling with fallback to stdout when pipe is unavailable
+- Optimized pipe existence check to happen only once during initialization
+
 ## [0.11.0] - 2025-03-18
 
 ### Added

--- a/packages/python/otlp-stdout-span-exporter/PUBLISHING.md
+++ b/packages/python/otlp-stdout-span-exporter/PUBLISHING.md
@@ -66,8 +66,8 @@ This approach ensures that:
 6. Run tests: `pytest`
 7. Run coverage: `pytest --cov`
 8. Build package: `python -m build` (this will automatically generate the version.py file)
-9. Create a branch for the release following the pattern `release-<rust|node|python|>-<package-name>-v<version>`
-10. Commit changes to the release branch and push to GitHub, with a commit message of `release <rust|node|python|> <package-name> v<version>`
+9. Create a branch for the release following the pattern `release/<rust|node|python|>/<package-name>-v<version>`
+10. Commit changes to the release branch and push to GitHub, with a commit message of `release: <rust|node|python|>/<package-name> v<version>`
 10. Tagging and publishing is done automatically by the CI pipeline
 
 ## Post-Publishing

--- a/packages/python/otlp-stdout-span-exporter/README.md
+++ b/packages/python/otlp-stdout-span-exporter/README.md
@@ -1,5 +1,7 @@
 # OTLP Stdout Span Exporter for Python
 
+[![PyPI version](https://img.shields.io/pypi/v/otlp-stdout-span-exporter.svg)](https://pypi.org/project/otlp-stdout-span-exporter/)
+
 A Python span exporter that writes OpenTelemetry spans to stdout, using a custom serialization format that embeds the spans serialized as OTLP protobuf in the `payload` field. The message envelope carries metadata about the spans, such as the service name, the OTLP endpoint, and the HTTP method:
 
 ```json
@@ -15,7 +17,8 @@ A Python span exporter that writes OpenTelemetry spans to stdout, using a custom
     "custom-header": "value"
   },
   "payload": "<base64-encoded-gzipped-protobuf>",
-  "base64": true
+  "base64": true,
+  "level": "INFO"
 }
 ```
 
@@ -30,6 +33,8 @@ Outputting telemetry data in this format directly to stdout makes the library ea
 - Applies GZIP compression with configurable levels
 - Detects service name from environment variables
 - Supports custom headers via environment variables
+- Supports log level for filtering in log aggregation systems
+- Supports writing to stdout or named pipe
 - Consistent JSON output format
 - Zero external HTTP dependencies
 - Lightweight and fast
@@ -51,13 +56,26 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from otlp_stdout_span_exporter import OTLPStdoutSpanExporter
+from otlp_stdout_span_exporter.constants import LogLevel, OutputType
 
 # Create and set the tracer provider
 provider = TracerProvider()
 trace.set_tracer_provider(provider)
 
-# Create and register the exporter with optional GZIP compression level
+# Create and register the exporter with default options (stdout output)
 exporter = OTLPStdoutSpanExporter(gzip_level=6)
+
+# Or with log level for filtering
+debug_exporter = OTLPStdoutSpanExporter(
+    gzip_level=6,
+    log_level=LogLevel.DEBUG
+)
+
+# Or with named pipe output
+pipe_exporter = OTLPStdoutSpanExporter(
+    output_type=OutputType.PIPE  # Will write to /tmp/otlp-stdout-span-exporter.pipe
+)
+
 provider.add_span_processor(BatchSpanProcessor(exporter))
 
 # Your instrumentation code here
@@ -75,7 +93,15 @@ with tracer.start_as_current_span("my-operation") as span:
 OTLPStdoutSpanExporter(
     # GZIP compression level (0-9, where 0 is no compression and 9 is maximum compression)
     # Will be overridden by environment variable if set
-    gzip_level=9
+    gzip_level=6,
+    
+    # Log level for filtering in log aggregation systems
+    # If not specified, no level field will be included in the output
+    log_level=LogLevel.INFO,
+    
+    # Output type (stdout or pipe)
+    # Defaults to OutputType.STDOUT if not specified
+    output_type=OutputType.STDOUT
 )
 ```
 
@@ -88,6 +114,8 @@ The exporter respects the following environment variables:
 - `OTEL_EXPORTER_OTLP_HEADERS`: Headers for OTLP export, used in the `headers` field
 - `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Trace-specific headers (which take precedence if conflicting with `OTEL_EXPORTER_OTLP_HEADERS`)
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9). Defaults to 6.
+- `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL`: Log level for filtering (debug, info, warn, error). If set, adds a `level` field to the output.
+- `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE`: Output type ("pipe" or "stdout"). Defaults to "stdout". If set to "pipe", writes to `/tmp/otlp-stdout-span-exporter.pipe`.
 
 >[!IMPORTANT]
 >Environment variables always take precedence over constructor parameters. If both are specified, the environment variable value will be used.
@@ -113,12 +141,13 @@ The exporter writes JSON objects to stdout with the following structure:
     "custom-header": "value"
   },
   "base64": true,
-  "payload": "<base64-encoded-gzipped-protobuf>"
+  "payload": "<base64-encoded-gzipped-protobuf>",
+  "level": "INFO"
 }
 ```
 
 - `__otel_otlp_stdout` is a marker to identify the output of this exporter.
-- `source` is the emittingservice name.
+- `source` is the emitting service name.
 - `endpoint` is the OTLP endpoint (defaults to `http://localhost:4318/v1/traces` and just indicates the signal type. The actual endpoint is determined by the process that forwards the data).
 - `method` is the HTTP method (always `POST`).
 - `content-type` is the content type (always `application/x-protobuf`).
@@ -126,7 +155,13 @@ The exporter writes JSON objects to stdout with the following structure:
 - `headers` is the headers defined in the `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_TRACES_HEADERS` environment variables.
 - `payload` is the base64-encoded, gzipped, Protobuf-serialized span data in OTLP format.
 - `base64` is a boolean flag to indicate if the payload is base64-encoded (always `true`).
+- `level` is the log level (only present if configured via constructor or environment variable).
 
+## Named Pipe Output
+
+When configured to use named pipe output (either via constructor or environment variable), the exporter will write to `/tmp/otlp-stdout-span-exporter.pipe` instead of stdout. This can be useful in environments where you want to process the telemetry data with a separate process.
+
+If the pipe doesn't exist or can't be written to, the exporter will automatically fall back to stdout with a warning.
 
 ## License
 
@@ -137,4 +172,3 @@ MIT
 - [GitHub](https://github.com/dev7a/serverless-otlp-forwarder) - The main project repository for the Serverless OTLP Forwarder project
 - [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/node/otlp-stdout-span-exporter) | [npm](https://www.npmjs.com/package/@dev7a/otlp-stdout-span-exporter) - The Node.js version of this exporter
 - [GitHub](https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packages/rust/otlp-stdout-span-exporter) | [crates.io](https://crates.io/crates/otlp-stdout-span-exporter) - The Rust version of this exporter
-

--- a/packages/python/otlp-stdout-span-exporter/pyproject.toml
+++ b/packages/python/otlp-stdout-span-exporter/pyproject.toml
@@ -8,7 +8,7 @@ path = "src/otlp_stdout_span_exporter/version.py"
 
 [project]
 name = "otlp-stdout-span-exporter"
-version = "0.11.0"
+version = "0.13.0"
 description = "OpenTelemetry span exporter that writes to stdout in OTLP format"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/python/otlp-stdout-span-exporter/src/otlp_stdout_span_exporter/constants.py
+++ b/packages/python/otlp-stdout-span-exporter/src/otlp_stdout_span_exporter/constants.py
@@ -4,12 +4,16 @@ This file centralizes all constants to ensure consistency across the codebase
 and provide a single source of truth for configuration parameters.
 """
 
+from enum import Enum
+
 
 class EnvVars:
     """Environment variable names for configuration."""
 
     # OTLP Stdout Span Exporter configuration
     COMPRESSION_LEVEL = "OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL"
+    LOG_LEVEL = "OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL"
+    OUTPUT_TYPE = "OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE"
 
     # Service name configuration
     SERVICE_NAME = "OTEL_SERVICE_NAME"
@@ -26,9 +30,27 @@ class Defaults:
     COMPRESSION_LEVEL = 6
     SERVICE_NAME = "unknown-service"
     ENDPOINT = "http://localhost:4318/v1/traces"
+    OUTPUT_TYPE = "stdout"
+    PIPE_PATH = "/tmp/otlp-stdout-span-exporter.pipe"
 
 
 class ResourceAttributes:
     """Resource attribute keys used in the Lambda resource."""
 
     COMPRESSION_LEVEL = "lambda_otel_lite.otlp_stdout_span_exporter.compression_level"
+
+
+class LogLevel(str, Enum):
+    """Log level for the exported spans."""
+
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARN = "WARN"
+    ERROR = "ERROR"
+
+
+class OutputType(str, Enum):
+    """Output type for the exporter."""
+
+    STDOUT = "stdout"
+    PIPE = "pipe"


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `otlp-stdout-span-exporter` package. The changes include adding support for log levels, named pipe output, and enhancing error handling and documentation.

### New Features:
* Added `LogLevel` enum with `DEBUG`, `INFO`, `WARN`, and `ERROR` variants.
* Introduced `OutputType` enum with `STDOUT` and `PIPE` variants and the `Output` abstract class with implementations for stdout and named pipe. [[1]](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21) [[2]](diffhunk://#diff-ac25b49e75a4d28aa37ad68e4360f00a6c43d015ab2e244d37ee2e966d0039e4R33-R56) [[3]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R7-R137)
* Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` and `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variables for configuring log level and output type. [[1]](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21) [[2]](diffhunk://#diff-ac25b49e75a4d28aa37ad68e4360f00a6c43d015ab2e244d37ee2e966d0039e4R33-R56)

### Documentation Updates:
* Updated `README.md` to include a badge for PyPI version, examples of using the new log level and named pipe output features, and detailed descriptions of the new environment variables. [[1]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R3-R4) [[2]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L18-R21) [[3]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R36-R37) [[4]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R59-R78) [[5]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L78-R104) [[6]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R117-R118) [[7]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L116-R145) [[8]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R158-R164) [[9]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L140)

### Code Enhancements:
* Improved error handling with a fallback to stdout when the named pipe is unavailable and optimized pipe existence checks. [[1]](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21) [[2]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R7-R137) [[3]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R150-R160)
* Updated example scripts to demonstrate the usage of the new log level and output type features. [[1]](diffhunk://#diff-82625fea3406b20ad21ddaa789bbc0671af92d1d9cfd1e6837fff4cd1170cd08R20-R32) [[2]](diffhunk://#diff-82625fea3406b20ad21ddaa789bbc0671af92d1d9cfd1e6837fff4cd1170cd08L39-R49)

### Version Bump:
* Updated the version in `pyproject.toml` to `0.13.0` to reflect the new features and improvements.

### Publishing Process:
* Modified the branch naming and commit message patterns in `PUBLISHING.md` for consistency.This pull request introduces several new features and improvements to the `otlp-stdout-span-exporter` package. The key changes include the addition of support for log levels and named pipe output, updates to the documentation, and enhancements to error handling and configuration options.

### New Features:
* Added `LogLevel` enum with `DEBUG`, `INFO`, `WARN`, and `ERROR` variants. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)
* Introduced `OutputType` enum with `STDOUT` and `PIPE` variants, and an `Output` abstract class with implementations for stdout and named pipe. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)
* Added support for named pipe output as an alternative to stdout, with a fixed path at `/tmp/otlp-stdout-span-exporter.pipe`. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)
* Added `OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL` and `OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE` environment variables to control log level and output type. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)
* Comprehensive tests for log level and named pipe output features were added. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)

### Documentation Updates:
* Updated `README.md` to include information about the new log level and named pipe output features, and added a PyPI version badge. (`[[1]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R3-R4)`, `[[2]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L18-R21)`, `[[3]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R36-R37)`, `[[4]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R59-R78)`, `[[5]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L78-R104)`, `[[6]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R117-R118)`, `[[7]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L116-R145)`, `[[8]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3R158-R164)`, `[[9]](diffhunk://#diff-f4e9e70c391483ad61d0bb8322af2dd55e24c08178d4068601256b5f04af4cf3L140)`)
* Updated `PUBLISHING.md` to reflect the new branch naming convention for releases. (`[packages/python/otlp-stdout-span-exporter/PUBLISHING.mdL69-R70](diffhunk://#diff-78f33fa3d3ae8befe691a25678a3b2ea248edd3eaa126d6477c9582108c844faL69-R70)`)

### Code Enhancements:
* Improved error handling with fallback to stdout when the named pipe is unavailable. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)
* Optimized pipe existence check to happen only once during initialization. (`[packages/python/otlp-stdout-span-exporter/CHANGELOG.mdR5-R21](diffhunk://#diff-e14c6c1119e1a8b095bac5f2c1015beafb1c1926f41803f3c8e3691eb11bbf72R5-R21)`)
* Updated `pyproject.toml` to reflect the new version `0.13.0`. (`[packages/python/otlp-stdout-span-exporter/pyproject.tomlL11-R11](diffhunk://#diff-d4c81995df4c839297a9a7eb904abb7db782ccbb68c9f7254776307c11cb65efL11-R11)`)

### Example Updates:
* Updated `examples/simple_stdout_hello.py` to demonstrate the use of the new log level and named pipe output features. (`[[1]](diffhunk://#diff-82625fea3406b20ad21ddaa789bbc0671af92d1d9cfd1e6837fff4cd1170cd08R20-R32)`, `[[2]](diffhunk://#diff-82625fea3406b20ad21ddaa789bbc0671af92d1d9cfd1e6837fff4cd1170cd08L39-R49)`)

### Internal Refactoring:
* Introduced `StdOutput` and `NamedPipeOutput` classes to handle different output types. (`[[1]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R7-R137)`, `[[2]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R150-R160)`)
* Added functions `create_output` and `parse_log_level` to manage output creation and log level parsing. (`[[1]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R7-R137)`, `[[2]](diffhunk://#diff-6f6ef3067810563bd09e3ba03c3eca318d042d81f291e42dabf66c10c0e723c7R150-R160)`)

These changes enhance the functionality and flexibility of the `otlp-stdout-span-exporter` package, making it easier to filter logs and use named pipes for output in various environments.