### PR TITLE
release: rust/lambda-otel-lite v0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,24 +50,24 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.30.0"
 log = "0.4"
-reqwest-tracing = { version = "0.5.6", features = ["opentelemetry_0_28"] }
+reqwest-tracing = { version = "0.5.7", features = ["opentelemetry_0_29"] }
 
 # AWS related
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-sts = { version = "1", features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = { version = "1", features = ["http-1x"] }
-aws_lambda_events = { version = "0.16.0", default-features = false, features = ["apigw", "alb", "sqs"] }
-lambda_runtime = { version = "0.13.0", features = ["anyhow", "tracing", "opentelemetry"] }
 aws-credential-types = "1"
-aws-sdk-secretsmanager = { version = "1.48.0", features = ["behavior-version-latest"] }
+aws-sdk-secretsmanager = { version = "1", features = ["behavior-version-latest"] }
 aws-sigv4 = "1"
-lambda-extension = "0.11.0"
-serde_dynamo = { version = "4.2.14", features = ["aws-sdk-dynamodb+1"] }
 aws-sdk-lambda = "1"
 aws-sdk-cloudformation = "1"
 aws-sdk-dynamodb = "1"
 aws-sdk-kinesis = { version = "1", default-features = false, features = ["rt-tokio"] }
-aws-sdk-cloudwatchlogs = { version = "1.76.0", features = ["behavior-version-latest"] }
+aws-sdk-cloudwatchlogs = { version = "1", features = ["behavior-version-latest"] }
+lambda_runtime = { version = "0.13.0", features = ["anyhow", "tracing", "opentelemetry"] }
+lambda-extension = "0.11.0"
+aws_lambda_events = { version = "0.16.0", default-features = false, features = ["apigw", "alb", "sqs"] }
+serde_dynamo = { version = "4.2.14", features = ["aws-sdk-dynamodb+1"] }
 
 # HTTP and networking
 reqwest = { version = "0.12.7", default-features = false, features = ["json", "rustls-tls"] }
@@ -135,3 +135,4 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
+

--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2025-04-21
+### Changed
+- Updated otlp-stdout-span-exporter dependency to version 0.14.0
+- Removed need to use Box::new() when creating OtlpStdoutSpanExporter instances
+- Updated SpanExporter trait implementation in testing code to match newer SDK
+- Simplified function names in example templates
+- Enhanced examples with better event handling and explicit attribute usage
+
 ## [0.13.1] - 2025-03-29
 ### Fixed
 - Changed propagator registration order to prioritize W3C TraceContext over X-Ray when both are present

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.13.1"
+version = "0.14.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -14,7 +14,8 @@ categories = ["development-tools::debugging", "web-programming::http-server"]
 exclude = ["examples/"]
 
 [dependencies]
-otlp-stdout-span-exporter = { version = "0.13.0" }
+# needs to be changed to the current version if publishing
+otlp-stdout-span-exporter = { version = "0.14.0" }
 
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true

--- a/packages/rust/lambda-otel-lite/PUBLISHING.md
+++ b/packages/rust/lambda-otel-lite/PUBLISHING.md
@@ -13,6 +13,7 @@ Before publishing a new version of `lambda-otel-lite`, ensure all these items ar
 - [ ] `homepage` URL is valid
 - [ ] `documentation` URL is specified
 - [ ] Dependencies are up-to-date and correct
+- [ ] Validate that otlp-stdout-span-exporter is not just using the workspace version, but is pinned to the last version
 - [ ] No extraneous dependencies
 - [ ] Development dependencies are in `[dev-dependencies]`
 - [ ] Feature flags are correctly defined

--- a/packages/rust/lambda-otel-lite/README.md
+++ b/packages/rust/lambda-otel-lite/README.md
@@ -325,7 +325,7 @@ use lambda_runtime::Error;
 async fn main() -> Result<(), Error> {
     let config = TelemetryConfig::builder()
         .with_span_processor(SimpleSpanProcessor::new(
-            Box::new(OtlpStdoutSpanExporter::default())
+            OtlpStdoutSpanExporter::default()
         ))
         .enable_fmt_layer(true)
         .build();

--- a/packages/rust/lambda-otel-lite/examples/samconfig.toml
+++ b/packages/rust/lambda-otel-lite/examples/samconfig.toml
@@ -1,0 +1,11 @@
+version = 0.1
+[default.global.parameters]
+beta_features = "yes"
+stack_name = "lambda-otel-lite-rust"
+
+[default.deploy.parameters]
+resolve_s3 = true
+s3_prefix = "lambda-otel-lite-rust"
+region = "us-east-1"
+capabilities = "CAPABILITY_IAM"
+image_repositories = []

--- a/packages/rust/lambda-otel-lite/examples/template.yaml
+++ b/packages/rust/lambda-otel-lite/examples/template.yaml
@@ -26,7 +26,7 @@ Resources:
       BuildProperties:
         Binary: handler-example
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-lambda-handler-example'
+      FunctionName: !Sub '${AWS::StackName}-handler-example'
       CodeUri: ./
       Handler: bootstrap
       Description: 'Demo Handler Example Lambda function to showcase OpenTelemetry integration'
@@ -44,7 +44,7 @@ Resources:
       BuildProperties:
         Binary: tower-example
     Properties:
-      FunctionName: !Sub '${AWS::StackName}-lambda-tower-example'
+      FunctionName: !Sub '${AWS::StackName}-tower-example'
       CodeUri: ./
       Handler: bootstrap
       Runtime: provided.al2023

--- a/packages/rust/lambda-otel-lite/src/extension.rs
+++ b/packages/rust/lambda-otel-lite/src/extension.rs
@@ -266,7 +266,6 @@ pub(crate) async fn register_extension(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::future::BoxFuture;
     use lambda_extension::{InvokeEvent, LambdaEvent};
     use opentelemetry_sdk::{
         trace::{SdkTracerProvider, SpanData, SpanExporter},
@@ -302,12 +301,13 @@ mod tests {
 
     impl SpanExporter for TestExporter {
         fn export(
-            &mut self,
+            &self,
             spans: Vec<SpanData>,
-        ) -> BoxFuture<'static, opentelemetry_sdk::error::OTelSdkResult> {
+        ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send
+        {
             self.export_count.fetch_add(spans.len(), Ordering::SeqCst);
             self.spans.lock().unwrap().extend(spans);
-            Box::pin(futures_util::future::ready(Ok(())))
+            futures_util::future::ready(Ok(()))
         }
     }
 

--- a/packages/rust/lambda-otel-lite/src/handler.rs
+++ b/packages/rust/lambda-otel-lite/src/handler.rs
@@ -279,7 +279,6 @@ where
 mod tests {
     use super::*;
     use crate::mode::ProcessorMode;
-    use futures_util::future::BoxFuture;
     use lambda_runtime::Context;
     use opentelemetry::trace::Status;
     use opentelemetry::trace::TracerProvider as _;
@@ -325,12 +324,13 @@ mod tests {
 
     impl SpanExporter for TestExporter {
         fn export(
-            &mut self,
+            &self,
             spans: Vec<SpanData>,
-        ) -> BoxFuture<'static, opentelemetry_sdk::error::OTelSdkResult> {
+        ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send
+        {
             self.export_count.fetch_add(spans.len(), Ordering::SeqCst);
             self.spans.lock().unwrap().extend(spans);
-            Box::pin(futures_util::future::ready(Ok(())))
+            futures_util::future::ready(Ok(()))
         }
     }
 

--- a/packages/rust/lambda-otel-lite/src/layer.rs
+++ b/packages/rust/lambda-otel-lite/src/layer.rs
@@ -374,7 +374,6 @@ where
 mod tests {
     use super::*;
     use crate::ProcessorMode;
-    use futures_util::future::BoxFuture;
     use lambda_runtime::Context;
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_sdk::{
@@ -404,11 +403,12 @@ mod tests {
 
     impl SpanExporter for CountingExporter {
         fn export(
-            &mut self,
+            &self,
             batch: Vec<SpanData>,
-        ) -> BoxFuture<'static, opentelemetry_sdk::error::OTelSdkResult> {
+        ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send
+        {
             self.export_count.fetch_add(batch.len(), Ordering::SeqCst);
-            Box::pin(futures_util::future::ready(Ok(())))
+            futures_util::future::ready(Ok(()))
         }
 
         fn shutdown(&mut self) -> opentelemetry_sdk::error::OTelSdkResult {

--- a/packages/rust/lambda-otel-lite/src/processor.rs
+++ b/packages/rust/lambda-otel-lite/src/processor.rs
@@ -364,7 +364,7 @@ where
                 return Ok(());
             }
 
-            let mut exporter = self.exporter.lock().map_err(|_| {
+            let exporter = self.exporter.lock().map_err(|_| {
                 OTelSdkError::InternalFailure(
                     "Failed to acquire exporter lock in force_flush".to_string(),
                 )
@@ -422,7 +422,7 @@ mod tests {
         trace::{SpanEvents, SpanLinks},
     };
     use serial_test::serial;
-    use std::{borrow::Cow, future::Future, pin::Pin, sync::Arc};
+    use std::{borrow::Cow, sync::Arc};
     use tokio::sync::Mutex;
 
     fn setup_test_logger() -> Logger {
@@ -445,9 +445,10 @@ mod tests {
 
     impl SpanExporter for MockExporter {
         fn export(
-            &mut self,
+            &self,
             batch: Vec<SpanData>,
-        ) -> Pin<Box<dyn Future<Output = OTelSdkResult> + Send>> {
+        ) -> impl std::future::Future<Output = opentelemetry_sdk::error::OTelSdkResult> + Send
+        {
             let spans = self.spans.clone();
             Box::pin(async move {
                 let mut spans = spans.lock().await;

--- a/packages/rust/lambda-otel-lite/src/telemetry.rs
+++ b/packages/rust/lambda-otel-lite/src/telemetry.rs
@@ -70,7 +70,7 @@
 //! async fn main() -> Result<(), Error> {
 //!     let config = TelemetryConfig::builder()
 //!         .with_span_processor(SimpleSpanProcessor::new(
-//!             Box::new(OtlpStdoutSpanExporter::default())
+//!             OtlpStdoutSpanExporter::default()
 //!         ))
 //!         .enable_fmt_layer(true)
 //!         .build();
@@ -341,7 +341,7 @@ impl<S: telemetry_config_builder::State> TelemetryConfigBuilder<S> {
     /// // Only use builder when adding custom processors
     /// let config = TelemetryConfig::builder()
     ///     .with_span_processor(SimpleSpanProcessor::new(
-    ///         Box::new(OtlpStdoutSpanExporter::default())
+    ///         OtlpStdoutSpanExporter::default()
     ///     ))
     ///     .build();
     /// ```
@@ -722,9 +722,7 @@ mod tests {
 
         // Test with explicit tracecontext propagator
         let config = TelemetryConfig::builder()
-            .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                OtlpStdoutSpanExporter::default(),
-            )))
+            .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
             .with_named_propagator("tracecontext")
             .build();
         assert_eq!(config.propagators.len(), 1);
@@ -904,9 +902,7 @@ mod tests {
     fn test_completion_handler_sync_mode() {
         let provider = Arc::new(
             SdkTracerProvider::builder()
-                .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                    OtlpStdoutSpanExporter::default(),
-                )))
+                .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
                 .build(),
         );
 
@@ -922,9 +918,7 @@ mod tests {
     async fn test_completion_handler_async_mode() {
         let provider = Arc::new(
             SdkTracerProvider::builder()
-                .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                    OtlpStdoutSpanExporter::default(),
-                )))
+                .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
                 .build(),
         );
 
@@ -946,9 +940,7 @@ mod tests {
     fn test_completion_handler_finalize_mode() {
         let provider = Arc::new(
             SdkTracerProvider::builder()
-                .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                    OtlpStdoutSpanExporter::default(),
-                )))
+                .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
                 .build(),
         );
 
@@ -966,9 +958,7 @@ mod tests {
     fn test_completion_handler_clone() {
         let provider = Arc::new(
             SdkTracerProvider::builder()
-                .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                    OtlpStdoutSpanExporter::default(),
-                )))
+                .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
                 .build(),
         );
 
@@ -989,9 +979,7 @@ mod tests {
     fn test_completion_handler_sync_mode_error_handling() {
         let provider = Arc::new(
             SdkTracerProvider::builder()
-                .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                    OtlpStdoutSpanExporter::default(),
-                )))
+                .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
                 .build(),
         );
 
@@ -1006,9 +994,7 @@ mod tests {
     async fn test_completion_handler_async_mode_error_handling() {
         let provider = Arc::new(
             SdkTracerProvider::builder()
-                .with_span_processor(SimpleSpanProcessor::new(Box::new(
-                    OtlpStdoutSpanExporter::default(),
-                )))
+                .with_span_processor(SimpleSpanProcessor::new(OtlpStdoutSpanExporter::default()))
                 .build(),
         );
 


### PR DESCRIPTION
This pull request introduces updates to dependencies, improves the logging system, and refactors the codebase for better maintainability and performance in the `lambda-otel-lite` project. Key changes include upgrading dependency versions, replacing `BoxFuture` with more efficient return types for futures, and enhancing logging with structured events. Below is a categorized summary of the most important changes:

### Dependency Updates
* Updated `reqwest-tracing` to version `0.5.7` with support for `opentelemetry_0_29`.
* Upgraded `aws-sdk-secretsmanager` and `aws-sdk-cloudwatchlogs` to version `1` for consistency with other AWS SDK dependencies.
* Updated `otlp-stdout-span-exporter` to version `0.14.0` in `Cargo.toml` and adjusted the version in the publishing checklist. [[1]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L17-R18) [[2]](diffhunk://#diff-ea2bff3bedf3b0ab3b13846b626165934ccb1d0f06f015c1cf900433c3370a12R16)

### Logging Enhancements
* Replaced `info!` and `error!` macros with structured `tracing::event!` calls in `handler` and `nested_function` implementations for detailed logging, including severity levels and event attributes. [[1]](diffhunk://#diff-bb63a8f0a2b68f023311847a098deda32a8ad927e52bc23cbdbdcac17f283227L26-R32) [[2]](diffhunk://#diff-bb63a8f0a2b68f023311847a098deda32a8ad927e52bc23cbdbdcac17f283227L56-R67) [[3]](diffhunk://#diff-bb63a8f0a2b68f023311847a098deda32a8ad927e52bc23cbdbdcac17f283227L73-R88) [[4]](diffhunk://#diff-bb63a8f0a2b68f023311847a098deda32a8ad927e52bc23cbdbdcac17f283227L84-R112)
* Applied similar structured logging updates in the `tower` example for consistency. [[1]](diffhunk://#diff-c8c6af0129e705d0b08e3ad1cc9a034f6b259a4e15d405eceece55087646a744L27-R32) [[2]](diffhunk://#diff-c8c6af0129e705d0b08e3ad1cc9a034f6b259a4e15d405eceece55087646a744L55-R112)

### Codebase Refactoring
* Removed `BoxFuture` in test implementations of the `SpanExporter` trait and replaced it with more efficient `impl Future` return types across multiple files (`extension.rs`, `handler.rs`, `layer.rs`, `processor.rs`). [[1]](diffhunk://#diff-4943d9f582e523147c9a7b19f34f8618859a318f760d8db60fdf9ad81993c3d4L305-R310) [[2]](diffhunk://#diff-65272e51cfdb2ee4a01cdf62ba8b72b9b60ead14a76d13cfaeaedc13f157efe5L328-R333) [[3]](diffhunk://#diff-f6ede88d38731a34552543f385433e53f764f8763bd9da4a01556c346d4350e4L407-R411) [[4]](diffhunk://#diff-ba12602017fb86038f601e7922b2f5407783c299cd99d156d6320809001a4c51L448-R451)
* Simplified the `force_flush` method in `processor.rs` by using immutable references for the exporter lock.

### Example Improvements
* Enhanced example templates with better event handling and explicit attribute usage, as reflected in the changelog.
* Added a `samconfig.toml` file for SAM CLI configuration, including deployment parameters like region and stack name.

### Miscellaneous
* Updated the package version to `0.14.0` in `Cargo.toml` and documented the changes in the changelog. [[1]](diffhunk://#diff-26cd2b53f6926e62cfe6fcd00f3950088acef5a9ca350092c42550bd5b1ad5c8L3-R3) [[2]](diffhunk://#diff-186498266ac8e953c6310f423de26221c85a117655d116518dd6abf581d93900R10-R17)
* Adjusted function names in `template.yaml` for better clarity in AWS Lambda deployments. [[1]](diffhunk://#diff-b760c127f868a8fd9ee7f973e59c411b481942f9208e7dd0ecd8500e2158843dL29-R29) [[2]](diffhunk://#diff-b760c127f868a8fd9ee7f973e59c411b481942f9208e7dd0ecd8500e2158843dL47-R47)