### PR TITLE
release cli/startled-v0.1.1

### DIFF
--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2025-05-10
 
 ### Added
 - Initial project setup for startled CLI.
 - Basic benchmarking functionality.
 - Screenshot capture feature (optional).
+- `tempfile` as a development dependency for managing temporary files in tests.
+- New test module `cli/startled/src/benchmark.rs` for `FunctionBenchmarkConfig` creation and `save_report` functionality, covering default memory configurations and successful report saving.
+- New test module `cli/startled/src/report.rs` validating utility functions:
+    - `snake_to_kebab` string conversion.
+    - `calculate_base_path` logic, including scenarios with and without a base URL.
+    - Data preparation for bar and line chart rendering, handling edge cases such as empty measurements.
+
+### Changed
+- Updated `startled` CLI version from 0.1.0 to 0.1.1 in `Cargo.toml`.

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -51,3 +51,6 @@ comfy-table = { workspace = true, features = ["tty", "custom_styling"] }
 regex.workspace = true
 rust_decimal = { workspace = true, features = ["serde-with-arbitrary-precision"] }
 pulldown-cmark.workspace = true
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,11 +1,13 @@
-## startled v0.1.0 (Upcoming)
+## startled v0.1.1
 
-This is the initial release of the startled CLI. It provides tools for benchmarking Lambda functions, including an optional screenshot capability.
+This maintenance release enhances the stability and reliability of the startled CLI by introducing a comprehensive suite of new tests for core benchmarking and reporting functionalities.
 
-### Key Features
-- Lambda function benchmarking.
-- Performance statistics collection.
-- HTML report generation.
-- Optional screenshot capture for visual analysis.
+### Key Changes in v0.1.1
+- **Improved Test Coverage:**
+    - Added extensive new tests for benchmarking configuration (`FunctionBenchmarkConfig`) and the report saving mechanism.
+    - Implemented new tests for various reporting utility functions, covering string formatting, path calculations, and data preparation for chart rendering.
+- Updated internal dependencies and bumped the CLI version.
 
-For a detailed list of all changes, please see the [CHANGELOG.md](./CHANGELOG.md).
+This increased test coverage ensures more robust and predictable behavior for startled's benchmarking and reporting features.
+
+For a detailed list of all code changes and specific test cases added, please see the [CHANGELOG.md](./CHANGELOG.md).

--- a/cli/startled/src/benchmark.rs
+++ b/cli/startled/src/benchmark.rs
@@ -633,3 +633,147 @@ pub async fn run_stack_benchmark(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{BenchmarkConfig, BenchmarkReport, ColdStartMetrics, WarmStartMetrics, ClientMetrics, EnvVar};
+    use tempfile::tempdir;
+    use std::fs;
+    use std::path::Path;
+    use chrono::Local;
+
+    #[test]
+    fn test_function_benchmark_config_new() {
+        let function_name = "test_func";
+        let memory_size = Some(512);
+        let concurrent = 10;
+        let rounds = 5;
+        let payload = Some("{}".to_string());
+        let output_dir = "test_output";
+        let environment = vec![("KEY".to_string(), "VALUE".to_string())];
+        let proxy_function = Some("proxy_func".to_string());
+
+        let config = FunctionBenchmarkConfig::new(
+            function_name,
+            memory_size,
+            concurrent,
+            rounds,
+            payload.clone(),
+            output_dir,
+            environment.clone(),
+            proxy_function.clone(),
+        );
+
+        assert_eq!(config.function_name, function_name);
+        assert_eq!(config.memory_size, memory_size);
+        assert_eq!(config.concurrent, concurrent);
+        assert_eq!(config.rounds, rounds);
+        assert_eq!(config.payload, payload);
+        assert_eq!(config.output_dir, output_dir);
+        assert_eq!(config.environment, environment);
+        assert_eq!(config.proxy_function, proxy_function);
+    }
+
+    #[tokio::test]
+    async fn test_save_report_happy_path() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir_path = temp_dir.path().join("benchmark_reports");
+        let output_dir_str = output_dir_path.to_str().unwrap();
+
+        let report = BenchmarkReport {
+            config: BenchmarkConfig {
+                function_name: "my_test_lambda".to_string(),
+                memory_size: Some(256),
+                concurrent_invocations: 1,
+                rounds: 1,
+                timestamp: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+                runtime: Some("nodejs18.x".to_string()),
+                architecture: Some("arm64".to_string()),
+                environment: vec![EnvVar { key: "TEST_ENV".to_string(), value: "TEST_VAL".to_string() }],
+            },
+            cold_starts: vec![ColdStartMetrics {
+                timestamp: "ts_cold".to_string(),
+                init_duration: 100.0,
+                duration: 200.0,
+                extension_overhead: 10.0,
+                total_cold_start_duration: Some(310.0),
+                billed_duration: 300,
+                max_memory_used: 128,
+                memory_size: 256,
+            }],
+            warm_starts: vec![WarmStartMetrics {
+                timestamp: "ts_warm".to_string(),
+                duration: 50.0,
+                extension_overhead: 5.0,
+                billed_duration: 50,
+                max_memory_used: 100,
+                memory_size: 256,
+            }],
+            client_measurements: vec![ClientMetrics {
+                timestamp: "ts_client".to_string(),
+                client_duration: 30.0,
+                memory_size: 256,
+            }],
+        };
+
+        let save_result = save_report(report.clone(), output_dir_str).await;
+        assert!(save_result.is_ok(), "Failed to save report: {:?}", save_result.err());
+
+        let expected_memory_dir = Path::new(output_dir_str).join("256mb");
+        assert!(expected_memory_dir.exists(), "Memory specific directory was not created");
+        assert!(expected_memory_dir.is_dir(), "Memory specific path is not a directory");
+
+        let expected_file_path = expected_memory_dir.join("my_test_lambda.json");
+        assert!(expected_file_path.exists(), "Report file was not created at {:?}", expected_file_path);
+        assert!(expected_file_path.is_file(), "Report path is not a file");
+
+        let file_content = fs::read_to_string(expected_file_path).unwrap();
+        let saved_report: BenchmarkReport = serde_json::from_str(&file_content).unwrap();
+        
+        // Basic check, ideally compare all fields or use a proper diffing library for structs
+        assert_eq!(saved_report.config.function_name, report.config.function_name);
+        assert_eq!(saved_report.config.memory_size, report.config.memory_size);
+        assert_eq!(saved_report.cold_starts.len(), 1);
+        assert_eq!(saved_report.warm_starts.len(), 1);
+        assert_eq!(saved_report.client_measurements.len(), 1);
+        assert_eq!(saved_report.cold_starts[0].init_duration, report.cold_starts[0].init_duration);
+
+        // Clean up
+        temp_dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_save_report_default_memory() {
+        let temp_dir = tempdir().unwrap();
+        let output_dir_path = temp_dir.path().join("benchmark_reports_default");
+        let output_dir_str = output_dir_path.to_str().unwrap();
+
+        let report = BenchmarkReport {
+            config: BenchmarkConfig {
+                function_name: "my_default_lambda".to_string(),
+                memory_size: None, // Test default memory case
+                concurrent_invocations: 1,
+                rounds: 1,
+                timestamp: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+                runtime: Some("python3.9".to_string()),
+                architecture: Some("x86_64".to_string()),
+                environment: vec![],
+            },
+            cold_starts: vec![],
+            warm_starts: vec![],
+            client_measurements: vec![],
+        };
+
+        let save_result = save_report(report.clone(), output_dir_str).await;
+        assert!(save_result.is_ok());
+
+        let expected_memory_dir = Path::new(output_dir_str).join("default");
+        assert!(expected_memory_dir.exists(), "Default memory directory was not created");
+        
+        let expected_file_path = expected_memory_dir.join("my_default_lambda.json");
+        assert!(expected_file_path.exists(), "Report file was not created for default memory");
+
+        temp_dir.close().unwrap();
+    }
+}

