### PR TITLE
release: node/lambda-otel-lite v0.15.0

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2025-04-30
+
+### Changed
+- Removed batching logic from `LambdaSpanProcessor.forceFlush` - all spans are now exported in a single batch regardless of size
+- Modified `forceFlush` to always call the exporter's `export` method, even when the span buffer is empty
+- Updated dependency on `@dev7a/otlp-stdout-span-exporter` to 0.15.0 or greater
+- Fixed issue where extension could hang waiting for EOF when no spans were sampled
+- Removed `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE` environment variable which is no longer needed
+
 ## [0.13.0] - 2025-04-16
 
 ### Added

--- a/packages/node/lambda-otel-lite/README.md
+++ b/packages/node/lambda-otel-lite/README.md
@@ -336,7 +336,6 @@ The package adds several resource attributes under the `lambda_otel_lite` namesp
 
 - `lambda_otel_lite.extension.span_processor_mode`: Current processing mode (`sync`, `async`, or `finalize`)
 - `lambda_otel_lite.lambda_span_processor.queue_size`: Maximum number of spans that can be queued
-- `lambda_otel_lite.lambda_span_processor.batch_size`: Maximum batch size for span export
 - `lambda_otel_lite.otlp_stdout_span_exporter.compression_level`: GZIP compression level used for span export
 
 These attributes are **only added to the resource when the corresponding environment variables are explicitly set**. This ensures that the recorded resource attributes accurately reflect the actual configuration values used by the components.
@@ -510,7 +509,6 @@ The package can be configured using the following environment variables. All con
   - `async`: Deferred export via extension
   - `finalize`: Custom export strategy
 - `LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE`: Maximum number of spans to queue (default: 2048)
-- `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE`: Maximum number of spans to export in each batch (default: 512)
 
 ### Resource Configuration
 - `OTEL_SERVICE_NAME`: Override the service name (defaults to function name)

--- a/packages/node/lambda-otel-lite/__tests__/test_resource.ts
+++ b/packages/node/lambda-otel-lite/__tests__/test_resource.ts
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach, expect } from '@jest/globals';
+import { getLambdaResource } from '../src/internal/telemetry/resource';
 import { EnvVarManager } from './utils';
