### PR TITLE
release: rust/lambda-otel-lite v0.13.1

### DIFF
--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2025-03-29
+### Fixed
+- Changed propagator registration order to prioritize W3C TraceContext over X-Ray when both are present
+- Fixed handling of Sampled=0 in X-Ray trace headers to allow proper root span sampling
+- Improved context extraction logic from the _X_AMZN_TRACE_ID environment variable
+- Enhanced X-Ray propagation with better validity and sampling checks
+
 ## [0.13.0] - 2025-03-28
 ### Added
 - Added ability to programmatically set the processor mode via `TelemetryConfig.processor_mode`

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This pull request introduces a patch release (`0.13.1`) for the `lambda-otel-lite` package, focusing on improving X-Ray propagation, context extraction, and sampling logic. Key changes include enhancements to the propagator registration order, better handling of sampled traces, and improved environment variable usage. Below are the most important changes grouped by theme:

### Propagation and Sampling Improvements:
* Adjusted the propagator registration order to prioritize W3C TraceContext over AWS X-Ray, ensuring the last valid context wins during extraction (`src/telemetry.rs`).
* Enhanced X-Ray propagation logic to skip context extraction for `Sampled=0` in `_X_AMZN_TRACE_ID`, allowing root span sampling when X-Ray is disabled (`src/propagation.rs`).
* Added checks to ensure only valid and sampled contexts are extracted from `_X_AMZN_TRACE_ID` (`src/propagation.rs`).

### Codebase Enhancements:
* Introduced a constant (`AWS_XRAY_TRACE_ENV_VAR`) for `_X_AMZN_TRACE_ID` to improve readability and maintainability (`src/propagation.rs`).
* Removed redundant import of `TraceContextExt` in the `has_active_span` helper function (`src/propagation.rs`).

### Versioning and Documentation:
* Updated the package version to `0.13.1` in `Cargo.toml` to reflect the new release.
* Documented the changes in the `CHANGELOG.md`, highlighting fixes and improvements in propagation and sampling.