### PR TITLE
release: node/otlp-stdout-span-exporter v0.15.0

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2025-04-28
+
+### Added
+- Added support for generating EOF signals on named pipes when exporting empty span batches
+- Implemented "pipe touch" operation (open and immediately close the pipe) when export is called with empty spans
+
+### Fixed
+- Fixed issue where downstream extensions would hang waiting for EOF when no spans were sampled
+- Resolved edge case where named pipes wouldn't receive EOF signals during empty span flushes
+
+### Changed
+- Version bump to align with other packages in the monorepo
+
 ## [0.13.0] - 2025-04-14
 
 ### Added

--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.0] - 2025-04-28
+## [0.15.0] - 2025-04-30
 
 ### Added
 - Added support for generating EOF signals on named pipes when exporting empty span batches

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -51,8 +51,8 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.30.1",
-    "@opentelemetry/otlp-transformer": "^0.57.0",
-    "@opentelemetry/sdk-trace-base": "^1.30.0"
+    "@opentelemetry/otlp-transformer": "^0.57.2",
+    "@opentelemetry/sdk-trace-base": "^1.30.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0"


### PR DESCRIPTION
This pull request introduces several updates to the `@dev7a/otlp-stdout-span-exporter` package, including new features, dependency updates, and expanded test coverage. The most significant changes involve adding support for EOF signals on named pipes, improving test robustness with mock spans, and handling edge cases for empty span exports.

### New Features
* Added support for generating EOF signals on named pipes when exporting empty span batches. Implemented a "pipe touch" operation to open and close the pipe immediately when export is called with empty spans.

### Dependency Updates
* Updated `@opentelemetry/otlp-transformer` to version `^0.57.2` and `@opentelemetry/sdk-trace-base` to version `^1.30.1` in `package.json`.

### Test Enhancements
* Introduced a `createMockSpan` helper function to improve test coverage and ensure non-empty spans are used in all test cases.
* Added new tests to verify the behavior of the "pipe touch" operation, including handling errors during this operation.
* Expanded test coverage for header parsing by introducing a `createHeaderTestSpan` helper function.

### Bug Fixes
* Fixed an issue where downstream extensions would hang waiting for EOF when no spans were sampled.
* Resolved an edge case where named pipes wouldn't receive EOF signals during empty span flushes.

### Version Update
* Bumped the package version from `0.13.0` to `0.15.0` to align with other packages in the monorepo.