--- a/cli/startled/src/report.rs
+++ b/cli/startled/src/report.rs
@@ -1019,7 +1019,10 @@ mod tests {
         assert_eq!(snake_to_kebab("single"), "single");
         assert_eq!(snake_to_kebab(""), "");
         assert_eq!(snake_to_kebab("_leading_underscore"), "-leading-underscore");
-        assert_eq!(snake_to_kebab("trailing_underscore_"), "trailing-underscore-");
+        assert_eq!(
+            snake_to_kebab("trailing_underscore_"),
+            "trailing-underscore-"
+        );
     }
 
     #[test]
@@ -1030,42 +1033,60 @@ mod tests {
         let _path3 = PathBuf::from("group1/subgroupA/chart_type"); // Max depth for calculation logic
         let _path4 = PathBuf::from("group1/subgroupA/chart_type/another_level");
 
-
         // The logic in calculate_base_path adds 1 to component count, then caps at 3.
         // current_dir is the output_directory/group_name/subgroup_name
         // The actual HTML file will be one level deeper (e.g., .../chart_name/index.html)
         // So, if current_dir is "group1/subgroupA", components = 2. depth = min(2+1, 3) = 3. Result: "../../../"
-        
+
         // If html_dir is root of output (e.g. "output_dir")
         // This case is not directly hit by generate_chart's usage, as html_dir is usually deeper.
         // However, testing the function directly:
         // If current_dir is "output_dir", components = 1. depth = min(1+1, 3) = 2. Result: "../../"
-        assert_eq!(calculate_base_path(&PathBuf::from("output_dir"), None).unwrap(), "../../");
-
+        assert_eq!(
+            calculate_base_path(&PathBuf::from("output_dir"), None).unwrap(),
+            "../../"
+        );
 
         // If html_dir is "output_dir/group1"
         // This means the chart's index.html will be at "output_dir/group1/chart_name/index.html"
         // current_dir for calculate_base_path is "output_dir/group1"
         // components = 2. depth = min(2+1, 3) = 3. Result: "../../../"
-        assert_eq!(calculate_base_path(&PathBuf::from("output_dir/group1"), None).unwrap(), "../../../");
-
+        assert_eq!(
+            calculate_base_path(&PathBuf::from("output_dir/group1"), None).unwrap(),
+            "../../../"
+        );
 
         // If html_dir is "output_dir/group1/subgroupA" (typical case for generate_chart)
         // Chart's index.html will be at "output_dir/group1/subgroupA/chart_name/index.html"
         // current_dir for calculate_base_path is "output_dir/group1/subgroupA"
         // components = 3. depth = min(3+1, 3) = 3. Result: "../../../"
-        assert_eq!(calculate_base_path(&PathBuf::from("output_dir/group1/subgroupA"), None).unwrap(), "../../../");
+        assert_eq!(
+            calculate_base_path(&PathBuf::from("output_dir/group1/subgroupA"), None).unwrap(),
+            "../../../"
+        );
 
         // Test with a path that would exceed max depth if not capped
-        assert_eq!(calculate_base_path(&PathBuf::from("output_dir/group1/subgroupA/extra"), None).unwrap(), "../../../");
+        assert_eq!(
+            calculate_base_path(&PathBuf::from("output_dir/group1/subgroupA/extra"), None).unwrap(),
+            "../../../"
+        );
     }
 
     #[test]
     fn test_calculate_base_path_with_base_url() {
         let current_dir = PathBuf::from("any/path");
-        assert_eq!(calculate_base_path(&current_dir, Some("http://example.com")).unwrap(), "http://example.com/");
-        assert_eq!(calculate_base_path(&current_dir, Some("http://example.com/")).unwrap(), "http://example.com/");
-        assert_eq!(calculate_base_path(&current_dir, Some("https://cdn.test/reports/")).unwrap(), "https://cdn.test/reports/");
+        assert_eq!(
+            calculate_base_path(&current_dir, Some("http://example.com")).unwrap(),
+            "http://example.com/"
+        );
+        assert_eq!(
+            calculate_base_path(&current_dir, Some("http://example.com/")).unwrap(),
+            "http://example.com/"
+        );
+        assert_eq!(
+            calculate_base_path(&current_dir, Some("https://cdn.test/reports/")).unwrap(),
+            "https://cdn.test/reports/"
+        );
         assert_eq!(calculate_base_path(&current_dir, Some("")).unwrap(), "/"); // Empty base_url becomes "/"
     }
 
