### PR TITLE
release: cli/startled v0.3.0

### DIFF
--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -39,3 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated `startled` CLI version from 0.1.0 to 0.1.1 in `Cargo.toml`.
+
+## [0.3.0] - 2025-05-12
+
+### Added
+- `--parallel` option to `stack` command for concurrent benchmarking of selected Lambda functions. Includes an overall progress bar and a final summary for parallel runs, suppressing detailed individual console logs.
+
+### Changed
+- `--memory` option is now **required** for both `function` and `stack` commands. This simplifies result directory structures by removing the "default" memory path.
+
+### Fixed
+- Improved console output management for parallel `stack` benchmarks to ensure a cleaner progress bar display by serializing configuration printing and conditionally suppressing other verbose logs from individual function benchmark tasks.

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/startled/PUBLISHING.md
+++ b/cli/startled/PUBLISHING.md
@@ -20,7 +20,7 @@ This document outlines the steps to publish a new version of the `startled` CLI 
         (e.g., `release/cli/startled-v0.2.0_candidate` - use a placeholder initially if exact version is TBD based on diff).
 
 3.  **Review Changes & Determine Version**:
-    *   Run `git diff main...HEAD cli/startled | cat` (or compare against the last release tag) to review all changes specific to the `cli/startled` directory for this release.
+    *   Run `git diff cli/startled | cat` (or git diff . if you are already in the cli/startled directory) to review all changes specific to the `cli/startled` directory for this release.
     *   Based on the `git diff`, decide if the release is a `patch` or `minor` update according to Semantic Versioning (SemVer) for 0.x releases:
         *   **Patch (0.x.Y -> 0.x.Z, where Z > Y)**: For backwards-compatible bug fixes.
         *   **Minor (0.X.y -> 0.Y.z, where Y > X)**: For new backwards-compatible functionality.
@@ -59,7 +59,7 @@ This document outlines the steps to publish a new version of the `startled` CLI 
     *   Navigate to the crate directory: `cd cli/startled` (if not already there).
     *   Perform a `cargo publish --dry-run --allow-dirty`. This checks for common packaging issues without actually publishing.
         ```bash
-        cargo publish --dry-run
+        cargo publish --dry-run --allow-dirty
         ```
     *   Address any errors or warnings from the dry run.
 
@@ -82,20 +82,5 @@ This document outlines the steps to publish a new version of the `startled` CLI 
         ```bash
         git push origin release/cli/startled-v<VERSION>
         ```
-
-10. **Open a Pull Request (PR)**:
-    *   Open a new PR from `release/cli/startled-v<VERSION>` to the main development branch.
-    *   Ensure the PR description includes or links to the release notes.
-    *   Wait for CI checks to pass and for code review.
-
-11. **Merge the PR**:
-    *   Once approved and all checks pass, merge the PR into the main development branch (e.g., using a squash merge if preferred, to keep the main branch history clean with a single commit for the release prep).
-
-12. **Automated Post-Merge Steps (CI/CD)**:
-    *   Upon merging the release PR (or a push to the main branch with the correct version commit), the CI/CD pipeline configured in `.github/workflows/publish-startled.yml` should automatically:
-        *   Create a Git tag (e.g., `cli/startled/v<VERSION>`).
-        *   Publish the `startled` crate (version from `Cargo.toml`) to Crates.io.
-        *   Create a corresponding GitHub Release, potentially using `RELEASE_NOTES.md`.
-
 ---
 This checklist should be followed for each new release to ensure consistency and quality. 

--- a/cli/startled/README.md
+++ b/cli/startled/README.md
@@ -153,7 +153,7 @@ Benchmarks a single, specified Lambda function.
 
 **Key Options:**
 -   `<FUNCTION_NAME>`: (Required) The name or ARN of the Lambda function to be benchmarked.
--   `--memory <MB>` (`-m <MB>`): Temporarily sets the function's memory allocation to `<MB>` for the benchmark duration.
+-   `--memory <MB>` (`-m <MB>`): (Required) Sets the function's memory allocation to `<MB>` for the benchmark duration.
 -   `--concurrent <N>` (`-c <N>`): Specifies the number of concurrent invocations (default: 1).
 -   `--rounds <N>` (`-n <N>`): Sets the number of repetitions for warm start measurements. Each round consists of `--concurrent` invocations (default: 1).
 -   `--payload <JSON_STRING>`: Provides a JSON payload string for each invocation. Conflicts with `--payload-file`.
