### PR TITLE
release: rust/otlp-stdout-span-exporter v0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ opentelemetry-http = { version = "0.29.0" }
 opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.29.0", features = ["http-proto", "http-json", "reqwest-client"] }
 opentelemetry-proto = { version = "0.29.0", features = ["gen-tonic", "trace"] }
+opentelemetry-semantic-conventions = { version = "0.29.0" }
 opentelemetry-aws = { version = "0.17.0", features = ["detector-aws-lambda"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -108,6 +109,7 @@ headless_chrome = "1.0.9"
 toml = "0.8.20"
 globset = "0.4"
 once_cell = "1.21.3"
+indexmap = "2.9.0"
 
 # Macros and code generation
 proc-macro2 = "1.0"
@@ -124,9 +126,10 @@ wiremock = "0.6"
 mockito = "1.2"
 doc-comment = "0.3"
 rand = "0.9"
-colored = "2.0"
+colored = "3.0.0"
 hex = "0.4"
 prettytable-rs = "0.10"
+comfy-table = "7.1.4"
 tabled = "0.19.0"
 nix = "0.29.0"
 scopeguard = "1.2"
@@ -138,4 +141,3 @@ opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"
-

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2025-04-30
+
+### Fixed
+- Ensure named pipe output performs an open/close operation (generating EOF) even when exporting an empty batch of spans. This guarantees downstream pipe readers receive a signal after every flush, even if no spans were sampled.
+
+### Added
+- Added `BufferOutput` struct, an `Output` implementation useful for testing that captures lines to an internal buffer.
+- Added `is_pipe()` and `touch_pipe()` methods to the public `Output` trait.
+
+### Changed
+- Made the `Output` trait public (`pub trait Output`).
+- Updated `nix` dependency to use workspace version.
+- Removed unused `futures-util` dependency.
+
 ## [0.14.0] - 2024-06-07
 
 ### Changed

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,7 +19,6 @@ opentelemetry_sdk.workspace = true
 opentelemetry-proto.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
-futures-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 base64.workspace = true
@@ -28,7 +27,7 @@ prost.workspace = true
 doc-comment.workspace = true
 log.workspace = true
 bon.workspace = true
-nix = { version = "0.29.0", features = ["fs"] }
+nix = { workspace = true, features = ["fs"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/packages/rust/otlp-stdout-span-exporter/src/lib.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/lib.rs
@@ -132,13 +132,13 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     env,
-    fmt::Display,
+    fmt::{self, Display},
     fs::OpenOptions,
     io::{self, Write},
     path::PathBuf,
     result::Result,
     str::FromStr,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 mod constants;
@@ -201,7 +201,7 @@ impl Display for LogLevel {
 ///
 /// This trait defines the interface for writing output lines. It is implemented
 /// by both the standard output handler and named pipe output handlers.
-trait Output: Send + Sync + std::fmt::Debug + std::any::Any {
+pub trait Output: Send + Sync + std::fmt::Debug + std::any::Any {
     /// Writes a single line of output
     ///
     /// # Arguments
@@ -212,6 +212,27 @@ trait Output: Send + Sync + std::fmt::Debug + std::any::Any {
     ///
     /// Returns `Ok(())` if the write was successful, or a `TraceError` if it failed
     fn write_line(&self, line: &str) -> Result<(), OTelSdkError>;
+
+    /// Checks if the output target is a named pipe.
+    ///
+    /// Returns `true` if the output is configured to write to a named pipe,
+    /// `false` otherwise (e.g., stdout).
+    fn is_pipe(&self) -> bool;
+
+    /// Performs a "touch" operation on the output target, primarily for named pipes.
+    ///
+    /// For named pipes, this should open and immediately close the pipe for writing
+    /// to generate an EOF signal for readers.
+    /// For other output types (like stdout), this is typically a no-op.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the touch was successful or is a no-op,
+    /// or a `TraceError` if opening/closing the pipe failed.
+    fn touch_pipe(&self) -> Result<(), OTelSdkError> {
+        // Default implementation is a no-op
+        Ok(())
+    }
 }
 
 /// Standard output implementation that writes to stdout
@@ -228,6 +249,10 @@ impl Output for StdOutput {
         writeln!(handle, "{}", line).map_err(|e| OTelSdkError::InternalFailure(e.to_string()))?;
 
         Ok(())
+    }
+
+    fn is_pipe(&self) -> bool {
+        false // Stdout is not a pipe
     }
 }
 
@@ -263,6 +288,58 @@ impl Output for NamedPipeOutput {
         })?;
 
         Ok(())
+    }
+
+    fn is_pipe(&self) -> bool {
+        true // This implementation is for named pipes
+    }
+
+    fn touch_pipe(&self) -> Result<(), OTelSdkError> {
+        // Open the pipe for writing and immediately close it (RAII handles close)
+        let _file = OpenOptions::new()
+            .write(true)
+            .open(&self.path)
+            .map_err(|e| OTelSdkError::InternalFailure(format!("Failed to touch pipe: {}", e)))?;
+        Ok(())
+    }
+}
+
+/// An Output implementation that writes lines to an internal buffer.
+#[derive(Clone, Default)]
+pub struct BufferOutput {
+    buffer: Arc<Mutex<Vec<String>>>,
+}
+
+impl BufferOutput {
+    /// Creates a new, empty BufferOutput.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Retrieves all lines currently in the buffer, clearing the buffer afterwards.
+    pub fn take_lines(&self) -> Vec<String> {
+        let mut guard = self.buffer.lock().expect("Failed to lock buffer mutex");
+        std::mem::take(&mut *guard) // Efficiently swaps the Vec with an empty one
+    }
+}
+
+impl Output for BufferOutput {
+    fn write_line(&self, line: &str) -> Result<(), OTelSdkError> {
+        let mut guard = self.buffer.lock().expect("Failed to lock buffer mutex");
+        guard.push(line.to_string());
+        Ok(())
+    }
+
+    fn is_pipe(&self) -> bool {
+        false // BufferOutput is not a pipe
+    }
+}
+
+// Need to implement Debug manually as Mutex doesn't implement Debug
+impl fmt::Debug for BufferOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Avoid locking the mutex in debug formatting if possible, or provide minimal info
+        f.debug_struct("BufferOutput").finish_non_exhaustive()
     }
 }
 
@@ -584,7 +661,14 @@ impl SpanExporter for OtlpStdoutSpanExporter {
         &self,
         batch: Vec<SpanData>,
     ) -> impl std::future::Future<Output = OTelSdkResult> + Send {
-        // Do all work synchronously
+        // Check for empty batch and pipe output configuration
+        if batch.is_empty() && self.output.is_pipe() {
+            // Perform the "pipe touch" operation: open for writing and immediately close.
+            let touch_result = self.output.touch_pipe();
+            return Box::pin(std::future::ready(touch_result));
+        }
+
+        // Original export logic for non-empty batches or stdout output
         let result = (|| {
             // Convert spans to OTLP format
             let resource = self
@@ -686,9 +770,6 @@ use doc_comment::doctest;
 #[cfg(doctest)]
 doctest!("../README.md", readme);
 
-#[cfg(test)]
-use std::sync::Mutex;
-
 /// Test output implementation that captures to a buffer
 #[cfg(test)]
 #[derive(Debug, Default)]
@@ -715,6 +796,12 @@ impl Output for TestOutput {
         self.buffer.lock().unwrap().push(line.to_string());
         Ok(())
     }
+
+    fn is_pipe(&self) -> bool {
+        false // TestOutput is not a pipe
+    }
+
+    // touch_pipe uses the default no-op implementation
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request introduces version `0.15.0` of the `otlp-stdout-span-exporter` package, with significant updates to enhance functionality, improve testing, and clean up dependencies. The changes include new features for the `Output` trait, a new `BufferOutput` struct for testing, and updates to dependency management.

### New Features and Enhancements:
* Made the `Output` trait public and added `is_pipe()` and `touch_pipe()` methods to support named pipe operations. These methods enable checking if the output is a named pipe and performing a "touch" operation to generate EOF signals for downstream readers. (`[[1]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L204-R204)`, `[[2]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040R215-R235)`, `[[3]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040R253-R256)`, `[[4]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040R292-R343)`)
* Introduced the `BufferOutput` struct, an `Output` implementation for testing that captures lines to an internal buffer. This includes methods for creating, retrieving, and clearing buffered lines. (`[packages/rust/otlp-stdout-span-exporter/src/lib.rsR292-R343](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040R292-R343)`)

### Dependency Updates:
* Updated the `nix` dependency to use the workspace version and removed the unused `futures-util` dependency for cleaner and more consistent dependency management. (`[[1]](diffhunk://#diff-139d37c5c8f0270080968f69d2217b6dc710f974739d4ef4f2b7410ce95f9ee6L22)`, `[[2]](diffhunk://#diff-139d37c5c8f0270080968f69d2217b6dc710f974739d4ef4f2b7410ce95f9ee6L31-R30)`)

### Fixes and Improvements:
* Ensured named pipe output performs an open/close operation even when exporting an empty batch of spans, guaranteeing EOF signals for downstream readers. (`[packages/rust/otlp-stdout-span-exporter/src/lib.rsL587-R671](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L587-R671)`)

### Codebase Cleanup:
* Refactored imports in `src/lib.rs` to group related items and added `Mutex` to support the new `BufferOutput` implementation. (`[[1]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L135-R141)`, `[[2]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L689-L691)`, `[[3]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040R799-R804)`)

### Documentation:
* Updated the changelog to reflect the new version `0.15.0` and document all notable changes. (`[packages/rust/otlp-stdout-span-exporter/CHANGELOG.mdR8-R21](diffhunk://#diff-51c986c5bb8e2e0e9f9c5ecc6f5ac74d2f94a63485f77b241081dc12820081ffR8-R21)`)