@@ -1080,18 +1101,22 @@ mod tests {
         let unit = "ms";
         let page_type = "test_bar";
 
-        let render_data = prepare_bar_chart_render_data(&function_names, &stats, title, unit, page_type);
+        let render_data =
+            prepare_bar_chart_render_data(&function_names, &stats, title, unit, page_type);
 
         assert_eq!(render_data.title, title);
         assert_eq!(render_data.unit, unit);
         assert_eq!(render_data.page_type, page_type);
-        assert_eq!(render_data.y_axis_categories, vec!["AVG", "P99", "P95", "P50"]);
-        
+        assert_eq!(
+            render_data.y_axis_categories,
+            vec!["AVG", "P99", "P95", "P50"]
+        );
+
         assert_eq!(render_data.series.len(), 2);
         // Series 1 (func_a)
         assert_eq!(render_data.series[0].name, "func_a");
         assert_eq!(render_data.series[0].values, vec![11.0, 15.0, 14.0, 12.0]); // Rounded
-        // Series 2 (func_b)
+                                                                                // Series 2 (func_b)
         assert_eq!(render_data.series[1].name, "func_b");
         assert_eq!(render_data.series[1].values, vec![20.0, 26.0, 24.0, 23.0]); // Rounded
     }
@@ -1099,21 +1124,53 @@ mod tests {
     #[test]
     fn test_prepare_line_chart_render_data() {
         let func_a_metrics = vec![
-            ClientMetrics { timestamp: "t1".to_string(), client_duration: 10.12, memory_size: 128 },
-            ClientMetrics { timestamp: "t2".to_string(), client_duration: 12.34, memory_size: 128 },
+            ClientMetrics {
+                timestamp: "t1".to_string(),
+                client_duration: 10.12,
+                memory_size: 128,
+            },
+            ClientMetrics {
+                timestamp: "t2".to_string(),
+                client_duration: 12.34,
+                memory_size: 128,
+            },
         ];
-        let func_b_metrics = vec![
-            ClientMetrics { timestamp: "t3".to_string(), client_duration: 20.56, memory_size: 128 },
-        ];
+        let func_b_metrics = vec![ClientMetrics {
+            timestamp: "t3".to_string(),
+            client_duration: 20.56,
+            memory_size: 128,
+        }];
 
         let results = vec![
-            BenchmarkReport { 
-                config: BenchmarkConfig { function_name: "func_a".to_string(), memory_size: Some(128), concurrent_invocations: 1, rounds: 1, timestamp: "".to_string(), runtime: None, architecture: None, environment: vec![] },
-                cold_starts: vec![], warm_starts: vec![], client_measurements: func_a_metrics 
+            BenchmarkReport {
+                config: BenchmarkConfig {
+                    function_name: "func_a".to_string(),
+                    memory_size: Some(128),
+                    concurrent_invocations: 1,
+                    rounds: 1,
+                    timestamp: "".to_string(),
+                    runtime: None,
+                    architecture: None,
+                    environment: vec![],
+                },
+                cold_starts: vec![],
+                warm_starts: vec![],
+                client_measurements: func_a_metrics,
             },
-            BenchmarkReport { 
-                config: BenchmarkConfig { function_name: "func_b".to_string(), memory_size: Some(128), concurrent_invocations: 1, rounds: 1, timestamp: "".to_string(), runtime: None, architecture: None, environment: vec![] },
-                cold_starts: vec![], warm_starts: vec![], client_measurements: func_b_metrics
+            BenchmarkReport {
+                config: BenchmarkConfig {
+                    function_name: "func_b".to_string(),
+                    memory_size: Some(128),
+                    concurrent_invocations: 1,
+                    rounds: 1,
+                    timestamp: "".to_string(),
+                    runtime: None,
+                    architecture: None,
+                    environment: vec![],
+                },
+                cold_starts: vec![],
+                warm_starts: vec![],
+                client_measurements: func_b_metrics,
             },
         ];
         let function_names = vec!["func_a".to_string(), "func_b".to_string()];
@@ -1121,7 +1178,8 @@ mod tests {
         let unit = "ms";
         let page_type = "test_line";
 
-        let render_data = prepare_line_chart_render_data(&results, &function_names, title, unit, page_type);
+        let render_data =
+            prepare_line_chart_render_data(&results, &function_names, title, unit, page_type);
 
         assert_eq!(render_data.title, title);
         assert_eq!(render_data.unit, unit);
@@ -1147,7 +1205,7 @@ mod tests {
         assert_eq!(render_data.series[1].points[0].x, 7); // offset 7, index 0
         assert_eq!(render_data.series[1].points[0].y, 20.56);
         assert_eq!(render_data.series[1].mean, Some(20.56));
-        
+
         // total_x_points = last_offset (7) + num_points_func_b (1) - gap (if series added)
         // current_offset after func_a = 2 (len) + 5 (gap) = 7
         // max_x after func_a = 7 - 5 = 2
@@ -1158,14 +1216,24 @@ mod tests {
 
     #[test]
     fn test_prepare_line_chart_render_data_empty_measurements() {
-        let results = vec![
-            BenchmarkReport { 
-                config: BenchmarkConfig { function_name: "func_a".to_string(), memory_size: Some(128), concurrent_invocations: 1, rounds: 1, timestamp: "".to_string(), runtime: None, architecture: None, environment: vec![] },
-                cold_starts: vec![], warm_starts: vec![], client_measurements: vec![] // Empty
+        let results = vec![BenchmarkReport {
+            config: BenchmarkConfig {
+                function_name: "func_a".to_string(),
+                memory_size: Some(128),
+                concurrent_invocations: 1,
+                rounds: 1,
+                timestamp: "".to_string(),
+                runtime: None,
+                architecture: None,
+                environment: vec![],
             },
-        ];
+            cold_starts: vec![],
+            warm_starts: vec![],
+            client_measurements: vec![], // Empty
+        }];
         let function_names = vec!["func_a".to_string()];
-        let render_data = prepare_line_chart_render_data(&results, &function_names, "Empty", "ms", "empty_line");
+        let render_data =
+            prepare_line_chart_render_data(&results, &function_names, "Empty", "ms", "empty_line");
 
         assert_eq!(render_data.series.len(), 1);
         assert_eq!(render_data.series[0].name, "func_a");

--- a/cli/startled/src/report.rs
+++ b/cli/startled/src/report.rs
@@ -1005,3 +1005,172 @@ fn prepare_line_chart_render_data(
         page_type: page_type.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{BenchmarkConfig, BenchmarkReport, ClientMetrics}; // Removed unused ColdStartMetrics, EnvVar, WarmStartMetrics
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_snake_to_kebab() {
+        assert_eq!(snake_to_kebab("hello_world"), "hello-world");
+        assert_eq!(snake_to_kebab("another_test_case"), "another-test-case");
+        assert_eq!(snake_to_kebab("single"), "single");
+        assert_eq!(snake_to_kebab(""), "");
+        assert_eq!(snake_to_kebab("_leading_underscore"), "-leading-underscore");
+        assert_eq!(snake_to_kebab("trailing_underscore_"), "trailing-underscore-");
+    }
+
+    #[test]
+    fn test_calculate_base_path_no_base_url() {
+        let _path0 = PathBuf::from(""); // Represents being at the root before any group/subgroup
+        let _path1 = PathBuf::from("group1");
+        let _path2 = PathBuf::from("group1/subgroupA");
+        let _path3 = PathBuf::from("group1/subgroupA/chart_type"); // Max depth for calculation logic
+        let _path4 = PathBuf::from("group1/subgroupA/chart_type/another_level");
+
+
+        // The logic in calculate_base_path adds 1 to component count, then caps at 3.
+        // current_dir is the output_directory/group_name/subgroup_name
+        // The actual HTML file will be one level deeper (e.g., .../chart_name/index.html)
+        // So, if current_dir is "group1/subgroupA", components = 2. depth = min(2+1, 3) = 3. Result: "../../../"
+        
+        // If html_dir is root of output (e.g. "output_dir")
+        // This case is not directly hit by generate_chart's usage, as html_dir is usually deeper.
+        // However, testing the function directly:
+        // If current_dir is "output_dir", components = 1. depth = min(1+1, 3) = 2. Result: "../../"
+        assert_eq!(calculate_base_path(&PathBuf::from("output_dir"), None).unwrap(), "../../");
+
+
+        // If html_dir is "output_dir/group1"
+        // This means the chart's index.html will be at "output_dir/group1/chart_name/index.html"
+        // current_dir for calculate_base_path is "output_dir/group1"
+        // components = 2. depth = min(2+1, 3) = 3. Result: "../../../"
+        assert_eq!(calculate_base_path(&PathBuf::from("output_dir/group1"), None).unwrap(), "../../../");
+
+
+        // If html_dir is "output_dir/group1/subgroupA" (typical case for generate_chart)
+        // Chart's index.html will be at "output_dir/group1/subgroupA/chart_name/index.html"
+        // current_dir for calculate_base_path is "output_dir/group1/subgroupA"
+        // components = 3. depth = min(3+1, 3) = 3. Result: "../../../"
+        assert_eq!(calculate_base_path(&PathBuf::from("output_dir/group1/subgroupA"), None).unwrap(), "../../../");
+
+        // Test with a path that would exceed max depth if not capped
+        assert_eq!(calculate_base_path(&PathBuf::from("output_dir/group1/subgroupA/extra"), None).unwrap(), "../../../");
+    }
+
+    #[test]
+    fn test_calculate_base_path_with_base_url() {
+        let current_dir = PathBuf::from("any/path");
+        assert_eq!(calculate_base_path(&current_dir, Some("http://example.com")).unwrap(), "http://example.com/");
+        assert_eq!(calculate_base_path(&current_dir, Some("http://example.com/")).unwrap(), "http://example.com/");
+        assert_eq!(calculate_base_path(&current_dir, Some("https://cdn.test/reports/")).unwrap(), "https://cdn.test/reports/");
+        assert_eq!(calculate_base_path(&current_dir, Some("")).unwrap(), "/"); // Empty base_url becomes "/"
+    }
+
+    #[test]
+    fn test_prepare_bar_chart_render_data() {
+        let function_names = vec!["func_a".to_string(), "func_b".to_string()];
+        let stats = vec![
+            (10.5, 15.1, 14.2, 12.3), // avg, p99, p95, p50 for func_a
+            (20.0, 25.5, 24.0, 22.5), // avg, p99, p95, p50 for func_b
+        ];
+        let title = "Test Bar Chart";
+        let unit = "ms";
+        let page_type = "test_bar";
+
+        let render_data = prepare_bar_chart_render_data(&function_names, &stats, title, unit, page_type);
+
+        assert_eq!(render_data.title, title);
+        assert_eq!(render_data.unit, unit);
+        assert_eq!(render_data.page_type, page_type);
+        assert_eq!(render_data.y_axis_categories, vec!["AVG", "P99", "P95", "P50"]);
+        
+        assert_eq!(render_data.series.len(), 2);
+        // Series 1 (func_a)
+        assert_eq!(render_data.series[0].name, "func_a");
+        assert_eq!(render_data.series[0].values, vec![11.0, 15.0, 14.0, 12.0]); // Rounded
+        // Series 2 (func_b)
+        assert_eq!(render_data.series[1].name, "func_b");
+        assert_eq!(render_data.series[1].values, vec![20.0, 26.0, 24.0, 23.0]); // Rounded
+    }
+
+    #[test]
+    fn test_prepare_line_chart_render_data() {
+        let func_a_metrics = vec![
+            ClientMetrics { timestamp: "t1".to_string(), client_duration: 10.12, memory_size: 128 },
+            ClientMetrics { timestamp: "t2".to_string(), client_duration: 12.34, memory_size: 128 },
+        ];
+        let func_b_metrics = vec![
+            ClientMetrics { timestamp: "t3".to_string(), client_duration: 20.56, memory_size: 128 },
+        ];
+
+        let results = vec![
+            BenchmarkReport { 
+                config: BenchmarkConfig { function_name: "func_a".to_string(), memory_size: Some(128), concurrent_invocations: 1, rounds: 1, timestamp: "".to_string(), runtime: None, architecture: None, environment: vec![] },
+                cold_starts: vec![], warm_starts: vec![], client_measurements: func_a_metrics 
+            },
+            BenchmarkReport { 
+                config: BenchmarkConfig { function_name: "func_b".to_string(), memory_size: Some(128), concurrent_invocations: 1, rounds: 1, timestamp: "".to_string(), runtime: None, architecture: None, environment: vec![] },
+                cold_starts: vec![], warm_starts: vec![], client_measurements: func_b_metrics
+            },
+        ];
+        let function_names = vec!["func_a".to_string(), "func_b".to_string()];
+        let title = "Test Line Chart";
+        let unit = "ms";
+        let page_type = "test_line";
+
+        let render_data = prepare_line_chart_render_data(&results, &function_names, title, unit, page_type);
+
+        assert_eq!(render_data.title, title);
+        assert_eq!(render_data.unit, unit);
+        assert_eq!(render_data.page_type, page_type);
+        assert_eq!(render_data.x_axis_label, "Test Sequence");
+        assert_eq!(render_data.y_axis_label, "Duration (ms)");
+
+        assert_eq!(render_data.series.len(), 2);
+
+        // Series 1 (func_a)
+        assert_eq!(render_data.series[0].name, "func_a");
+        assert_eq!(render_data.series[0].points.len(), 2);
+        assert_eq!(render_data.series[0].points[0].x, 0); // offset 0, index 0
+        assert_eq!(render_data.series[0].points[0].y, 10.12);
+        assert_eq!(render_data.series[0].points[1].x, 1); // offset 0, index 1
+        assert_eq!(render_data.series[0].points[1].y, 12.34);
+        assert_eq!(render_data.series[0].mean, Some(11.23)); // (10.12 + 12.34) / 2 = 11.23
+
+        // Series 2 (func_b)
+        // current_offset for func_b starts at num_points_func_a (2) + gap (5) = 7
+        assert_eq!(render_data.series[1].name, "func_b");
+        assert_eq!(render_data.series[1].points.len(), 1);
+        assert_eq!(render_data.series[1].points[0].x, 7); // offset 7, index 0
+        assert_eq!(render_data.series[1].points[0].y, 20.56);
+        assert_eq!(render_data.series[1].mean, Some(20.56));
+        
+        // total_x_points = last_offset (7) + num_points_func_b (1) - gap (if series added)
+        // current_offset after func_a = 2 (len) + 5 (gap) = 7
+        // max_x after func_a = 7 - 5 = 2
+        // current_offset after func_b = 7 (prev_offset) + 1 (len) + 5 (gap) = 13
+        // max_x after func_b = 13 - 5 = 8
+        assert_eq!(render_data.total_x_points, 8);
+    }
+
+    #[test]
+    fn test_prepare_line_chart_render_data_empty_measurements() {
+        let results = vec![
+            BenchmarkReport { 
+                config: BenchmarkConfig { function_name: "func_a".to_string(), memory_size: Some(128), concurrent_invocations: 1, rounds: 1, timestamp: "".to_string(), runtime: None, architecture: None, environment: vec![] },
+                cold_starts: vec![], warm_starts: vec![], client_measurements: vec![] // Empty
+            },
+        ];
+        let function_names = vec!["func_a".to_string()];
+        let render_data = prepare_line_chart_render_data(&results, &function_names, "Empty", "ms", "empty_line");
+
+        assert_eq!(render_data.series.len(), 1);
+        assert_eq!(render_data.series[0].name, "func_a");
+        assert_eq!(render_data.series[0].points.len(), 0);
+        assert_eq!(render_data.series[0].mean, None);
+        assert_eq!(render_data.total_x_points, 0); // max_x remains 0 if no points
+    }
+}

--- a/cli/startled/src/stats.rs
+++ b/cli/startled/src/stats.rs
@@ -151,11 +151,31 @@ mod tests {
     }
 
     fn assert_metrics_stats_eq(actual: &MetricsStats, expected: &MetricsStats, context: &str) {
-        assert_f64_eq(actual.mean, expected.mean, &format!("{}: mean mismatch", context));
-        assert_f64_eq(actual.p50, expected.p50, &format!("{}: p50 mismatch", context));
-        assert_f64_eq(actual.p95, expected.p95, &format!("{}: p95 mismatch", context));
-        assert_f64_eq(actual.p99, expected.p99, &format!("{}: p99 mismatch", context));
-        assert_f64_eq(actual.std_dev, expected.std_dev, &format!("{}: std_dev mismatch", context));
+        assert_f64_eq(
+            actual.mean,
+            expected.mean,
+            &format!("{}: mean mismatch", context),
+        );
+        assert_f64_eq(
+            actual.p50,
+            expected.p50,
+            &format!("{}: p50 mismatch", context),
+        );
+        assert_f64_eq(
+            actual.p95,
+            expected.p95,
+            &format!("{}: p95 mismatch", context),
+        );
+        assert_f64_eq(
+            actual.p99,
+            expected.p99,
+            &format!("{}: p99 mismatch", context),
+        );
+        assert_f64_eq(
+            actual.std_dev,
+            expected.std_dev,
+            &format!("{}: std_dev mismatch", context),
+        );
     }
 
     fn assert_option_tuple_eq(
@@ -231,8 +251,26 @@ mod tests {
     #[test]
     fn test_calculate_cold_start_init_stats_happy_path() {
         let cold_starts = [
-            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
-            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: Some(352.0), billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+            ColdStartMetrics {
+                timestamp: "ts1".to_string(),
+                init_duration: 100.0,
+                duration: 200.0,
+                extension_overhead: 10.0,
+                total_cold_start_duration: Some(310.0),
+                billed_duration: 300,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            ColdStartMetrics {
+                timestamp: "ts2".to_string(),
+                init_duration: 120.0,
+                duration: 220.0,
+                extension_overhead: 12.0,
+                total_cold_start_duration: Some(352.0),
+                billed_duration: 320,
+                max_memory_used: 130,
+                memory_size: 256,
+            },
         ];
         let result = calculate_cold_start_init_stats(&cold_starts);
         let durations = [100.0, 120.0];
@@ -251,8 +289,26 @@ mod tests {
     #[test]
     fn test_calculate_cold_start_server_stats_happy_path() {
         let cold_starts = [
-            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
-            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: Some(352.0), billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+            ColdStartMetrics {
+                timestamp: "ts1".to_string(),
+                init_duration: 100.0,
+                duration: 200.0,
+                extension_overhead: 10.0,
+                total_cold_start_duration: Some(310.0),
+                billed_duration: 300,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            ColdStartMetrics {
+                timestamp: "ts2".to_string(),
+                init_duration: 120.0,
+                duration: 220.0,
+                extension_overhead: 12.0,
+                total_cold_start_duration: Some(352.0),
+                billed_duration: 320,
+                max_memory_used: 130,
+                memory_size: 256,
+            },
         ];
         let result = calculate_cold_start_server_stats(&cold_starts);
         let durations = [200.0, 220.0];
@@ -260,7 +316,7 @@ mod tests {
         let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
         assert_option_tuple_eq(result, expected, "cs_server_happy");
     }
-    
+
     fn get_warm_duration(ws: &WarmStartMetrics) -> f64 {
         ws.duration
     }
@@ -275,8 +331,22 @@ mod tests {
     #[test]
     fn test_calculate_warm_start_stats_happy_path() {
         let warm_starts = [
-            WarmStartMetrics { timestamp: "ts1".to_string(), duration: 50.0, extension_overhead: 5.0, billed_duration: 50, max_memory_used: 128, memory_size: 256 },
-            WarmStartMetrics { timestamp: "ts2".to_string(), duration: 60.0, extension_overhead: 6.0, billed_duration: 60, max_memory_used: 130, memory_size: 256 },
+            WarmStartMetrics {
+                timestamp: "ts1".to_string(),
+                duration: 50.0,
+                extension_overhead: 5.0,
+                billed_duration: 50,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            WarmStartMetrics {
+                timestamp: "ts2".to_string(),
+                duration: 60.0,
+                extension_overhead: 6.0,
+                billed_duration: 60,
+                max_memory_used: 130,
+                memory_size: 256,
+            },
         ];
         let result = calculate_warm_start_stats(&warm_starts, get_warm_duration);
         let durations = [50.0, 60.0];
@@ -295,8 +365,16 @@ mod tests {
     #[test]
     fn test_calculate_client_stats_happy_path() {
         let client_metrics = [
-            ClientMetrics { timestamp: "ts1".to_string(), client_duration: 30.0, memory_size: 256 },
-            ClientMetrics { timestamp: "ts2".to_string(), client_duration: 35.0, memory_size: 256 },
+            ClientMetrics {
+                timestamp: "ts1".to_string(),
+                client_duration: 30.0,
+                memory_size: 256,
+            },
+            ClientMetrics {
+                timestamp: "ts2".to_string(),
+                client_duration: 35.0,
+                memory_size: 256,
+            },
         ];
         let result = calculate_client_stats(&client_metrics);
         let durations = [30.0, 35.0];
@@ -315,8 +393,22 @@ mod tests {
     #[test]
     fn test_calculate_memory_stats_happy_path() {
         let warm_starts = [
-            WarmStartMetrics { timestamp: "ts1".to_string(), duration: 50.0, extension_overhead: 5.0, billed_duration: 50, max_memory_used: 128, memory_size: 256 },
-            WarmStartMetrics { timestamp: "ts2".to_string(), duration: 60.0, extension_overhead: 6.0, billed_duration: 60, max_memory_used: 256, memory_size: 512 },
+            WarmStartMetrics {
+                timestamp: "ts1".to_string(),
+                duration: 50.0,
+                extension_overhead: 5.0,
+                billed_duration: 50,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            WarmStartMetrics {
+                timestamp: "ts2".to_string(),
+                duration: 60.0,
+                extension_overhead: 6.0,
+                billed_duration: 60,
+                max_memory_used: 256,
+                memory_size: 512,
+            },
         ];
         let result = calculate_memory_stats(&warm_starts);
         let memory_values = [128.0, 256.0];
@@ -335,8 +427,26 @@ mod tests {
     #[test]
     fn test_calculate_cold_start_extension_overhead_stats_happy_path() {
         let cold_starts = [
-            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
-            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: Some(352.0), billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+            ColdStartMetrics {
+                timestamp: "ts1".to_string(),
+                init_duration: 100.0,
+                duration: 200.0,
+                extension_overhead: 10.0,
+                total_cold_start_duration: Some(310.0),
+                billed_duration: 300,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            ColdStartMetrics {
+                timestamp: "ts2".to_string(),
+                init_duration: 120.0,
+                duration: 220.0,
+                extension_overhead: 12.0,
+                total_cold_start_duration: Some(352.0),
+                billed_duration: 320,
+                max_memory_used: 130,
+                memory_size: 256,
+            },
         ];
         let result = calculate_cold_start_extension_overhead_stats(&cold_starts);
         let overheads = [10.0, 12.0];
@@ -355,8 +465,26 @@ mod tests {
     #[test]
     fn test_calculate_cold_start_total_duration_stats_all_none() {
         let cold_starts = [
-            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: None, billed_duration: 300, max_memory_used: 128, memory_size: 256 },
-            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: None, billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+            ColdStartMetrics {
+                timestamp: "ts1".to_string(),
+                init_duration: 100.0,
+                duration: 200.0,
+                extension_overhead: 10.0,
+                total_cold_start_duration: None,
+                billed_duration: 300,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            ColdStartMetrics {
+                timestamp: "ts2".to_string(),
+                init_duration: 120.0,
+                duration: 220.0,
+                extension_overhead: 12.0,
+                total_cold_start_duration: None,
+                billed_duration: 320,
+                max_memory_used: 130,
+                memory_size: 256,
+            },
         ];
         let result = calculate_cold_start_total_duration_stats(&cold_starts);
         assert_eq!(result, None, "cs_total_dur_all_none");
@@ -365,9 +493,36 @@ mod tests {
     #[test]
     fn test_calculate_cold_start_total_duration_stats_happy_path() {
         let cold_starts = [
-            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
-            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: None, billed_duration: 320, max_memory_used: 130, memory_size: 256 }, // One None
-            ColdStartMetrics { timestamp: "ts3".to_string(), init_duration: 130.0, duration: 230.0, extension_overhead: 13.0, total_cold_start_duration: Some(373.0), billed_duration: 330, max_memory_used: 140, memory_size: 256 },
+            ColdStartMetrics {
+                timestamp: "ts1".to_string(),
+                init_duration: 100.0,
+                duration: 200.0,
+                extension_overhead: 10.0,
+                total_cold_start_duration: Some(310.0),
+                billed_duration: 300,
+                max_memory_used: 128,
+                memory_size: 256,
+            },
+            ColdStartMetrics {
+                timestamp: "ts2".to_string(),
+                init_duration: 120.0,
+                duration: 220.0,
+                extension_overhead: 12.0,
+                total_cold_start_duration: None,
+                billed_duration: 320,
+                max_memory_used: 130,
+                memory_size: 256,
+            }, // One None
+            ColdStartMetrics {
+                timestamp: "ts3".to_string(),
+                init_duration: 130.0,
+                duration: 230.0,
+                extension_overhead: 13.0,
+                total_cold_start_duration: Some(373.0),
+                billed_duration: 330,
+                max_memory_used: 140,
+                memory_size: 256,
+            },
         ];
         let result = calculate_cold_start_total_duration_stats(&cold_starts);
         let durations = [310.0, 373.0]; // Only Some values

--- a/cli/startled/src/stats.rs
+++ b/cli/startled/src/stats.rs
@@ -138,3 +138,241 @@ pub fn calculate_cold_start_total_duration_stats(
     let stats = calculate_stats(&durations);
     Some((stats.mean, stats.p99, stats.p95, stats.p50))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ClientMetrics, ColdStartMetrics, WarmStartMetrics};
+
+    const EPSILON: f64 = 1e-9;
+
+    fn assert_f64_eq(a: f64, b: f64, msg: &str) {
+        assert!((a - b).abs() < EPSILON, "{} | {} vs {}", msg, a, b);
+    }
+
+    fn assert_metrics_stats_eq(actual: &MetricsStats, expected: &MetricsStats, context: &str) {
+        assert_f64_eq(actual.mean, expected.mean, &format!("{}: mean mismatch", context));
+        assert_f64_eq(actual.p50, expected.p50, &format!("{}: p50 mismatch", context));
+        assert_f64_eq(actual.p95, expected.p95, &format!("{}: p95 mismatch", context));
+        assert_f64_eq(actual.p99, expected.p99, &format!("{}: p99 mismatch", context));
+        assert_f64_eq(actual.std_dev, expected.std_dev, &format!("{}: std_dev mismatch", context));
+    }
+
+    fn assert_option_tuple_eq(
+        actual: Option<(f64, f64, f64, f64)>,
+        expected: Option<(f64, f64, f64, f64)>,
+        context: &str,
+    ) {
+        match (actual, expected) {
+            (Some(a), Some(e)) => {
+                assert_f64_eq(a.0, e.0, &format!("{}: mean (tuple.0) mismatch", context));
+                assert_f64_eq(a.1, e.1, &format!("{}: p99 (tuple.1) mismatch", context));
+                assert_f64_eq(a.2, e.2, &format!("{}: p95 (tuple.2) mismatch", context));
+                assert_f64_eq(a.3, e.3, &format!("{}: p50 (tuple.3) mismatch", context));
+            }
+            (None, None) => {} // Both are None, which is fine.
+            _ => panic!(
+                "{}: Option mismatch. Actual: {:?}, Expected: {:?}",
+                context, actual, expected
+            ),
+        }
+    }
+
+    #[test]
+    fn test_calculate_stats_empty_slice() {
+        let values: [f64; 0] = [];
+        let stats = calculate_stats(&values);
+        let expected = MetricsStats {
+            mean: 0.0,
+            p50: 0.0,
+            p95: 0.0,
+            p99: 0.0,
+            std_dev: 0.0,
+        };
+        assert_metrics_stats_eq(&stats, &expected, "empty_slice");
+    }
+
+    #[test]
+    fn test_calculate_stats_single_value() {
+        let values = [5.0];
+        let stats = calculate_stats(&values);
+        let expected = MetricsStats {
+            mean: 5.0,
+            p50: 5.0,
+            p95: 5.0,
+            p99: 5.0,
+            std_dev: 0.0,
+        };
+        assert_metrics_stats_eq(&stats, &expected, "single_value");
+    }
+
+    #[test]
+    fn test_calculate_stats_multiple_values() {
+        let values = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 100.0]; // N=11
+        let stats = calculate_stats(&values);
+        let mut data = statrs::statistics::Data::new(values.to_vec());
+        let expected = MetricsStats {
+            mean: data.mean().unwrap(),
+            p50: data.percentile(50),
+            p95: data.percentile(95),
+            p99: data.percentile(99),
+            std_dev: data.std_dev().unwrap(),
+        };
+        assert_metrics_stats_eq(&stats, &expected, "multiple_values");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_init_stats_empty() {
+        let cold_starts: [ColdStartMetrics; 0] = [];
+        let result = calculate_cold_start_init_stats(&cold_starts);
+        assert_eq!(result, None, "cs_init_empty");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_init_stats_happy_path() {
+        let cold_starts = [
+            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
+            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: Some(352.0), billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+        ];
+        let result = calculate_cold_start_init_stats(&cold_starts);
+        let durations = [100.0, 120.0];
+        let stats = calculate_stats(&durations);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "cs_init_happy");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_server_stats_empty() {
+        let cold_starts: [ColdStartMetrics; 0] = [];
+        let result = calculate_cold_start_server_stats(&cold_starts);
+        assert_eq!(result, None, "cs_server_empty");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_server_stats_happy_path() {
+        let cold_starts = [
+            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
+            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: Some(352.0), billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+        ];
+        let result = calculate_cold_start_server_stats(&cold_starts);
+        let durations = [200.0, 220.0];
+        let stats = calculate_stats(&durations);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "cs_server_happy");
+    }
+    
+    fn get_warm_duration(ws: &WarmStartMetrics) -> f64 {
+        ws.duration
+    }
+
+    #[test]
+    fn test_calculate_warm_start_stats_empty() {
+        let warm_starts: [WarmStartMetrics; 0] = [];
+        let result = calculate_warm_start_stats(&warm_starts, get_warm_duration);
+        assert_eq!(result, None, "ws_empty");
+    }
+
+    #[test]
+    fn test_calculate_warm_start_stats_happy_path() {
+        let warm_starts = [
+            WarmStartMetrics { timestamp: "ts1".to_string(), duration: 50.0, extension_overhead: 5.0, billed_duration: 50, max_memory_used: 128, memory_size: 256 },
+            WarmStartMetrics { timestamp: "ts2".to_string(), duration: 60.0, extension_overhead: 6.0, billed_duration: 60, max_memory_used: 130, memory_size: 256 },
+        ];
+        let result = calculate_warm_start_stats(&warm_starts, get_warm_duration);
+        let durations = [50.0, 60.0];
+        let stats = calculate_stats(&durations);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "ws_happy");
+    }
+
+    #[test]
+    fn test_calculate_client_stats_empty() {
+        let client_metrics: [ClientMetrics; 0] = [];
+        let result = calculate_client_stats(&client_metrics);
+        assert_eq!(result, None, "client_empty");
+    }
+
+    #[test]
+    fn test_calculate_client_stats_happy_path() {
+        let client_metrics = [
+            ClientMetrics { timestamp: "ts1".to_string(), client_duration: 30.0, memory_size: 256 },
+            ClientMetrics { timestamp: "ts2".to_string(), client_duration: 35.0, memory_size: 256 },
+        ];
+        let result = calculate_client_stats(&client_metrics);
+        let durations = [30.0, 35.0];
+        let stats = calculate_stats(&durations);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "client_happy");
+    }
+
+    #[test]
+    fn test_calculate_memory_stats_empty() {
+        let warm_starts: [WarmStartMetrics; 0] = [];
+        let result = calculate_memory_stats(&warm_starts);
+        assert_eq!(result, None, "mem_empty");
+    }
+
+    #[test]
+    fn test_calculate_memory_stats_happy_path() {
+        let warm_starts = [
+            WarmStartMetrics { timestamp: "ts1".to_string(), duration: 50.0, extension_overhead: 5.0, billed_duration: 50, max_memory_used: 128, memory_size: 256 },
+            WarmStartMetrics { timestamp: "ts2".to_string(), duration: 60.0, extension_overhead: 6.0, billed_duration: 60, max_memory_used: 256, memory_size: 512 },
+        ];
+        let result = calculate_memory_stats(&warm_starts);
+        let memory_values = [128.0, 256.0];
+        let stats = calculate_stats(&memory_values);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "mem_happy");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_extension_overhead_stats_empty() {
+        let cold_starts: [ColdStartMetrics; 0] = [];
+        let result = calculate_cold_start_extension_overhead_stats(&cold_starts);
+        assert_eq!(result, None, "cs_ext_overhead_empty");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_extension_overhead_stats_happy_path() {
+        let cold_starts = [
+            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
+            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: Some(352.0), billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+        ];
+        let result = calculate_cold_start_extension_overhead_stats(&cold_starts);
+        let overheads = [10.0, 12.0];
+        let stats = calculate_stats(&overheads);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "cs_ext_overhead_happy");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_total_duration_stats_empty_input() {
+        let cold_starts: [ColdStartMetrics; 0] = [];
+        let result = calculate_cold_start_total_duration_stats(&cold_starts);
+        assert_eq!(result, None, "cs_total_dur_empty_input");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_total_duration_stats_all_none() {
+        let cold_starts = [
+            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: None, billed_duration: 300, max_memory_used: 128, memory_size: 256 },
+            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: None, billed_duration: 320, max_memory_used: 130, memory_size: 256 },
+        ];
+        let result = calculate_cold_start_total_duration_stats(&cold_starts);
+        assert_eq!(result, None, "cs_total_dur_all_none");
+    }
+
+    #[test]
+    fn test_calculate_cold_start_total_duration_stats_happy_path() {
+        let cold_starts = [
+            ColdStartMetrics { timestamp: "ts1".to_string(), init_duration: 100.0, duration: 200.0, extension_overhead: 10.0, total_cold_start_duration: Some(310.0), billed_duration: 300, max_memory_used: 128, memory_size: 256 },
+            ColdStartMetrics { timestamp: "ts2".to_string(), init_duration: 120.0, duration: 220.0, extension_overhead: 12.0, total_cold_start_duration: None, billed_duration: 320, max_memory_used: 130, memory_size: 256 }, // One None
+            ColdStartMetrics { timestamp: "ts3".to_string(), init_duration: 130.0, duration: 230.0, extension_overhead: 13.0, total_cold_start_duration: Some(373.0), billed_duration: 330, max_memory_used: 140, memory_size: 256 },
+        ];
+        let result = calculate_cold_start_total_duration_stats(&cold_starts);
+        let durations = [310.0, 373.0]; // Only Some values
+        let stats = calculate_stats(&durations);
+        let expected = Some((stats.mean, stats.p99, stats.p95, stats.p50));
+        assert_option_tuple_eq(result, expected, "cs_total_dur_happy");
+    }
+}

--- a/cli/startled/src/types.rs
+++ b/cli/startled/src/types.rs
@@ -33,7 +33,7 @@ impl std::str::FromStr for EnvVar {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkConfig {
     pub function_name: String,
     pub memory_size: Option<i32>,
@@ -46,7 +46,7 @@ pub struct BenchmarkConfig {
     pub environment: Vec<EnvVar>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ColdStartMetrics {
     pub timestamp: String,
     pub init_duration: f64,
@@ -58,7 +58,7 @@ pub struct ColdStartMetrics {
     pub memory_size: i64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WarmStartMetrics {
     pub timestamp: String,
     pub duration: f64,
@@ -68,7 +68,7 @@ pub struct WarmStartMetrics {
     pub memory_size: i64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClientMetrics {
     pub timestamp: String,
     pub client_duration: f64,
@@ -129,7 +129,7 @@ impl InvocationMetrics {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkReport {
     pub config: BenchmarkConfig,
     pub cold_starts: Vec<ColdStartMetrics>,


### PR DESCRIPTION
This pull request introduces several updates to the `startled` CLI tool, including a version bump, dependency additions, and a comprehensive suite of new tests for benchmarking and reporting functionality.

### Dependency and Version Updates:

* Updated the `startled` package version from `0.1.0` to `0.1.1` in `Cargo.toml`.
* Added `tempfile` as a development dependency for temporary file management in tests.

### New Tests for Benchmarking:

* Added a new test module in `cli/startled/src/benchmark.rs` to validate `FunctionBenchmarkConfig` creation and the `save_report` function's behavior, including cases for default memory configurations and successful report saving.

### New Tests for Reporting:

* Introduced a test module in `cli/startled/src/report.rs` for various utility functions:
  - `snake_to_kebab` conversion.
  - `calculate_base_path` logic with and without a base URL.
  - Data preparation for bar and line chart rendering, including edge cases like empty measurements.