-import { getLambdaResource } from '../src/internal/telemetry/init';
+import { ENV_VARS } from '../src/constants';
 
 describe('getLambdaResource', () => {
   const envManager = new EnvVarManager();
@@ -105,32 +106,16 @@ describe('getLambdaResource', () => {
   });
 
   it('should include Lambda environment variables when present', () => {
-    const lambdaEnv = {
-      AWS_REGION: 'us-west-2',
-      AWS_LAMBDA_FUNCTION_NAME: 'test-function',
-      AWS_LAMBDA_FUNCTION_VERSION: '$LATEST',
-      AWS_LAMBDA_LOG_STREAM_NAME: 'test-stream',
-      AWS_LAMBDA_FUNCTION_MEMORY_SIZE: '128',
-      LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: 'async',
-      LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE: '1024',
-      LAMBDA_SPAN_PROCESSOR_BATCH_SIZE: '256',
-      OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL: '4',
-    };
-    envManager.setup(lambdaEnv);
+    // Set up Lambda specific environment variables for testing
+    process.env[ENV_VARS.PROCESSOR_MODE] = 'async';
+    process.env[ENV_VARS.QUEUE_SIZE] = '1024';
+    process.env[ENV_VARS.COMPRESSION_LEVEL] = '4';
 
     const resource = getLambdaResource();
 
-    // Check standard Lambda attributes
-    expect(resource.attributes['cloud.region']).toBe('us-west-2');
-    expect(resource.attributes['faas.name']).toBe('test-function');
-    expect(resource.attributes['faas.version']).toBe('$LATEST');
-    expect(resource.attributes['faas.instance']).toBe('test-stream');
-    expect(resource.attributes['faas.max_memory']).toBe(134217728); // 128MB in bytes
-
-    // Check telemetry configuration attributes
+    // Verify that Lambda environment variables were added
     expect(resource.attributes['lambda_otel_lite.extension.span_processor_mode']).toBe('async');
     expect(resource.attributes['lambda_otel_lite.lambda_span_processor.queue_size']).toBe(1024);
-    expect(resource.attributes['lambda_otel_lite.lambda_span_processor.batch_size']).toBe(256);
     expect(
       resource.attributes['lambda_otel_lite.otlp_stdout_span_exporter.compression_level']
     ).toBe(4);
@@ -143,9 +128,6 @@ describe('getLambdaResource', () => {
     expect(resource.attributes['lambda_otel_lite.extension.span_processor_mode']).toBeUndefined();
     expect(
       resource.attributes['lambda_otel_lite.lambda_span_processor.queue_size']
-    ).toBeUndefined();
-    expect(
-      resource.attributes['lambda_otel_lite.lambda_span_processor.batch_size']
     ).toBeUndefined();
     expect(
       resource.attributes['lambda_otel_lite.otlp_stdout_span_exporter.compression_level']

--- a/packages/node/lambda-otel-lite/examples/template.yaml
+++ b/packages/node/lambda-otel-lite/examples/template.yaml
@@ -32,7 +32,7 @@ Resources:
       FunctionName: !Sub '${AWS::StackName}-example'
       CodeUri: ./handler
       Handler: app.handler
-      Tracing: Enabled
+      Tracing: Active
       Description: 'Demo Node Lambda function to showcase OpenTelemetry integration'
       FunctionUrlConfig:
         AuthType: NONE

--- a/packages/node/lambda-otel-lite/package-lock.json
+++ b/packages/node/lambda-otel-lite/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dev7a/lambda-otel-lite",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "@dev7a/otlp-stdout-span-exporter": "^0.13.0",
+        "@dev7a/otlp-stdout-span-exporter": "^0.15.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
@@ -583,14 +583,14 @@
       }
     },
     "node_modules/@dev7a/otlp-stdout-span-exporter": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@dev7a/otlp-stdout-span-exporter/-/otlp-stdout-span-exporter-0.13.0.tgz",
-      "integrity": "sha512-nac+FWNdLNTdfOO0DBJzzNpuFOStdRWyvfdvtcIExq6c1NhdXeToArLWT+8jswbmphTq5bjG6+heoQP/SVZssw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@dev7a/otlp-stdout-span-exporter/-/otlp-stdout-span-exporter-0.15.0.tgz",
+      "integrity": "sha512-njOA8oIz3aDnrkVf/4mEPVSI7tlK89YVe/hBp3dJem5BJW/gp0W6blyk3STolT4s6Q6jw0Q8JCCqxqkT8Mi4DA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/core": "^1.30.1",
-        "@opentelemetry/otlp-transformer": "^0.57.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.0"
+        "@opentelemetry/otlp-transformer": "^0.57.2",
+        "@opentelemetry/sdk-trace-base": "^1.30.1"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -598,180 +598,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.0.tgz",
-      "integrity": "sha512-l1aJ30CXeauVYaI+btiynHpw341LthkMTv3omi1VJDX14werY2Wmv9n1yudMsq9HuY0m8PvXEVX4d8zxEb+WRg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.0.tgz",
-      "integrity": "sha512-yHX7sdwkdAmSa6Jbi3caSLDWy0PCHS1pKQeKz8AIWSyQqL7IojHKgdk9A+7eRd98Z1n9YTdwWSWLnObvIqhEhQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.57.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/sdk-logs": "0.57.0",
-        "@opentelemetry/sdk-metrics": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
-        "protobufjs": "^7.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/resources": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.0.tgz",
-      "integrity": "sha512-5mGMjL0Uld/99t7/pcd7CuVtJbkARckLVuiOX84nO8RtLtIz0/J6EOHM2TGvPZ6F4K+XjUq13gMx14w80SVCQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.0.tgz",
-      "integrity": "sha512-6Kbxdu/QE9LWH7+WSLmYo3DjAq+c55TiCLXiXu6b/2m2muy5SyOG2m0MrGqetyRpfYSSbIqHmJoqNVTN3+2a9g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.57.0",
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.0.tgz",
-      "integrity": "sha512-5kcj6APyRMvv6dEIP5plz2qfJAD4OMipBRT11u/pa1a68rHKI2Ln+iXVkAGKgx8o7CXbD7FdPypTUY88ZQgP4Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.0.tgz",
-      "integrity": "sha512-RKQDaDIkV7PwizmHw+rE/FgfB2a6MBx+AEVVlAHXRG1YYxLiBpPX2KhmoB99R5vA4b72iJrjle68NDWnbrE9Dg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources": "1.30.0",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@dev7a/otlp-stdout-span-exporter/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.0.tgz",
-      "integrity": "sha512-Q/3u/K73KUjTCnFUP97ZY+pBjQ1kPEgjOfXj/bJl8zW7GbXdkw6cwuyZk6ZTXkVgCBsYRYUzx4fvYK1jxdb9MA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1343,6 +1169,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
+      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
@@ -1368,6 +1206,27 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.57.2.tgz",
+      "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/sdk-logs": "0.57.2",
+        "@opentelemetry/sdk-metrics": "1.30.1",
+        "@opentelemetry/sdk-trace-base": "1.30.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
@@ -1426,6 +1285,39 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.57.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.57.2.tgz",
+      "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.57.2",
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.30.1.tgz",
+      "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -4691,9 +4583,9 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
-      "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
@@ -5310,9 +5202,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
+      "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [
@@ -62,7 +62,7 @@
     "test:watch": "jest -c jest.config.ts --watch"
   },
   "dependencies": {
-    "@dev7a/otlp-stdout-span-exporter": "^0.13.0",
+    "@dev7a/otlp-stdout-span-exporter": "^0.15.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1",
     "@opentelemetry/propagator-aws-xray": "^1.3.1",

--- a/packages/node/lambda-otel-lite/src/constants.ts
+++ b/packages/node/lambda-otel-lite/src/constants.ts
@@ -23,11 +23,6 @@ export const ENV_VARS = {
   QUEUE_SIZE: 'LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE',
 
   /**
-   * Maximum number of spans to export in each batch (default: 512)
-   */
-  BATCH_SIZE: 'LAMBDA_SPAN_PROCESSOR_BATCH_SIZE',
-
-  /**
    * GZIP compression level for stdout exporter:
    * - 0: No compression
    * - 1: Best speed
@@ -63,11 +58,6 @@ export const DEFAULTS = {
   QUEUE_SIZE: 2048,
 
   /**
-   * Default maximum number of spans to export in each batch
-   */
-  BATCH_SIZE: 512,
-
-  /**
    * Default GZIP compression level
    */
   COMPRESSION_LEVEL: 6,
@@ -96,11 +86,6 @@ export const RESOURCE_ATTRIBUTES = {
    * Maximum number of spans that can be queued
    */
   QUEUE_SIZE: 'lambda_otel_lite.lambda_span_processor.queue_size',
-
-  /**
-   * Maximum batch size for span export
-   */
-  BATCH_SIZE: 'lambda_otel_lite.lambda_span_processor.batch_size',
 
   /**
    * GZIP compression level used for span export

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/init.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/init.ts
@@ -111,7 +111,6 @@ export { getLambdaResource } from './resource';
  * Environment Variables:
  * - LAMBDA_EXTENSION_SPAN_PROCESSOR_MODE: Processing mode (sync, async, finalize)
  * - LAMBDA_SPAN_PROCESSOR_QUEUE_SIZE: Maximum spans to queue (default: 2048)
- * - LAMBDA_SPAN_PROCESSOR_BATCH_SIZE: Maximum batch size (default: 512)
  * - OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL: GZIP level (default: 6)
  * - OTEL_SERVICE_NAME: Service name (defaults to function name)
  * - OTEL_RESOURCE_ATTRIBUTES: Additional resource attributes (key=value,...)

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/resource.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/resource.ts
@@ -91,9 +91,6 @@ export function getLambdaResource(): Resource {
   // Add queue size attribute only when environment variable is set
   parseNumericAttribute(RESOURCE_ATTRIBUTES.QUEUE_SIZE, process.env[ENV_VARS.QUEUE_SIZE]);
 
-  // Add batch size attribute only when environment variable is set
-  parseNumericAttribute(RESOURCE_ATTRIBUTES.BATCH_SIZE, process.env[ENV_VARS.BATCH_SIZE]);
-
   // Add compression level attribute only when environment variable is set
   parseNumericAttribute(
     RESOURCE_ATTRIBUTES.COMPRESSION_LEVEL,


### PR DESCRIPTION
This pull request introduces significant updates to the `@dev7a/lambda-otel-lite` package, focusing on simplifying the span processing logic, removing unused configuration options, and improving test coverage. The most notable changes include removing batch processing logic, updating dependencies, and modifying tests to align with the new behavior.

### Span Processing Simplifications:
* Removed batching logic from `LambdaSpanProcessor`—spans are now exported in a single batch regardless of size, and the `forceFlush` method always calls the exporter's `export` method, even when the span buffer is empty. (`packages/node/lambda-otel-lite/src/internal/telemetry/processor.ts`, [[1]](diffhunk://#diff-485c81f552d648e9494fc693b1832bc2034279aaf85daac21693d2c5cc164877L189-R181) [[2]](diffhunk://#diff-485c81f552d648e9494fc693b1832bc2034279aaf85daac21693d2c5cc164877L245-L282)
* Eliminated `LAMBDA_SPAN_PROCESSOR_BATCH_SIZE` configuration, including related constants, environment variables, and resource attributes. (`packages/node/lambda-otel-lite/src/constants.ts`, [[1]](diffhunk://#diff-349fe1806a12f044ef753fc549b40fb460cac7349e11aa83858d1c0f42673d33L25-L29) [[2]](diffhunk://#diff-349fe1806a12f044ef753fc549b40fb460cac7349e11aa83858d1c0f42673d33L65-L69) [[3]](diffhunk://#diff-349fe1806a12f044ef753fc549b40fb460cac7349e11aa83858d1c0f42673d33L100-L104)

### Dependency and Version Updates:
* Updated the dependency on `@dev7a/otlp-stdout-span-exporter` to version 0.15.0 or greater. (`packages/node/lambda-otel-lite/package.json`, [packages/node/lambda-otel-lite/package.jsonL65-R65](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L65-R65))
* Bumped the package version from 0.13.0 to 0.15.0. (`packages/node/lambda-otel-lite/package.json`, [packages/node/lambda-otel-lite/package.jsonL3-R3](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3))

### Test Enhancements:
* Updated tests to reflect the removal of batching logic, ensuring no spans are exported after shutdown and that the exporter is called even with an empty span buffer. (`packages/node/lambda-otel-lite/__tests__/test_processor.ts`, [[1]](diffhunk://#diff-96baf5cd6e4355a9c5e628c8e16989aab85a1dcd445f3d86eeec55021ddf4adfL69-R76) [[2]](diffhunk://#diff-96baf5cd6e4355a9c5e628c8e16989aab85a1dcd445f3d86eeec55021ddf4adfL96-R108) [[3]](diffhunk://#diff-96baf5cd6e4355a9c5e628c8e16989aab85a1dcd445f3d86eeec55021ddf4adfR178-R198)
* Improved resource tests by removing checks for batch size attributes and refactoring environment variable setup to use constants. (`packages/node/lambda-otel-lite/__tests__/test_resource.ts`, [[1]](diffhunk://#diff-a3342e3982590c3a1b951ce467528556e268698aa77d227c83af7643dbffbf35L108-L133) [[2]](diffhunk://#diff-a3342e3982590c3a1b951ce467528556e268698aa77d227c83af7643dbffbf35L147-L149)

### Documentation Updates:
* Updated the README and changelog to reflect the removal of batch size configuration and the new behavior of `forceFlush`. (`packages/node/lambda-otel-lite/README.md`, [[1]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddL339) [[2]](diffhunk://#diff-3f14b3187ed47a0cef26dfccfc088aa10aa5dae68add235626f5ee99ff8d94ddL513); `packages/node/lambda-otel-lite/CHANGELOG.md`, [[3]](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR8-R16)

### Miscellaneous:
* Changed the `Tracing` configuration in the example template from `Enabled` to `Active` for better alignment with AWS Lambda tracing options. (`packages/node/lambda-otel-lite/examples/template.yaml`, [packages/node/lambda-otel-lite/examples/template.yamlL35-R35](diffhunk://#diff-7e67c8ad3fb66d883081711651dd550acdfbbb4e327022ee7fb4022aa7d7a575L35-R35))