### PR TITLE
release: rust/otlp-stdout-span-exporter v0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "demo/rust",
     "benchmark",
     "benchmark/proxy", 
-    "packages/rust/lambda-otel-lite/examples"
+    "packages/rust/lambda-otel-lite/examples",
+    "cli/livetrace"
 ]
 
 resolver = "2"
@@ -39,36 +40,38 @@ futures-executor = "0.3.31"
 tokio-test = "0.4.4"
 
 # OpenTelemetry and tracing
-opentelemetry = { version = "0.28.0", features = ["trace"] }
-opentelemetry-http = { version = "0.28.0" }
-opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.28.0", features = ["http-proto", "http-json", "reqwest-client"] }
-opentelemetry-proto = { version = "0.28.0", features = ["gen-tonic", "trace"] }
-opentelemetry-aws = { version = "0.16.0", features = ["detector-aws-lambda"] }
+opentelemetry = { version = "0.29.1", features = ["trace"] }
+opentelemetry-http = { version = "0.29.0" }
+opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.29.0", features = ["http-proto", "http-json", "reqwest-client"] }
+opentelemetry-proto = { version = "0.29.0", features = ["gen-tonic", "trace"] }
+opentelemetry-aws = { version = "0.17.0", features = ["detector-aws-lambda"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-opentelemetry = "0.29.0"
+tracing-opentelemetry = "0.30.0"
 log = "0.4"
 reqwest-tracing = { version = "0.5.6", features = ["opentelemetry_0_28"] }
 
 # AWS related
-aws-config = { version = "1.5.7", features = ["behavior-version-latest"] }
-aws-smithy-runtime-api = { version = "1.7.3", features = ["http-1x"] }
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-sts = { version = "1", features = ["behavior-version-latest"] }
+aws-smithy-runtime-api = { version = "1", features = ["http-1x"] }
 aws_lambda_events = { version = "0.16.0", default-features = false, features = ["apigw", "alb", "sqs"] }
 lambda_runtime = { version = "0.13.0", features = ["anyhow", "tracing", "opentelemetry"] }
-aws-credential-types = "1.1.4"
+aws-credential-types = "1"
 aws-sdk-secretsmanager = { version = "1.48.0", features = ["behavior-version-latest"] }
-aws-sigv4 = "1.2.6"
+aws-sigv4 = "1"
 lambda-extension = "0.11.0"
 serde_dynamo = { version = "4.2.14", features = ["aws-sdk-dynamodb+1"] }
-aws-sdk-lambda = "1.59.0"
-aws-sdk-cloudformation = "1.26.0"
-aws-sdk-dynamodb = "1.43.0"
+aws-sdk-lambda = "1"
+aws-sdk-cloudformation = "1"
+aws-sdk-dynamodb = "1"
 aws-sdk-kinesis = { version = "1", default-features = false, features = ["rt-tokio"] }
+aws-sdk-cloudwatchlogs = { version = "1.76.0", features = ["behavior-version-latest"] }
 
 # HTTP and networking
 reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls"] }
-http = "1.1.0"
+http = "1.3.1"
 reqwest-middleware = "0.4.1"
 tower = "0.5.2"
 url = "2.5.3"
@@ -80,18 +83,18 @@ serde_yaml = "0.9"
 prost = "0.13.5"
 
 # Error handling
-thiserror = "2.0.4"
-anyhow = "1.0.94"
+thiserror = "2.0"
+anyhow = "1.0"
 
 # Utilities and helpers
 base64 = "0.22.1"
 flate2 = "1.0"
-regex = "1.11.1"
-pin-project = "1.1.8"
+regex = "1.11"
+pin-project = "1.1"
 bytes = "1.7"
-chrono = "0.4.39"
+chrono = "0.4"
 uuid = { version = "1.0", features = ["v4"] }
-urlencoding = "2.1.3"
+urlencoding = "2.1"
 bon = "3.5"
 lazy_static = "1.5.0"
 libc = "0.2"
@@ -101,6 +104,9 @@ statrs = "0.18.0"
 clap = { version = "4.4.8", features = ["derive"] }
 indicatif = { version = "0.17", features = ["improved_unicode"] }
 headless_chrome = "1.0.9"
+toml = "0.8.20"
+globset = "0.4"
+once_cell = "1.21.3"
 
 # Macros and code generation
 proc-macro2 = "1.0"
@@ -116,7 +122,13 @@ serial_test = "3.2.0"
 wiremock = "0.6"
 mockito = "1.2"
 doc-comment = "0.3"
-rand = "0.9.0"
+rand = "0.9"
+colored = "2.0"
+hex = "0.4"
+prettytable-rs = "0.10"
+nix = "0.29.0"
+scopeguard = "1.2"
+tempfile = "3.8"
 
 [profile.release]
 opt-level = "z"

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2024-06-07
+
+### Changed
+- Upgraded OpenTelemetry dependencies from 0.28.0 to 0.29.0
+- Updated API implementation to match OpenTelemetry SDK 0.29.0 changes
+- Addressed breaking changes and deprecations introduced in OpenTelemetry 0.29.0
+- Added separate example for named pipe and stdout output
+
 ## [0.13.0] - 2025-03-27
 
 ### Added

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -28,6 +28,7 @@ prost.workspace = true
 doc-comment.workspace = true
 log.workspace = true
 bon.workspace = true
+nix = { version = "0.29.0", features = ["fs"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/packages/rust/otlp-stdout-span-exporter/examples/README.md
+++ b/packages/rust/otlp-stdout-span-exporter/examples/README.md
@@ -1,0 +1,39 @@
+# OTLP Stdout Span Exporter Examples
+
+This directory contains example programs demonstrating how to use the `otlp-stdout-span-exporter` crate in different output modes.
+
+## Examples
+
+### 1. `simple-stdout-hello.rs`
+
+**Description:**
+- Exports OpenTelemetry spans directly to standard output (stdout) in OTLP format.
+
+**How to run:**
+```sh
+cargo run --example simple-stdout-hello
+```
+
+**Expected output:**
+- Span data will be printed to stdout as JSON lines.
+
+---
+
+### 2. `simple-pipe-hello.rs`
+
+**Description:**
+- Exports OpenTelemetry spans to a named pipe (`/tmp/otlp-stdout-span-exporter.pipe`) in OTLP format.
+- A background thread reads from the pipe and prints the output to stdout.
+
+**How to run:**
+```sh
+cargo run --example simple-pipe-hello
+```
+
+**Notes:**
+- The example will create the named pipe if it does not exist.
+- Output will be printed to stdout by the reader thread.
+
+---
+
+For more details, see the source code of each example. 

--- a/packages/rust/otlp-stdout-span-exporter/examples/simple-pipe-hello.rs
+++ b/packages/rust/otlp-stdout-span-exporter/examples/simple-pipe-hello.rs
@@ -1,21 +1,28 @@
+use nix::sys::stat::Mode;
+use nix::unistd::mkfifo;
 use opentelemetry::global;
 use opentelemetry::trace::{get_active_span, Tracer};
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use otlp_stdout_span_exporter::{LogLevel, OtlpStdoutSpanExporter};
 use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::thread;
 
 fn init_tracer() -> SdkTracerProvider {
     let mut headers: HashMap<String, String> = HashMap::new();
     headers.insert("test".to_string(), "test".to_string());
 
-    // Create exporter with the Debug log level and stdout output
+    // Create exporter with the Debug log level and named pipe output
     // You can also use environment variables:
     // OTLP_STDOUT_SPAN_EXPORTER_LOG_LEVEL=debug
-    // OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE=stdout
+    // OTLP_STDOUT_SPAN_EXPORTER_OUTPUT_TYPE=pipe
     let exporter = OtlpStdoutSpanExporter::builder()
         .headers(headers)
         .level(LogLevel::Debug)
+        .pipe(true) // Will write to /tmp/otlp-stdout-span-exporter.pipe
         .build();
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
@@ -27,7 +34,27 @@ fn init_tracer() -> SdkTracerProvider {
 
 #[tokio::main]
 async fn main() {
-    eprintln!("Writing spans to stdout with DEBUG level");
+    eprintln!("Writing spans to /tmp/otlp-stdout-span-exporter.pipe with DEBUG level");
+    eprintln!("Note: Make sure the named pipe exists (create with `mkfifo /tmp/otlp-stdout-span-exporter.pipe`)");
+
+    // Create the named pipe if it doesn't exist
+    let pipe_path = "/tmp/otlp-stdout-span-exporter.pipe";
+    if !Path::new(pipe_path).exists() {
+        mkfifo(pipe_path, Mode::S_IRWXU).expect("Failed to create FIFO");
+    }
+
+    // Spawn a thread to read from the pipe and write to stdout
+    let reader_path = pipe_path.to_string();
+    let handle = thread::spawn(move || {
+        let file = File::open(&reader_path).expect("Failed to open FIFO for reading");
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            match line {
+                Ok(l) => println!("{}", l),
+                Err(e) => eprintln!("Error reading from pipe: {:?}", e),
+            }
+        }
+    });
 
     let provider = init_tracer();
     let tracer = global::tracer("example/simple");
@@ -51,5 +78,7 @@ async fn main() {
         eprintln!("Error flushing provider: {:?}", err);
     }
 
-    eprintln!("Spans have been written to stdout");
+    eprintln!("Spans have been written to /tmp/otlp-stdout-span-exporter.pipe");
+    // Wait for the reader thread to finish
+    handle.join().expect("Reader thread panicked");
 }


### PR DESCRIPTION
This pull request updates the `otlp-stdout-span-exporter` crate to version 0.14.0 with significant changes, including dependency upgrades, new examples, and code refactoring for improved maintainability and compatibility with OpenTelemetry SDK 0.29.0. Below are the most important changes grouped by theme:

### Dependency and Version Updates:
* Upgraded OpenTelemetry dependencies from 0.28.0 to 0.29.0 and updated the API implementation to address breaking changes and deprecations introduced in the new version. (`packages/rust/otlp-stdout-span-exporter/CHANGELOG.md`, `Cargo.toml`) [[1]](diffhunk://#diff-51c986c5bb8e2e0e9f9c5ecc6f5ac74d2f94a63485f77b241081dc12820081ffR8-R15) [[2]](diffhunk://#diff-139d37c5c8f0270080968f69d2217b6dc710f974739d4ef4f2b7410ce95f9ee6L3-R3)
* Added the `nix` dependency with version 0.29.0 and `fs` feature enabled. (`Cargo.toml`)

### New Examples:
* Introduced two examples demonstrating the usage of the exporter:
  - [`simple-stdout-hello.rs`](diffhunk://#diff-1915b87b525de1444c80ac3933a402d1fd78cb9f612a7692dee0337674226f3bR1-R39): Exports spans to standard output in OTLP format. [[1]](diffhunk://#diff-1915b87b525de1444c80ac3933a402d1fd78cb9f612a7692dee0337674226f3bR1-R39) [[2]](diffhunk://#diff-54a778fe5f66ccda5e0c6dd793bf41e39b2b726acc044560e417a9faf83edbe8L12-L19) [[3]](diffhunk://#diff-54a778fe5f66ccda5e0c6dd793bf41e39b2b726acc044560e417a9faf83edbe8L31-R30) [[4]](diffhunk://#diff-54a778fe5f66ccda5e0c6dd793bf41e39b2b726acc044560e417a9faf83edbe8L56-R54)
  - [`simple-pipe-hello.rs`](diffhunk://#diff-1915b87b525de1444c80ac3933a402d1fd78cb9f612a7692dee0337674226f3bR1-R39): Exports spans to a named pipe with a reader thread printing the output to stdout. [[1]](diffhunk://#diff-1915b87b525de1444c80ac3933a402d1fd78cb9f612a7692dee0337674226f3bR1-R39) [[2]](diffhunk://#diff-4a83da88f6d6d70cb67ad9aa8083a51b35d120e89a347d0e069d390a65d96db4R1-R84)

### Code Refactoring:
* Updated the `export` method in the `OtlpStdoutSpanExporter` implementation to use `impl Future` instead of `BoxFuture`, simplifying the code. (`src/lib.rs`)
* Removed unnecessary `mut` qualifiers from exporter instances in test cases, improving code clarity. (`src/lib.rs`) [[1]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L869-R872) [[2]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L881-R884) [[3]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L944-R947) [[4]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L977-R980) [[5]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L1040-R1043)

### Documentation:
* Added a README file in the `examples` directory providing detailed instructions for running the new examples. (`examples/README.md`)

These updates enhance the functionality, usability, and maintainability of the `otlp-stdout-span-exporter` crate.