@@ -186,12 +186,13 @@ Benchmarks Lambda functions defined within a specified AWS CloudFormation stack.
 -   `--select <PATTERN>` (`-s <PATTERN>`): (Required) A simple string pattern for substring matching against function names or ARNs within the stack. This pattern is also used to name a subdirectory for the results unless `--select-name` is provided. The pattern must be filesystem-safe if used for directory naming (alphanumeric, underscores, hyphens).
 -   `--select-regex <REGEX>`: (Optional) A regular expression to filter functions within the stack. If provided, this regex is used for filtering instead of the `--select <PATTERN>`. This option does not affect directory naming.
 -   `--select-name <NAME>`: (Optional) Specifies a custom name for the subdirectory where results for this selection group will be stored. If provided, this name overrides the `--select <PATTERN>` for directory naming purposes. The name must be filesystem-safe (alphanumeric, underscores, hyphens).
--   `--memory <MB>` (`-m <MB>`): Temporarily sets memory for all selected functions.
+-   `--memory <MB>` (`-m <MB>`): (Required) Sets memory for all selected functions to `<MB>` for the benchmark duration.
 -   `--concurrent <N>` (`-c <N>`): Number of concurrent invocations (default: 1).
 -   `--rounds <N>` (`-n <N>`): Number of warm start repetitions (default: 1).
 -   `--payload <JSON_STRING>` / `--payload-file <PATH>`: Payload for invocations, applied to all selected functions.
 -   `--env <KEY=VALUE>` (`-e <KEY=VALUE>`): Environment variables for selected functions.
 -   `--proxy <PROXY_FUNCTION_NAME_OR_ARN>`: Proxy Lambda for client-side measurements.
+-   `--parallel`: (Optional) If specified, benchmarks for all selected functions in the stack are run in parallel. This will suppress detailed console output for individual function benchmarks and show an overall progress bar instead. A summary will be printed upon completion.
 -   `--output-dir <PATH>` (`-d <PATH>`): (Optional) Base directory for JSON results. If provided, a subdirectory named after `--select-name` (or `--select <PATTERN>`) will be created within this base directory to store the results. If this option is not specified, no benchmark results will be saved.
 
 **Example:**
@@ -318,7 +319,7 @@ The main HTML report will be accessible at `/var/www/benchmarks/my-application-s
 ### Output File Structure
 
 -   **JSON Results**: Individual benchmark results are stored in a structured path if an output directory is specified.
-    -   For `function` command: If `--output-dir` is specified, results are saved under `<YOUR_OUTPUT_DIR>/function/{memory_setting}/{function_name}.json` (e.g., `/tmp/results/function/128mb/my-lambda.json`). If memory is not set, `{memory_setting}` will be "default". If `--output-dir` is omitted, no results are saved.
+    -   For `function` command: If `--output-dir` is specified, results are saved under `<YOUR_OUTPUT_DIR>/function/{memory_setting}/{function_name}.json` (e.g., `/tmp/results/function/128mb/my-lambda.json`). If `--output-dir` is omitted, no results are saved.
     -   For `stack` command: If `--output-dir` is specified, results are saved to `your_output_dir/{select_name_or_pattern}/{memory_setting}/{function_name}.json` (or `your_output_dir/{select_name_or_pattern}/default/{function_name}.json` if memory is not set). If `--output-dir` is omitted, no results are saved.
 -   **HTML Reports**: The `report` command generates a structured set of HTML files within its specified `--output-dir`. The input directory for the report command should point to the level containing the `{select_name_or_pattern}` or `{memory_setting}` (for function command) directories.
     -   Example: `/srv/benchmarks/run1/index.html`, with sub-pages such as `/srv/benchmarks/run1/api-tests/512mb/cold_start_init.html`.

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,47 +1,11 @@
-# Release Notes - startled v0.2.0
+# Release Notes - startled v0.3.0
 
-**Release Date:** 2025-05-11
+**Release Date:** 2025-05-12
 
-This release of `startled` (v0.2.0) introduces significant enhancements to metrics reporting and report usability.
+This release introduces parallel benchmarking for stack commands and makes the `--memory` option required for all benchmarks.
 
 ## Key Highlights
 
-*   **Enhanced Metrics Collection & Reporting**: `startled` now captures a richer set of platform metrics from AWS Lambda, including:
-    *   Response Latency
-    *   Response Duration
-    *   Runtime Overhead
-    *   Produced Bytes
-    *   Runtime Done Duration
-    These new metrics are available in both the raw JSON output and the generated HTML reports, providing deeper insights into function performance.
-
-*   **Standard Deviation in Reports**: All statistical summaries and bar charts in the HTML report now include Standard Deviation (StdDev), offering a better understanding of the variability in your benchmark results alongside averages and percentiles.
-
-*   **Improved HTML Report Layout**: The navigation for metric groups (Cold Start, Warm Start, Resources) within the HTML report has been redesigned. Groups are now stacked vertically, and the links within each group are arranged in a responsive grid, making it easier to navigate and view on various screen sizes.
-
-*   **Accurate Sub-Millisecond Reporting**: Values in HTML charts, especially for short durations, are now rounded to 3 decimal places, ensuring that sub-millisecond timings are accurately represented instead of being rounded to zero.
-
-*   **Full-Length Descriptions**: Link labels and page titles in the HTML report now use their full, descriptive names for clarity, leveraging the new flexible layout.
-
-## Detailed Changes
-
-### Added
-- Collection and reporting (JSON & HTML) for new platform metrics: Response Latency, Response Duration, Runtime Overhead, Produced Bytes, and Runtime Done Duration.
-- Calculation and display of Standard Deviation (StdDev) for all relevant metrics in HTML reports.
-- `PUBLISHING.md`: A comprehensive guide for the internal release process.
-
-### Changed
-- **HTML Report UI**: 
-    - Navigation groups (Cold Start, Warm Start, Resources) are now stacked vertically.
-    - Links within these groups wrap into a grid layout, improving usability on different screen widths.
-    - Link labels and page H1 titles reverted to full descriptive text.
-- **Data Precision**: Statistical values in HTML bar charts are now rounded to 3 decimal places.
-- **Telemetry**: `telemetry.rs` updated for conditional console tracing via the `TRACING_STDOUT` environment variable.
-- Minor updates to `testbed/Makefile` and `testbed/testbed.md`.
-
-### Fixed
-- Addressed various test failures and linter warnings that arose during the development of these new features.
-- Resolved CSS issues to ensure correct chart display and navigation link layout.
-- Corrected test data in `benchmark.rs` and `stats.rs` to properly initialize all metric fields in test structs.
-
----
-We believe these enhancements make `startled` an even more powerful tool for Lambda performance analysis. As always, feedback and contributions are welcome!
+- **Parallel Stack Benchmarks:** The new `--parallel` option for the `stack` command allows benchmarking all selected Lambda functions concurrently, with an overall progress bar and summary output.
+- **Required Memory Argument:** The `--memory` option is now required for both `function` and `stack` commands, simplifying result directory structures and ensuring explicit configuration.
+- **Improved Output:** Console output for parallel stack benchmarks is now cleaner, with configuration printing serialized and verbose logs suppressed for individual function tasks.

--- a/cli/startled/src/report.rs
+++ b/cli/startled/src/report.rs
@@ -1450,7 +1450,7 @@ mod tests {
             BenchmarkReport {
                 config: BenchmarkConfig {
                     function_name: "func_a".to_string(),
-                    memory_size: Some(128),
+                    memory_size: 128,
                     concurrent_invocations: 1,
                     rounds: 1,
                     timestamp: "".to_string(),
@@ -1465,7 +1465,7 @@ mod tests {
             BenchmarkReport {
                 config: BenchmarkConfig {
                     function_name: "func_b".to_string(),
-                    memory_size: Some(128),
+                    memory_size: 128,
                     concurrent_invocations: 1,
                     rounds: 1,
                     timestamp: "".to_string(),
@@ -1524,7 +1524,7 @@ mod tests {
         let results = vec![BenchmarkReport {
             config: BenchmarkConfig {
                 function_name: "func_a".to_string(),
-                memory_size: Some(128),
+                memory_size: 128,
                 concurrent_invocations: 1,
                 rounds: 1,
                 timestamp: "".to_string(),

--- a/cli/startled/src/templates/css/style.css
+++ b/cli/startled/src/templates/css/style.css
@@ -583,6 +583,7 @@ a:hover {
     flex-direction: column;
     gap: 0.25rem;
     align-items: flex-start;
+    width: 100%;
 }
 
 .nav-group-label {
@@ -600,6 +601,7 @@ a:hover {
     justify-content: flex-start;
     flex-wrap: wrap;
     margin-left: 1rem;
+    width: 100%;
 }
 
 .nav-link {
@@ -610,7 +612,8 @@ a:hover {
     font-weight: 400;
     padding: 0.25rem 0.5rem;
     border: 1px solid var(--border-color);
-    width: 6rem;
+    width: calc(100% / 11);
+    min-width: 6rem;
     height: 4rem;
     text-align: left;
     background: var(--env-bg);

--- a/cli/startled/src/types.rs
+++ b/cli/startled/src/types.rs
@@ -36,7 +36,7 @@ impl std::str::FromStr for EnvVar {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkConfig {
     pub function_name: String,
-    pub memory_size: Option<i32>,
+    pub memory_size: i32,
     pub concurrent_invocations: u32,
     pub rounds: u32,
     pub timestamp: String,
@@ -199,7 +199,7 @@ pub struct StackBenchmarkConfig {
     pub stack_name: String,
     pub select_pattern: String,       // Value from --select (required)
     pub select_regex: Option<String>, // Value from --select-regex (optional)
-    pub memory_size: Option<i32>,
+    pub memory_size: i32,
     pub concurrent_invocations: usize,
     pub rounds: usize,
     pub output_dir: Option<String>, // Path like "base_dir/group_name" or "group_name"
@@ -207,6 +207,7 @@ pub struct StackBenchmarkConfig {
     pub environment: Vec<EnvVar>,
     pub client_metrics_mode: bool,
     pub proxy_function: Option<String>,
+    pub parallel: bool, // Added for parallel execution
 }
 
 /// Original function configuration to restore after testing

--- a/cli/startled/testbed/functions/rust/stdout/src/main.rs
+++ b/cli/startled/testbed/functions/rust/stdout/src/main.rs
@@ -1,7 +1,6 @@
 use lambda_otel_lite::{create_traced_handler, init_telemetry, TelemetryConfig};
 use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
 use serde_json::{json, Value};
-use tracing::{info, instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 const DEFAULT_DEPTH: u64 = 2;


### PR DESCRIPTION
This pull request introduces significant updates to the `startled` CLI, including new features, required argument changes, improved output handling, and internal code refactoring. The changes enhance the benchmarking capabilities, simplify configurations, and improve the user experience, particularly for parallel benchmarking scenarios.

### New Features and Enhancements:
* Added a `--parallel` option to the `stack` command, enabling concurrent benchmarking of multiple Lambda functions. This feature includes an overall progress bar, a final summary output, and suppressed detailed logs for individual benchmarks. (`cli/startled/CHANGELOG.md`, `cli/startled/README.md`, `cli/startled/RELEASE_NOTES.md`, [[1]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55L163-R169) [[2]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55R240-R252)

### Breaking Changes:
* The `--memory` option is now **required** for both `function` and `stack` commands. This change eliminates the "default" memory path in result directories, ensuring explicit memory configuration. (`cli/startled/CHANGELOG.md`, `cli/startled/README.md`, `cli/startled/src/benchmark.rs`, [[1]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55L32-R34) [[2]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55L46-R48)

### Improved Output Management:
* Enhanced console output for parallel stack benchmarks by serializing configuration printing and suppressing verbose logs when `quiet_mode` is enabled. This ensures a cleaner progress bar display. (`cli/startled/src/benchmark.rs`, [[1]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55R85-R87) [[2]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55R240-R252) [[3]](diffhunk://#diff-c5590841151d74f9edd27ee7308b1b096f2ef5614a42a5113ece9a74e69d3e55L286-R316)

### Documentation Updates:
* Updated `README.md` and `CHANGELOG.md` to reflect the new `--parallel` option and required `--memory` argument. (`cli/startled/README.md`, `cli/startled/CHANGELOG.md`)
* Simplified instructions in `PUBLISHING.md` for reviewing changes and performing a dry run during the release process. (`cli/startled/PUBLISHING.md`, [[1]](diffhunk://#diff-5d40ff563ad8cb9a3cce77734f5bb1dd6333abe33e356c6f313f4c4aa211b5abL23-R23) [[2]](diffhunk://#diff-5d40ff563ad8cb9a3cce77734f5bb1dd6333abe33e356c6f313f4c4aa211b5abL62-R62)

### Version Update:
* Bumped the `startled` CLI version from `0.2.0` to `0.3.0` in `Cargo.toml` and updated the release notes to reflect the new features and changes. (`cli/startled/Cargo.toml`, `cli/startled/RELEASE_NOTES.md`, [[1]](diffhunk://#diff-112c3857fa8d5706869ef8ba5fdaee05097cf93d95f849ab39a4c1457fafa30bL3-R3) [[2]](diffhunk://#diff-355350d3a7fa2003a39ec9494c944acb48edffadf500b4cd0b27e322927cf8eaL1-R11)