### PR TITLE
release cli/livetrace/v0.2.0

### DIFF
--- a/cli/livetrace/CHANGELOG.md
+++ b/cli/livetrace/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-05-14
+
+### Added
+- Added `--grep <REGEX>` option to filter spans/events based on attribute values matching a Rust-compatible regular expression. Matching text is highlighted in the console.
+- Added `--backtrace <DURATION>` option to fetch logs from a specified duration ago for the initial poll in polling mode. Supports parsing durations in seconds (`s`) or minutes (`m`).
+- Added `regex` dependency for implementing the `--grep` feature.
+- Implemented shell completion for the `--theme` argument using `clap::ValueEnum` for a better user experience.
+- Introduced "red-safe" alternatives in `TABLEAU_12`, `MATERIAL_12`, and `SOLARIZED_12` color palettes to prevent them from being mistaken for error indicators.
+- Implemented dynamic column width adjustment in the timeline log for `service_name` and `item.name` to ensure consistent alignment.
+
+### Changed
+- Updated `livetrace` version to `0.2.0` in `Cargo.toml`.
+- Enhanced `README.md` to include examples and descriptions for the new `--grep` and `--backtrace` options.
+- Updated shell completion instructions in `README.md` to escape single quotes for better compatibility.
+- Refactored `cli.rs` to improve readability and maintainability, including grouping related options and simplifying imports.
+- Centralized most CLI argument default values as constants in `cli.rs`.
+- Modified `Theme` enum in `console_display.rs` to derive `serde::Serialize`, `serde::Deserialize` and use `#[serde(rename_all = "kebab-case")]` for consistent theme naming in configuration files.
+- Updated `config.rs` to handle the new `--grep` and `--backtrace` options in both `ProfileConfig` and `EffectiveConfig`.
+- Improved color selection for services and spans in `console_display.rs` by using FNV-1a hashing for a more even distribution of palette colors.
+- Refactored the `console_display::display_console` function into several smaller, private helper functions (`prepare_trace_data_from_batch`, `calculate_layout_widths`, `print_trace_header`, `collect_and_filter_timeline_items_for_trace`, `build_waterfall_hierarchy_and_meta`, `render_waterfall_table`, `print_timeline_log`) to enhance modularity and readability.
+- Updated the handling of CLI argument default values (e.g., for `theme`, `events_only`, `color_by`, and duration-based fields) to correctly prioritize explicit CLI arguments over profile settings, even when the CLI argument matches a `clap` default. This involved changing these fields to `Option<T>` in `CliArgs` and removing `default_value_t` attributes.
+
+### Fixed
+- Resolved a bug where default values provided by `clap` for CLI arguments (e.g., `--theme default`) would incorrectly override settings specified in a loaded configuration profile.
+- Addressed a console display issue in `console_display.rs` where timestamp and status/level fields were sometimes missing for `SpanStart` items in the timeline log output.
+- Corrected the display of the selected theme in the startup preamble in `lib.rs`.
+
+### Removed
+- Removed unused `monochrome` field from `config.rs` for cleaner configuration handling.
+
 ## [0.1.0] - 2025-05-10
 
 ### Added

--- a/cli/livetrace/CHANGELOG.md
+++ b/cli/livetrace/CHANGELOG.md
@@ -13,8 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `regex` dependency for implementing the `--grep` feature.
 - Implemented shell completion for the `--theme` argument using `clap::ValueEnum` for a better user experience.
 - Introduced "red-safe" alternatives in `TABLEAU_12`, `MATERIAL_12`, and `SOLARIZED_12` color palettes to prevent them from being mistaken for error indicators.
-- Implemented dynamic column width adjustment in the timeline log for `service_name` and `item.name` to ensure consistent alignment.
-
 ### Changed
 - Updated `livetrace` version to `0.2.0` in `Cargo.toml`.
 - Enhanced `README.md` to include examples and descriptions for the new `--grep` and `--backtrace` options.

--- a/cli/livetrace/Cargo.toml
+++ b/cli/livetrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livetrace"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -63,6 +63,7 @@ toml.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 
 globset.workspace = true
+regex = { workspace = true } # Added for --grep
 # New dependency
 hex = { workspace = true }
 # Spinner and progress indicators

--- a/cli/livetrace/README.md
+++ b/cli/livetrace/README.md
@@ -28,6 +28,8 @@
 
 ## Overview
 
+[livetracing a demo app](https://github.com/user-attachments/assets/9087fbbe-3e99-47d2-8cb3-64273eea5204)
+
 In the [Serverless OTLP Forwarder architecture](https://dev7a.github.io/serverless-otlp-forwarder/architecture/), Lambda functions (or other compute resources) emit OpenTelemetry (OTLP) trace data to standard output. This tool enables you to correlate and visualize complete traces—especially valuable during development. Because logs from different services involved in a single request may be distributed across multiple Log Groups, _livetrace_ can tail several log groups simultaneously and reconstruct traces spanning all participating services.
 
 `livetrace` supports:

--- a/cli/livetrace/README.md
+++ b/cli/livetrace/README.md
@@ -110,6 +110,11 @@ You can specify *at most one* of the following:
     # Poll every 15 seconds
     livetrace --stack-name my-dev-stack --poll-interval 15
     ```
+*   `--backtrace <DURATION>`: (Polling mode only) Fetch logs starting from `<DURATION>` ago (e.g., `30s`, `5m`, `120` for 120 seconds) for the initial poll. Subsequent polls fetch new logs.
+    ```bash
+    # Poll, fetching initial logs from the last 2 minutes
+    livetrace --stack-name my-dev-stack --poll-interval 15 --backtrace 2m
+    ```
 *   `--session-timeout <MINUTES>`: (Default: 30) Automatically exit after the specified number of minutes. **Only applicable in Live Tail mode (when `--poll-interval` is *not* used).**
     ```bash
     # Use Live Tail, but exit after 60 minutes
@@ -153,6 +158,11 @@ Control the appearance of the console output:
 *   `--theme <THEME>`: Select a color theme (e.g., `default`, `tableau`, `monochrome`). Default is `default`.
 *   `--list-themes`: List all available color themes with descriptions and exit.
 *   `--attrs <GLOB_LIST>`: Comma-separated list of glob patterns (e.g., `"http.*,db.statement,my.custom.*"`) to filter which attributes are displayed. Applied to both span attributes and event attributes. If omitted, all attributes are shown.
+*   `--grep <REGEX>`: Filter spans and events displayed in the console. Only telemetry where at least one attribute *value* matches the provided Rust-compatible regular expression will be shown. Matching text within attribute values will be highlighted (yellow background) in the timeline log.
+    ```bash
+    # Show only telemetry where an attribute value contains "error" or "failure"
+    livetrace --pattern "my-app" --grep "error|failure"
+    ```
 *   `--event-severity-attribute <ATTRIBUTE_NAME>`: (Default: `event.severity`) Specify the event attribute key used to determine the severity level for coloring event output.
 *   `--events-only`: Only display events in the timeline log, hiding span start information.
 *   `--trace-timeout <SECONDS>`: (Default: 5) Maximum time in seconds to wait for spans belonging to a trace before displaying/forwarding it, even if the root span hasn't been received.
@@ -269,8 +279,8 @@ The exact installation method varies by shell. Here are some common examples:
 
 **Bash:**
 
-1.  Ensure you have `bash-completion` installed (often available via your system's package manager).
-2.  Create the completions directory if it doesn't exist:
+1.  Ensure you have `bash-completion` installed (often available via your system\'s package manager).
+2.  Create the completions directory if it doesn\'t exist:
     ```bash
     mkdir -p ~/.local/share/bash-completion/completions
     ```
@@ -282,7 +292,7 @@ The exact installation method varies by shell. Here are some common examples:
 
 **Zsh:**
 
-1.  Create a directory for completions if you don't have one (e.g., `~/.zsh/completions`).
+1.  Create a directory for completions if you don\'t have one (e.g., `~/.zsh/completions`).
     ```bash
     mkdir -p ~/.zsh/completions
     ```
@@ -300,7 +310,7 @@ The exact installation method varies by shell. Here are some common examples:
 
 **Fish:**
 
-1.  Create the completions directory if it doesn't exist:
+1.  Create the completions directory if it doesn\'t exist:
     ```bash
     mkdir -p ~/.config/fish/completions
     ```
@@ -310,7 +320,7 @@ The exact installation method varies by shell. Here are some common examples:
     ```
     Fish should pick up the completions automatically on next launch.
 
-Refer to your shell's documentation for the most up-to-date and specific instructions.
+Refer to your shell\'s documentation for the most up-to-date and specific instructions.
 
 ## Development
 

--- a/cli/livetrace/README.md
+++ b/cli/livetrace/README.md
@@ -2,6 +2,30 @@
 
 `livetrace` is a command-line tool designed to enhance local development workflows when working with distributed tracing in serverless environments using the [Serverless OTLP Forwarder Architecture](https://dev7a.github.io/serverless-otlp-forwarder/architecture/).
 
+## Table of Contents
+
+*   [Overview](#overview)
+*   [Features](#features)
+*   [Installation](#installation)
+    *   [Prerequisites](#prerequisites)
+    *   [From Crates.io (Recommended)](#from-cratesio-recommended)
+    *   [From Source](#from-source)
+*   [Usage](#usage)
+    *   [Discovery Options](#discovery-options)
+    *   [Mode and Duration Control](#mode-and-duration-control)
+    *   [OTLP Forwarding](#otlp-forwarding)
+    *   [Console Display Options](#console-display-options)
+    *   [Other Options](#other-options)
+*   [Console Output](#console-output)
+*   [Configuration Profiles](#configuration-profiles)
+    *   [Saving a Profile](#saving-a-profile)
+    *   [Using a Profile](#using-a-profile)
+    *   [Configuration File Format](#configuration-file-format)
+*   [Shell Completions](#shell-completions)
+    *   [Installation Examples](#installation-examples)
+*   [Development](#development)
+*   [License](#license)
+
 ## Overview
 
 In the Serverless OTLP Forwarder architecture, Lambda functions (or other compute resources) emit OpenTelemetry (OTLP) trace data to standard output. This tool enables you to correlate and visualize complete traces—especially valuable during development. Because logs from different services involved in a single request may be distributed across multiple Log Groups, _livetrace_ can tail several log groups simultaneously and reconstruct traces spanning all participating services.
@@ -79,7 +103,7 @@ If you want to build from the latest source code or contribute to development:
 livetrace [OPTIONS]
 ```
 
-### Discovery Options (One or Both Required)
+### Discovery Options
 
 You must specify at least one of the following to identify the log groups. They can be used together:
 
@@ -101,29 +125,29 @@ You must specify at least one of the following to identify the log groups. They 
     livetrace --stack-name my-api-stack --log-group-pattern "/aws/lambda/auth-"
     ```
 
-### Mode Selection (Optional, Mutually Exclusive Group)
+### Mode and Duration Control
 
-You can specify *at most one* of the following:
-
-*   `--poll-interval <SECONDS>`: Use the `FilterLogEvents` API instead of `StartLiveTail`, polling every specified number of seconds.
+*   `--poll-interval <DURATION>`: Use the `FilterLogEvents` API instead of `StartLiveTail`, polling at the specified interval. Duration format requires a unit suffix (e.g., `10s`, `1500ms`, `1m`). Decimal values are not supported. If this option is not provided, Live Tail mode is used by default.
     ```bash
     # Poll every 15 seconds
-    livetrace --stack-name my-dev-stack --poll-interval 15
+    livetrace --stack-name my-dev-stack --poll-interval 15s
     ```
-*   `--backtrace <DURATION>`: (Polling mode only) Fetch logs starting from `<DURATION>` ago (e.g., `30s`, `5m`, `120` for 120 seconds) for the initial poll. Subsequent polls fetch new logs.
+*   `--backtrace <DURATION>`: (Polling mode only) Fetch logs starting from `<DURATION>` ago for the initial poll. Duration format requires a unit suffix (e.g., `30s`, `5m`, `2h`). Decimal values are not supported. Subsequent polls fetch new logs.
     ```bash
     # Poll, fetching initial logs from the last 2 minutes
-    livetrace --stack-name my-dev-stack --poll-interval 15 --backtrace 2m
+    livetrace --stack-name my-dev-stack --poll-interval 15s --backtrace 2m
     ```
-*   `--session-timeout <MINUTES>`: (Default: 30) Automatically exit after the specified number of minutes. **Only applicable in Live Tail mode (when `--poll-interval` is *not* used).**
+*   `--session-timeout <DURATION>`: (Default: `30m`) Automatically exit after the specified duration. Applies to both Live Tail mode and Polling mode. Duration format requires a unit suffix (e.g., `30m`, `1h`, `900s`). Decimal values are not supported.
     ```bash
     # Use Live Tail, but exit after 60 minutes
-    livetrace --pattern "my-service-" --session-timeout 60
+    livetrace --pattern "my-service-" --session-timeout 60m
+    # Poll every 10 seconds, but exit after 5 minutes total
+    livetrace --stack-name my-app --poll-interval 10s --session-timeout 5m
     ```
 [!NOTE]
 > Live Tail mode is the default, but it's not free, at 1c/minute. For long sessions, it's probably better to use the `FilterLogEvents` API with a polling interval.
 
-### OTLP Forwarding (Optional)
+### OTLP Forwarding
 
 Configure forwarding to send traces to another OTLP receiver:
 
@@ -151,21 +175,25 @@ export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=secret123,x-tenant-id=abc"
 livetrace --stack-name my-stack
 ```
 
-### Console Display Options (Optional)
+### Console Display Options
 
 Control the appearance of the console output:
 
 *   `--theme <THEME>`: Select a color theme (e.g., `default`, `tableau`, `monochrome`). Default is `default`.
 *   `--list-themes`: List all available color themes with descriptions and exit.
 *   `--attrs <GLOB_LIST>`: Comma-separated list of glob patterns (e.g., `"http.*,db.statement,my.custom.*"`) to filter which attributes are displayed. Applied to both span attributes and event attributes. If omitted, all attributes are shown.
-*   `--grep <REGEX>`: Filter spans and events displayed in the console. Only telemetry where at least one attribute *value* matches the provided Rust-compatible regular expression will be shown. Matching text within attribute values will be highlighted (yellow background) in the timeline log.
+*   `--grep <REGEX>`: Filter entries in the **Timeline Log**. Only SpanStart and Event entries where at least one attribute *value* (including parent span attributes for events) matches the provided Rust-compatible regular expression will be shown. Matching text within attribute values will be highlighted (yellow background). This filter does not affect the waterfall span display.
     ```bash
-    # Show only telemetry where an attribute value contains "error" or "failure"
+    # Show only timeline log entries where an attribute value contains "error" or "failure"
     livetrace --pattern "my-app" --grep "error|failure"
     ```
+*   `--color-by <MODE>`: Specify how spans are colored in the waterfall and timeline views.
+    *   `service`: Color by service name.
+    *   `span`: Color by span ID. (Default: `span`)
 *   `--event-severity-attribute <ATTRIBUTE_NAME>`: (Default: `event.severity`) Specify the event attribute key used to determine the severity level for coloring event output.
-*   `--events-only`: Only display events in the timeline log, hiding span start information.
-*   `--trace-timeout <SECONDS>`: (Default: 5) Maximum time in seconds to wait for spans belonging to a trace before displaying/forwarding it, even if the root span hasn't been received.
+*   `--events-only [true|false]`: Controls visibility of span start entries in the timeline log. By default (`true`), only events are shown. Use `--events-only=false` to include span start information. Providing the flag without a value (e.g., `--events-only`) implies `true`.
+*   `--trace-timeout <DURATION>`: (Default: `5s`) Maximum time to wait for spans belonging to a trace before displaying/forwarding it. Duration format requires a unit suffix (e.g., `5s`, `500ms`, `1m`). Decimal values are not supported.
+*   `--trace-stragglers-wait <DURATION>`: (Default: `500ms`) Time to wait for late-arriving (straggler) spans after the last observed activity on a trace (if its root span has been received) before flushing. Useful for collecting additional spans that might arrive slightly out of order. Duration format requires a unit suffix (e.g., `500ms`, `1s`). Decimal values are not supported.
 
 ### Other Options
 

--- a/cli/livetrace/README.md
+++ b/cli/livetrace/README.md
@@ -28,7 +28,7 @@
 
 ## Overview
 
-In the Serverless OTLP Forwarder architecture, Lambda functions (or other compute resources) emit OpenTelemetry (OTLP) trace data to standard output. This tool enables you to correlate and visualize complete traces—especially valuable during development. Because logs from different services involved in a single request may be distributed across multiple Log Groups, _livetrace_ can tail several log groups simultaneously and reconstruct traces spanning all participating services.
+In the [Serverless OTLP Forwarder architecture](https://dev7a.github.io/serverless-otlp-forwarder/architecture/), Lambda functions (or other compute resources) emit OpenTelemetry (OTLP) trace data to standard output. This tool enables you to correlate and visualize complete traces—especially valuable during development. Because logs from different services involved in a single request may be distributed across multiple Log Groups, _livetrace_ can tail several log groups simultaneously and reconstruct traces spanning all participating services.
 
 `livetrace` supports:
 
@@ -41,6 +41,22 @@ In the Serverless OTLP Forwarder architecture, Lambda functions (or other comput
 7.  **Optionally forwarding** the raw OTLP protobuf data to a specified OTLP-compatible endpoint (like a local OpenTelemetry Collector or Jaeger instance).
 
 It acts as a local observability companion, giving you immediate feedback on trace behavior without needing to navigate the AWS console, your o11y tool, or wait for logs to propagate fully to a backend system.
+
+To instrument your lambda functions, you can use the OTLP stdout span exporter, available for Node, Python, and Rust:
+
+*   [npm](https://www.npmjs.com/package/@dev7a/otlp-stdout-span-exporter)
+*   [pypi](https://pypi.org/project/otlp-stdout-span-exporter/)
+*   [crates.io](https://crates.io/crates/otlp-stdout-span-exporter)
+
+Or, you can use the Lambda Otel Lite library, which also simplifies setting up your OpenTelemetry pipeline:
+
+*   [npm](https://www.npmjs.com/package/@dev7a/lambda-otel-lite)
+*   [pypi](https://pypi.org/project/lambda-otel-lite/)
+*   [crates.io](https://crates.io/crates/lambda-otel-lite)
+
+
+
+
 
 ## Features
 

--- a/cli/livetrace/RELEASE_NOTES.md
+++ b/cli/livetrace/RELEASE_NOTES.md
@@ -1,16 +1,37 @@
-## livetrace v0.1.0 - 2025-05-10
+## livetrace v0.2.0 - 2025-05-17
 
-This initial release of `livetrace` marks its first public version, bringing a powerful tool for local development and debugging of distributed traces in serverless environments that use the Serverless OTLP Forwarder architecture.
+This release of `livetrace` introduces powerful new filtering and log fetching capabilities, enhances usability with improved CLI arguments and color palettes, and includes important bug fixes and code refactoring for better maintainability.
 
-### Highlights of this Release:
+### New Features and Enhancements:
 
-*   **Shell Completion Support:** Boost your productivity with shell completion scripts for Bash, Zsh, Fish, and more. Generate them easily using the new `livetrace generate-completions <SHELL>` command.
-*   **Comprehensive Documentation:** The `README.md` has been significantly enhanced with detailed usage examples, clear installation instructions (including for shell completions), and better alignment with the overall Serverless OTLP Forwarder architecture.
-*   **Under-the-Hood Improvements:**
-    *   Updated key dependencies like `chrono`, `nix`, and `indicatif` to their latest versions.
-    *   Refactored internal code structure, particularly around AWS setup, and added module-level documentation for improved readability and maintainability.
-*   **Metadata Updates:** Project description, keywords in `Cargo.toml`, and the license year have been updated to reflect the current state and focus of the tool.
+*   **CLI Options:**
+    *   Added `--grep <REGEX>` to filter spans/events based on attribute values matching a Rust-compatible regex, with highlighted matches in the console.
+    *   Introduced `--backtrace <DURATION>` to fetch logs from a specified duration ago in polling mode.
+    *   Implemented shell completion for the `--theme` argument using `clap::ValueEnum`.
+    *   Enhanced duration-based CLI arguments to accept units (e.g., `s`, `m`, `h`) for better flexibility.
+*   **Color Palettes:**
+    *   Introduced "red-safe" alternatives in `TABLEAU_12`, `MATERIAL_12`, and `SOLARIZED_12` palettes to avoid confusion with error indicators.
 
-This release focuses on providing a solid foundation with essential features and a great developer experience.
+### Documentation Updates:
 
-For a detailed list of all individual changes, bug fixes, and commits, please see the [CHANGELOG.md](./CHANGELOG.md).
+*   **README.md:**
+    *   Added detailed examples and descriptions for new features like `--grep` and `--backtrace`.
+    *   Improved shell completion instructions with escaped single quotes for compatibility.
+
+### Code Refactoring:
+
+*   **CLI Codebase:**
+    *   Centralized default values for CLI arguments as constants for better maintainability.
+    *   Refactored `cli.rs` to group related options and simplify imports.
+    *   Updated `CliArgs` to use `Option<T>` for better handling of defaults and explicit CLI arguments.
+
+### Bug Fixes:
+
+*   **Configuration and Display:**
+    *   Fixed an issue where clap default values for CLI arguments incorrectly overrode configuration profile settings.
+    *   Resolved missing timestamp and status/level fields for `SpanStart` items in the timeline log.
+*   **Dependency Updates:**
+    *   Added `regex` crate to support the new `--grep` feature.
+
+For a detailed list of all individual changes, bug fixes, and commits, please see the [CHANGELOG.md](https://github.com/dev7a/serverless-otlp-forwarder/blob/main/cli/livetrace/CHANGELOG.md).
+

--- a/cli/livetrace/src/aws_setup.rs
+++ b/cli/livetrace/src/aws_setup.rs
@@ -15,7 +15,7 @@ use aws_sdk_cloudformation::Client as CfnClient;
 use aws_sdk_cloudwatchlogs::Client as CwlClient;
 use aws_sdk_sts::Client as StsClient;
 
-// --- AWS Setup Public Function ---
+// AWS Setup Public Function
 
 pub struct AwsSetupResult {
     pub cwl_client: CwlClient,
@@ -32,7 +32,7 @@ pub async fn setup_aws_resources(
     aws_region: &Option<String>,
     aws_profile: &Option<String>,
 ) -> Result<AwsSetupResult> {
-    // --- 1. Load AWS Config ---
+    // 1. Load AWS Config
     let region_provider =
         RegionProviderChain::first_try(aws_region.clone().map(aws_config::Region::new))
             .or_default_provider()
@@ -51,7 +51,7 @@ pub async fn setup_aws_resources(
         aws_config.region()
     );
 
-    // --- 2. Create AWS Clients ---
+    // 2. Create AWS Clients
     let cwl_client = CwlClient::new(&aws_config);
     tracing::debug!("CloudWatch Logs client created.");
     let cfn_client = CfnClient::new(&aws_config);
@@ -59,7 +59,7 @@ pub async fn setup_aws_resources(
     let sts_client = StsClient::new(&aws_config);
     tracing::debug!("STS client created.");
 
-    // --- Get Account ID and Region for ARN construction ---
+    // Get Account ID and Region for ARN construction
     let region_str = aws_config
         .region()
         .ok_or_else(|| anyhow::anyhow!("Could not determine AWS region from config"))?
@@ -78,11 +78,11 @@ pub async fn setup_aws_resources(
     let partition = "aws"; // Assuming standard AWS partition
     tracing::debug!(region = %region_str, account_id = %account_id, partition = %partition, "Determined region, account ID, and partition");
 
-    // --- 5. Discover Log Groups based on pattern or stack name ---
+    // 5. Discover Log Groups based on pattern or stack name
     let resolved_log_group_names =
         discover_log_group_names(&cfn_client, &cwl_client, log_group_pattern, stack_name).await?;
 
-    // --- Add validation step ---
+    // Add validation step
     tracing::debug!("Validating discovered log group names...");
     let validated_log_group_names =
         validate_log_groups(&cwl_client, resolved_log_group_names, &region_str).await?;
@@ -91,7 +91,7 @@ pub async fn setup_aws_resources(
         validated_log_group_names
     );
 
-    // --- Validate count of *validated* names ---
+    // Validate count of *validated* names
     let group_count = validated_log_group_names.len(); // Use validated count
     if group_count == 0 {
         let error_msg = if stack_name.is_some() {
@@ -130,7 +130,7 @@ pub async fn setup_aws_resources(
         );
     }
 
-    // --- Construct ARNs from *validated* names ---
+    // Construct ARNs from *validated* names
     let resolved_log_group_arns: Vec<String> = validated_log_group_names
         .iter()
         .map(|name| {
@@ -151,7 +151,7 @@ pub async fn setup_aws_resources(
     })
 }
 
-// --- Private Helper Functions ---
+// Private Helper Functions
 
 /// Discovers log group names based on stack or pattern arguments.
 async fn discover_log_group_names(

--- a/cli/livetrace/src/cli.rs
+++ b/cli/livetrace/src/cli.rs
@@ -84,11 +84,7 @@ EXAMPLES:
 /// livetrace: Tail CloudWatch Logs for OTLP/stdout traces and forward them.
 #[derive(Parser, Debug, Clone)]
 #[command(author = crate_authors!(", "), version, about = crate_description!(), long_about = None, after_help = USAGE_EXAMPLES)]
-#[clap(group( // Group now only for poll_interval to define mode if present
-    ArgGroup::new("mode_selector") // Renamed for clarity, only contains poll_interval if we want to be explicit
-        .required(false)
-        .args(["poll_interval"]), // session_timeout removed from this group
-))]
+// Removed the `mode_selector` group as it no longer serves its original purpose.
 pub struct CliArgs {
     /// Log group name pattern(s) for discovery (case-sensitive substring search). Can be specified multiple times.
     #[arg(short = 'g', long = "log-group-pattern", num_args(1..))]

--- a/cli/livetrace/src/cli.rs
+++ b/cli/livetrace/src/cli.rs
@@ -6,7 +6,7 @@
 //! and helper functions related to CLI argument processing (e.g., parsing glob patterns).
 
 use crate::console_display::Theme;
-use clap::{crate_authors, crate_description, ArgGroup, Parser, Subcommand, ValueEnum};
+use clap::{crate_authors, crate_description, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};

--- a/cli/livetrace/src/cli.rs
+++ b/cli/livetrace/src/cli.rs
@@ -6,22 +6,62 @@
 //! and helper functions related to CLI argument processing (e.g., parsing glob patterns).
 
 use crate::console_display::Theme;
-use clap::{
-    builder::TypedValueParser, crate_authors, crate_description, error::ErrorKind, ArgGroup,
-    Parser, Subcommand, ValueEnum,
-};
+use clap::{crate_authors, crate_description, ArgGroup, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+// Made public for use in lib.rs
+pub struct ThemeCliInfo {
+    pub name: &'static str,
+    pub description: &'static str,
+}
+
+// Made public for use in lib.rs
+pub const AVAILABLE_THEMES_INFO: &[ThemeCliInfo] = &[
+    ThemeCliInfo {
+        name: "default",
+        description: "OpenTelemetry-inspired blue-purple palette",
+    },
+    ThemeCliInfo {
+        name: "tableau",
+        description: "Tableau 12 color palette with distinct hues",
+    },
+    ThemeCliInfo {
+        name: "colorbrewer",
+        description: "ColorBrewer Set3 palette (pastel colors)",
+    },
+    ThemeCliInfo {
+        name: "material",
+        description: "Material Design palette with bright, modern colors",
+    },
+    ThemeCliInfo {
+        name: "solarized",
+        description: "Solarized color scheme with muted tones",
+    },
+    ThemeCliInfo {
+        name: "monochrome",
+        description: "Grayscale palette for minimal distraction",
+    },
+];
+
+// Public constants for default CLI argument values
+pub const DEFAULT_SESSION_TIMEOUT_MS: u64 = 30 * 60 * 1000; // 30m
+pub const DEFAULT_TRACE_TIMEOUT_MS: u64 = 5 * 1000; // 5s
+pub const DEFAULT_TRACE_STRAGGLERS_WAIT_MS: u64 = 0; // 0ms
+pub const DEFAULT_EVENT_SEVERITY_ATTRIBUTE: &str = "event.severity";
+pub const DEFAULT_EVENTS_ONLY: bool = true;
+pub const DEFAULT_COLOR_BY: ColoringMode = ColoringMode::Span;
 
 /// Defines coloring strategies for the console output
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize, Default)]
 pub enum ColoringMode {
-    /// Color by service name (default)
+    /// Color by span ID (default)
     #[default]
-    Service,
-    /// Color by span ID
     Span,
+    /// Color by service name
+    Service,
 }
 
 const USAGE_EXAMPLES: &str = "\
@@ -33,7 +73,7 @@ EXAMPLES:
     livetrace --log-group-pattern \"/aws/lambda/my-service-\" -e http://localhost:4318
 
     # Poll logs every 30 seconds from a stack, showing only events, with a specific theme
-    livetrace --stack-name my-data-processing --poll-interval 30 --events-only --theme solarized
+    livetrace --stack-name my-data-processing --poll-interval 30s --events-only --theme solarized
 
     # Discover log groups by pattern and save the configuration to a profile named \"dev\"
     livetrace --log-group-pattern \"/aws/lambda/user-service-\" --save-profile dev
@@ -44,10 +84,10 @@ EXAMPLES:
 /// livetrace: Tail CloudWatch Logs for OTLP/stdout traces and forward them.
 #[derive(Parser, Debug, Clone)]
 #[command(author = crate_authors!(", "), version, about = crate_description!(), long_about = None, after_help = USAGE_EXAMPLES)]
-#[clap(group( // Add group to make poll/timeout mutually exclusive
-    ArgGroup::new("mode")
-        .required(false) // One or neither can be specified
-        .args(["poll_interval", "session_timeout"]),
+#[clap(group( // Group now only for poll_interval to define mode if present
+    ArgGroup::new("mode_selector") // Renamed for clarity, only contains poll_interval if we want to be explicit
+        .required(false)
+        .args(["poll_interval"]), // session_timeout removed from this group
 ))]
 pub struct CliArgs {
     /// Log group name pattern(s) for discovery (case-sensitive substring search). Can be specified multiple times.
@@ -88,16 +128,20 @@ pub struct CliArgs {
     pub attrs: Option<String>,
 
     /// Optional polling interval in seconds. If set, uses FilterLogEvents API instead of StartLiveTail.
-    #[arg(long, group = "mode")]
-    pub poll_interval: Option<u64>,
+    #[arg(long, group = "mode_selector", value_parser = parse_duration_to_millis, help = "Polling interval (e.g., '10s', '1m'). Requires suffix: ms, s, m, h.")]
+    pub poll_interval: Option<u64>, // Stores milliseconds
 
-    /// Session duration in minutes after which livetrace will automatically exit (LiveTail mode only).
-    #[arg(long, default_value_t = 30, group = "mode")]
-    pub session_timeout: u64,
+    /// Overall session duration after which livetrace will automatically exit.
+    /// Applies to both LiveTail and Polling modes.
+    #[arg(long, value_parser = parse_duration_to_millis, help = "Overall session duration (e.g., '30m', '1h'). Requires suffix: ms, s, m, h. [default: 30m]")]
+    pub session_timeout: Option<u64>, // Changed to Option<u64>, removed default_value
 
     /// Event attribute name to use for determining event severity level.
-    #[arg(long, default_value = "event.severity")]
-    pub event_severity_attribute: String,
+    #[arg(
+        long,
+        help = "Event attribute name for severity. [default: event.severity]"
+    )]
+    pub event_severity_attribute: Option<String>, // Changed to Option<String>, removed default_value
 
     /// Load configuration from a specific profile in .livetrace.toml.
     #[arg(long)]
@@ -108,22 +152,15 @@ pub struct CliArgs {
     pub save_profile: Option<String>,
 
     /// Color theme for console output.
-    ///
-    /// Available themes:
-    ///  * default - OpenTelemetry-inspired blue-purple palette
-    ///  * tableau - Tableau 12 color palette with distinct hues
-    ///  * colorbrewer - ColorBrewer Set3 palette (pastel colors)
-    ///  * material - Material Design palette with bright, modern colors
-    ///  * solarized - Solarized color scheme with muted tones
-    ///  * monochrome - Grayscale palette for minimal distraction
+    /// Use --list-themes for all available options and their descriptions.
     #[arg(
         long,
-        default_value = "default",
-        value_parser = ThemeValueParser,
+        value_enum,
         value_name = "THEME",
         help_heading = "Display Options",
+        help = "Color theme for console output. Use --list-themes for options. [default: default]"
     )]
-    pub theme: String,
+    pub theme: Option<Theme>, // Changed to Option<Theme>
 
     /// List available color themes and exit.
     #[arg(
@@ -137,18 +174,29 @@ pub struct CliArgs {
     #[arg(
         long = "color-by",
         value_enum,
-        default_value_t = ColoringMode::Service,
         help_heading = "Display Options",
+        help = "Color output by service name or span ID. [default: span]"
     )]
-    pub color_by: ColoringMode,
+    pub color_by: Option<ColoringMode>, // Changed to Option<ColoringMode>
 
     /// Only display events, hiding span start information in the timeline log view.
-    #[arg(long, help_heading = "Display Options")]
-    pub events_only: bool,
+    #[arg(
+        long,
+        value_name = "true|false", // Explicit values
+        num_args = 0..=1, // Allows --events-only or --events-only=value
+        default_missing_value = "true", // If --events-only is specified without a value, it's true
+        help_heading = "Display Options",
+        help = "Only display events, hiding span start information. [default: true]"
+    )]
+    pub events_only: Option<bool>, // Changed to Option<bool>
 
-    /// Maximum time in seconds to wait for spans belonging to a trace before displaying/forwarding it.
-    #[arg(long, default_value_t = 5, help_heading = "Processing Options")]
-    pub trace_timeout: u64,
+    /// Maximum time to wait for spans belonging to a trace before displaying/forwarding it.
+    #[arg(long, value_parser = parse_duration_to_millis, help_heading = "Processing Options", help = "Max trace buffering time (e.g., '5s', '500ms'). Requires suffix: ms, s, m, h. [default: 5s]")]
+    pub trace_timeout: Option<u64>, // Changed to Option<u64>, removed default_value
+
+    /// Time to wait for late-arriving (straggler) spans after the last observed activity on a trace (if its root span has been received) before flushing.
+    #[arg(long, value_parser = parse_duration_to_millis, help_heading = "Processing Options", help = "Time to wait for straggler spans after last trace activity (if root is present). (e.g., '500ms', '1s'). Requires suffix: ms, s, m, h. [default: 0ms]")]
+    pub trace_stragglers_wait: Option<u64>, // Changed to Option<u64>, removed default_value
 
     #[command(subcommand)]
     pub command: Option<Commands>,
@@ -158,23 +206,34 @@ pub struct CliArgs {
     pub grep: Option<String>,
 
     /// Go back in time for initial log poll (e.g., 30, 120s, 3m)
-    #[arg(long, value_parser = parse_backtrace_duration, help_heading = "Filtering Options")]
-    pub backtrace: Option<u64>, // Stores seconds
+    #[arg(long, value_parser = parse_duration_to_millis, help_heading = "Filtering Options")]
+    pub backtrace: Option<u64>, // Stores milliseconds
 }
 
-// Custom parser for --backtrace duration
-fn parse_backtrace_duration(s: &str) -> Result<u64, String> {
-    if let Some(stripped) = s.strip_suffix('m') {
-        stripped
-            .parse::<u64>()
-            .map(|n| n * 60)
-            .map_err(|e| format!("Invalid minutes value: {}", e))
-    } else if let Some(stripped) = s.strip_suffix('s') {
-        stripped
-            .parse::<u64>()
-            .map_err(|e| format!("Invalid seconds value: {}", e))
+// Custom parser for duration strings into milliseconds
+// Made pub(crate) so it can be called from config.rs
+pub(crate) fn parse_duration_to_millis(s: &str) -> Result<u64, String> {
+    let s_lower = s.to_lowercase();
+    if let Some(stripped) = s_lower.strip_suffix("ms") {
+        u64::from_str(stripped)
+            .map_err(|e| format!("Invalid milliseconds value '{}': {}", stripped, e))
+    } else if let Some(stripped) = s_lower.strip_suffix('s') {
+        u64::from_str(stripped)
+            .map(|n| n * 1000)
+            .map_err(|e| format!("Invalid seconds value '{}': {}", stripped, e))
+    } else if let Some(stripped) = s_lower.strip_suffix('m') {
+        u64::from_str(stripped)
+            .map(|n| n * 60 * 1000)
+            .map_err(|e| format!("Invalid minutes value '{}': {}", stripped, e))
+    } else if let Some(stripped) = s_lower.strip_suffix('h') {
+        u64::from_str(stripped)
+            .map(|n| n * 60 * 60 * 1000)
+            .map_err(|e| format!("Invalid hours value '{}': {}", stripped, e))
     } else {
-        s.parse::<u64>().map_err(|e| format!("Invalid duration '{}'. Must be a number (seconds), or end with 's' or 'm'. Error: {}", s, e))
+        Err(format!(
+            "Invalid duration string '{}'. Must end with 'ms', 's', 'm', or 'h'. Bare numbers are not allowed.",
+            s
+        ))
     }
 }
 
@@ -187,74 +246,6 @@ pub enum Commands {
         #[arg(value_enum)]
         shell: Shell,
     },
-}
-
-// Create a custom value parser for themes
-#[derive(Clone)]
-struct ThemeValueParser;
-
-impl TypedValueParser for ThemeValueParser {
-    type Value = String;
-
-    /// This method is called by Clap when validating the theme argument.
-    /// It receives the command, argument definition, and user-provided value.
-    /// We only use the value parameter to validate the theme name.
-    fn parse_ref(
-        &self,
-        _cmd: &clap::Command,
-        _arg: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        // Array of valid themes for display
-        let valid_themes = [
-            "default - OpenTelemetry-inspired blue-purple palette",
-            "tableau - Tableau 12 color palette with distinct hues",
-            "colorbrewer - ColorBrewer Set3 palette (pastel colors)",
-            "material - Material Design palette with bright, modern colors",
-            "solarized - Solarized color scheme with muted tones",
-            "monochrome - Grayscale palette for minimal distraction",
-        ];
-
-        // Convert OsStr to a regular string for validation
-        let theme_str = value.to_string_lossy().to_string();
-
-        // Handle empty theme value (when user just types --theme without a value)
-        if theme_str.is_empty() {
-            // Show the themes and exit
-            print_available_themes();
-            // This line should never be reached due to exit()
-            return Ok("default".to_string());
-        }
-
-        // Check if the theme is valid
-        if !Theme::is_valid_theme(&theme_str) {
-            // Create a helpful error message with valid themes
-            let themes_list = valid_themes.join("\n  * ");
-
-            let err = format!(
-                "Invalid theme '{}'. Available themes:\n  * {}",
-                theme_str, themes_list
-            );
-
-            return Err(clap::Error::raw(ErrorKind::InvalidValue, err));
-        }
-
-        // Valid theme, return it
-        Ok(theme_str)
-    }
-}
-
-// Helper function to print available themes
-fn print_available_themes() {
-    println!("\nAvailable themes:");
-    println!("  * default - OpenTelemetry-inspired blue-purple palette");
-    println!("  * tableau - Tableau 12 color palette with distinct hues");
-    println!("  * colorbrewer - ColorBrewer Set3 palette (pastel colors)");
-    println!("  * material - Material Design palette with bright, modern colors");
-    println!("  * solarized - Solarized color scheme with muted tones");
-    println!("  * monochrome - Grayscale palette for minimal distraction");
-    println!("\nUsage: livetrace --theme <THEME>");
-    std::process::exit(0);
 }
 
 /// Parses attribute glob patterns from a string pattern.

--- a/cli/livetrace/src/config.rs
+++ b/cli/livetrace/src/config.rs
@@ -642,7 +642,8 @@ backtrace = "5m"       # Example profile duration as string
         args_with_defaults.trace_stragglers_wait = Some(DEFAULT_TRACE_STRAGGLERS_WAIT_MS); // Use const
         args_with_defaults.theme = Some(Theme::Default); // Default theme
         args_with_defaults.color_by = Some(DEFAULT_COLOR_BY); // Use const for default color_by
-        args_with_defaults.event_severity_attribute = Some(DEFAULT_EVENT_SEVERITY_ATTRIBUTE.to_string()); // Use const
+        args_with_defaults.event_severity_attribute =
+            Some(DEFAULT_EVENT_SEVERITY_ATTRIBUTE.to_string()); // Use const
         args_with_defaults.events_only = Some(DEFAULT_EVENTS_ONLY); // Use const
 
         let profile_with_defaults = ProfileConfig::from_cli_args(&args_with_defaults);

--- a/cli/livetrace/src/config.rs
+++ b/cli/livetrace/src/config.rs
@@ -15,7 +15,7 @@ use crate::cli::{CliArgs, ColoringMode};
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::{fs, io::Write, path::Path};
+use std::{fs, io::Write, path::Path, path::PathBuf};
 
 // Default filename for the configuration
 const LIVETRACE_TOML: &str = ".livetrace.toml";
@@ -36,7 +36,7 @@ pub struct ConfigFile {
 
 /// Represents the configuration settings within a profile (or global section).
 /// Fields should generally mirror CliArgs, using `Option<T>` and serde attributes.
-#[derive(Debug, Deserialize, Serialize, Default, Clone)] // Added Clone
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ProfileConfig {
     // --- Discovery --- (Mirroring CliArgs groups)
@@ -64,8 +64,6 @@ pub struct ProfileConfig {
     pub attrs: Option<String>,
     #[serde(rename = "event-severity-attribute")]
     pub event_severity_attribute: Option<String>,
-    #[serde(rename = "monochrome")]
-    pub monochrome: Option<bool>,
     #[serde(rename = "theme")]
     pub theme: Option<String>,
     #[serde(rename = "color-by", skip_serializing_if = "Option::is_none")]
@@ -82,10 +80,16 @@ pub struct ProfileConfig {
 
     #[serde(rename = "trace-timeout", skip_serializing_if = "Option::is_none")]
     pub trace_timeout: Option<u64>,
+
+    // --- Filtering Options ---
+    #[serde(rename = "grep", skip_serializing_if = "Option::is_none")]
+    pub grep: Option<String>,
+    #[serde(rename = "backtrace", skip_serializing_if = "Option::is_none")]
+    pub backtrace: Option<u64>, // Stored as seconds
 }
 
 /// Represents the final, merged configuration after applying precedence rules.
-#[derive(Debug, Clone)] // Clone is useful
+#[derive(Debug, Clone)]
 pub struct EffectiveConfig {
     // --- Discovery ---
     pub log_group_pattern: Option<Vec<String>>,
@@ -113,12 +117,13 @@ pub struct EffectiveConfig {
 
     // --- Execution Control ---
     pub verbose: u8, // Keep verbosity
-    pub theme: String, // Changed from monochrome: bool
-                     // We don't store config_profile or save_profile here,
-                     // as they are processed before creating EffectiveConfig.
+    pub theme: String,
+
+    // --- Filtering Options ---
+    pub grep: Option<String>,
+    pub backtrace: Option<u64>, // Stored as seconds
 }
 
-// --- Add from_cli_args implementation ---
 impl ProfileConfig {
     /// Creates a ProfileConfig from CliArgs, only including non-default values.
     pub fn from_cli_args(args: &CliArgs) -> Self {
@@ -133,29 +138,26 @@ impl ProfileConfig {
             },
             aws_region: args.aws_region.clone(),
             aws_profile: args.aws_profile.clone(),
-            // Only save flags/options if they differ from clap's default
-            forward_only: Some(args.forward_only).filter(|&f| f), // Default is false
+            forward_only: Some(args.forward_only).filter(|&f| f),
             attrs: args.attrs.clone(),
             poll_interval: args.poll_interval,
-            session_timeout: Some(args.session_timeout).filter(|&t| t != 30), // Default is 30
+            session_timeout: Some(args.session_timeout).filter(|&t| t != 30),
             event_severity_attribute: Some(args.event_severity_attribute.clone())
-                .filter(|s| s != "event.severity"), // Default
-            monochrome: None, // No longer used, but kept for compatibility
-            theme: Some(args.theme.clone()).filter(|s| s != "default"), // Default is "default"
-            color_by: Some(args.color_by).filter(|&c| c != ColoringMode::Service), // Default is Service
-            events_only: Some(args.events_only).filter(|&e| e), // Default is false
-            trace_timeout: Some(args.trace_timeout).filter(|&t| t != 5), // Default is 5
+                .filter(|s| s != "event.severity"),
+            theme: Some(args.theme.clone()).filter(|s| s != "default"),
+            color_by: Some(args.color_by).filter(|&c| c != ColoringMode::Service),
+            events_only: Some(args.events_only).filter(|&e| e),
+            trace_timeout: Some(args.trace_timeout).filter(|&t| t != 5),
+            grep: args.grep.clone(),
+            backtrace: args.backtrace,
         }
     }
 }
-
-// --- Main configuration functions ---
 
 pub fn load_and_resolve_config(
     config_profile_name: Option<String>,
     cli_args: &CliArgs,
 ) -> Result<EffectiveConfig> {
-    // First, we'll construct the base effective config with default values
     let mut effective = EffectiveConfig {
         log_group_pattern: None,
         stack_name: None,
@@ -173,42 +175,36 @@ pub fn load_and_resolve_config(
         color_by: ColoringMode::Service,
         events_only: false,
         trace_timeout: 5,
+        grep: None,
+        backtrace: None,
     };
 
-    // If no profile specified, just return CLI args as effective config
     if config_profile_name.is_none() {
-        // Apply CLI arguments to the empty effective config
         apply_cli_args_to_effective(cli_args, &mut effective);
         return Ok(effective);
     }
 
-    // Try to load the config file
     let config_path = get_config_path()?;
     if !config_path.exists() {
         tracing::warn!(
             path = %config_path.display(),
             "Config file not found while trying to load profile. Using CLI arguments only."
         );
-        // Still apply CLI args even if config file doesn't exist
         apply_cli_args_to_effective(cli_args, &mut effective);
         return Ok(effective);
     }
 
-    // Load the configuration file
     let config_file = load_config_file(&config_path)?;
 
-    // Apply global settings first (lowest precedence)
     if let Some(global_config) = &config_file.global {
         apply_profile_to_effective(global_config, &mut effective);
     }
 
-    // Apply profile-specific settings if the named profile exists
-    let profile_name = config_profile_name.unwrap(); // Safe because we checked is_none() above
+    let profile_name = config_profile_name.unwrap();
     if let Some(profile_config) = config_file.profiles.get(&profile_name) {
         apply_profile_to_effective(profile_config, &mut effective);
         tracing::info!(profile = %profile_name, "Loaded configuration from profile");
     } else {
-        // Profile specified but not found - return an error
         return Err(anyhow::anyhow!(
             "Configuration profile '{}' not found in config file '{}'",
             profile_name,
@@ -216,16 +212,11 @@ pub fn load_and_resolve_config(
         ));
     }
 
-    // Apply CLI arguments (highest precedence)
-    // This ensures explicitly set CLI args override settings from the profile
     apply_cli_args_to_effective(cli_args, &mut effective);
-
     Ok(effective)
 }
 
-/// Applies CLI arguments to an effective configuration, but only if they are explicitly set.
 fn apply_cli_args_to_effective(cli_args: &CliArgs, effective: &mut EffectiveConfig) {
-    // For Option<T> fields, we know they're explicitly set if they're Some
     if cli_args
         .log_group_pattern
         .as_ref()
@@ -233,120 +224,78 @@ fn apply_cli_args_to_effective(cli_args: &CliArgs, effective: &mut EffectiveConf
     {
         effective.log_group_pattern = cli_args.log_group_pattern.clone();
     }
-
     if cli_args.stack_name.is_some() {
         effective.stack_name = cli_args.stack_name.clone();
     }
-
     if cli_args.otlp_endpoint.is_some() {
         effective.otlp_endpoint = cli_args.otlp_endpoint.clone();
     }
-
     if !cli_args.otlp_headers.is_empty() {
         effective.otlp_headers = cli_args.otlp_headers.clone();
     }
-
     if cli_args.aws_region.is_some() {
         effective.aws_region = cli_args.aws_region.clone();
     }
-
     if cli_args.aws_profile.is_some() {
         effective.aws_profile = cli_args.aws_profile.clone();
     }
-
     if cli_args.attrs.is_some() {
         effective.attrs = cli_args.attrs.clone();
     }
-
+    if cli_args.grep.is_some() {
+        effective.grep = cli_args.grep.clone();
+    }
+    if cli_args.backtrace.is_some() {
+        effective.backtrace = cli_args.backtrace;
+    }
     if cli_args.poll_interval.is_some() {
         effective.poll_interval = cli_args.poll_interval;
     }
-
-    // For non-Option types, check if they differ from their default values
-    // Only apply them if they're different (indicating they were explicitly set)
-
-    // Default: false
     if cli_args.forward_only {
         effective.forward_only = true;
     }
-
-    // Default: "event.severity"
     if cli_args.event_severity_attribute != "event.severity" {
         effective.event_severity_attribute = cli_args.event_severity_attribute.clone();
     }
-
-    // Default: 30 (Only applicable if poll_interval is None)
     if cli_args.poll_interval.is_none() && cli_args.session_timeout != 30 {
         effective.session_timeout = cli_args.session_timeout;
     }
-
-    // Default: ColoringMode::Service
     if cli_args.color_by != ColoringMode::default() {
         effective.color_by = cli_args.color_by;
     }
-
-    // Default: false
     if cli_args.events_only {
         effective.events_only = true;
     }
-
-    // Default: 5
     if cli_args.trace_timeout != 5 {
         effective.trace_timeout = cli_args.trace_timeout;
     }
-
-    // Default: "default"
     if cli_args.theme != "default" {
         effective.theme = cli_args.theme.clone();
     }
-
-    // Always apply verbosity from CLI - highest precedence makes sense here
     effective.verbose = cli_args.verbose;
 }
 
-// Remove the old placeholder:
-// pub fn handle_save_profile(
-//     profile_name: &str,
-//     // cli_args: &CliArgs, // We'll likely need clap::ArgMatches later
-// ) -> Result<()> {
-//     // TODO: Implement saving logic
-//     unimplemented!("Saving profile configuration not yet implemented.");
-// }
-
-// Add the new implementation:
-use std::path::PathBuf; // Need this for path manipulation
-
 pub fn get_config_path() -> Result<PathBuf> {
-    // For now, just use the local directory. Could be extended later.
     Ok(PathBuf::from(LIVETRACE_TOML))
 }
 
-// Helper to load or create default config
 pub fn load_or_default_config_file() -> Result<ConfigFile> {
     let config_path = get_config_path()?;
     if config_path.exists() {
-        load_config_file(&config_path) // Use existing private helper
+        load_config_file(&config_path)
     } else {
-        Ok(ConfigFile::default()) // Create a default if file doesn't exist
+        Ok(ConfigFile::default())
     }
 }
 
-/// Saves the provided profile configuration under the given name in the config file.
 pub fn save_profile_config(profile_name: &str, profile_data: &ProfileConfig) -> Result<()> {
     let config_path = get_config_path()?;
-    // Load existing config or create a default one
     let mut config = load_or_default_config_file()?;
-
-    // Update the specific profile in the HashMap
     config
         .profiles
         .insert(profile_name.to_string(), profile_data.clone());
-
-    // Serialize the entire ConfigFile structure back to TOML
     let toml_string =
         toml::to_string_pretty(&config).context("Failed to serialize configuration to TOML")?;
-
-    // Write the TOML string back to the file, overwriting it
     let mut file = fs::File::create(&config_path).with_context(|| {
         format!(
             "Failed to create or open config file for writing: {}",
@@ -355,26 +304,18 @@ pub fn save_profile_config(profile_name: &str, profile_data: &ProfileConfig) -> 
     })?;
     file.write_all(toml_string.as_bytes())
         .with_context(|| format!("Failed to write to config file: {}", config_path.display()))?;
-
     Ok(())
 }
 
-// --- Helper for Loading --- (Basic version)
 fn load_config_file(path: &Path) -> Result<ConfigFile> {
-    // Make private helper
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read config file: {}", path.display()))?;
     let config: ConfigFile = toml::from_str(&content)
         .with_context(|| format!("Failed to parse TOML from config file: {}", path.display()))?;
-    // Basic validation (e.g., version check) could go here
     Ok(config)
 }
 
-// Add the apply_profile_to_effective function that was removed during the edit
-
-/// Applies settings from a profile to an effective configuration.
 fn apply_profile_to_effective(profile: &ProfileConfig, effective: &mut EffectiveConfig) {
-    // Only override non-None values from the profile
     if profile
         .log_group_pattern
         .as_ref()
@@ -382,71 +323,56 @@ fn apply_profile_to_effective(profile: &ProfileConfig, effective: &mut Effective
     {
         effective.log_group_pattern = profile.log_group_pattern.clone();
     }
-
     if let Some(val) = &profile.stack_name {
         effective.stack_name = Some(val.clone());
     }
-
     if let Some(val) = &profile.otlp_endpoint {
         effective.otlp_endpoint = Some(val.clone());
     }
-
     if let Some(val) = &profile.otlp_headers {
         effective.otlp_headers = val.clone();
     }
-
     if let Some(val) = &profile.aws_region {
         effective.aws_region = Some(val.clone());
     }
-
     if let Some(val) = &profile.aws_profile {
         effective.aws_profile = Some(val.clone());
     }
-
     if let Some(val) = profile.forward_only {
         effective.forward_only = val;
     }
-
     if let Some(val) = &profile.attrs {
         effective.attrs = Some(val.clone());
     }
-
     if let Some(val) = &profile.event_severity_attribute {
         effective.event_severity_attribute = val.clone();
     }
-
     if let Some(val) = profile.poll_interval {
         effective.poll_interval = Some(val);
     }
-
     if let Some(val) = profile.session_timeout {
         effective.session_timeout = val;
     }
-
     if let Some(val) = &profile.theme {
         effective.theme = val.clone();
-    } else if let Some(true) = profile.monochrome {
-        // For backward compatibility, set theme to monochrome if monochrome was true
-        effective.theme = "monochrome".to_string();
     }
-
     if let Some(val) = &profile.color_by {
         effective.color_by = *val;
     }
-
     if let Some(val) = profile.events_only {
         effective.events_only = val;
     }
-
     if let Some(val) = profile.trace_timeout {
         effective.trace_timeout = val;
     }
+    if let Some(val) = &profile.grep {
+        effective.grep = Some(val.clone());
+    }
+    if let Some(val) = profile.backtrace {
+        effective.backtrace = Some(val);
+    }
 }
 
-/// Merges two ProfileConfig instances.
-///
-/// Values from `overrides` take precedence if they are `Some`.
-/// Otherwise, the values from `base` are kept.
 pub fn merge_into_profile_config(base: &ProfileConfig, overrides: &ProfileConfig) -> ProfileConfig {
     ProfileConfig {
         log_group_pattern: overrides
@@ -485,9 +411,8 @@ pub fn merge_into_profile_config(base: &ProfileConfig, overrides: &ProfileConfig
         color_by: overrides.color_by.or(base.color_by),
         events_only: overrides.events_only.or(base.events_only),
         trace_timeout: overrides.trace_timeout.or(base.trace_timeout),
-        // Note: monochrome is deprecated, so we don't explicitly merge it.
-        // If needed for backward compat, theme should handle it.
-        monochrome: base.monochrome, // Keep base value if needed elsewhere, but don't merge overrides
+        grep: overrides.grep.clone().or_else(|| base.grep.clone()),
+        backtrace: overrides.backtrace.or(base.backtrace),
     }
 }
 
@@ -523,7 +448,9 @@ mod tests {
             color_by: ColoringMode::Service,
             events_only: true,
             trace_timeout: 10,
-            command: None, // Add the new field
+            command: None,
+            grep: None,
+            backtrace: None,
         }
     }
 
@@ -555,7 +482,6 @@ aws-region = "us-west-1"
         let args = mock_cli_args();
         let profile = ProfileConfig::from_cli_args(&args);
 
-        // Verify fields are converted correctly
         assert_eq!(
             profile.log_group_pattern,
             Some(vec![
@@ -590,26 +516,16 @@ aws-region = "us-west-1"
     #[test]
     fn test_save_profile_config() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-
-        // Get the temporary path
         let temp_path = temp_dir.path().to_path_buf().join(LIVETRACE_TOML);
-
-        // Create a test profile
         let args = mock_cli_args();
         let profile = ProfileConfig::from_cli_args(&args);
-
-        // Since we can't easily mock the get_config_path function,
-        // we'll directly write to our temporary path
         let mut config = ConfigFile::default();
         config.profiles.insert("test-profile".to_string(), profile);
         let toml_string = toml::to_string_pretty(&config).expect("Failed to serialize");
         fs::write(&temp_path, toml_string).expect("Failed to write test config");
-
-        // Now read it back to verify
         let read_config: ConfigFile =
             toml::from_str(&fs::read_to_string(&temp_path).expect("Failed to read test config"))
                 .expect("Failed to parse test config");
-
         assert!(read_config.profiles.contains_key("test-profile"));
         let saved_profile = &read_config.profiles["test-profile"];
         assert_eq!(
@@ -627,7 +543,6 @@ aws-region = "us-west-1"
 
     #[test]
     fn test_apply_profile_to_effective() {
-        // Create a base effective config
         let mut effective = EffectiveConfig {
             log_group_pattern: Some(vec!["initial-pattern".to_string()]),
             stack_name: Some("original-stack".to_string()),
@@ -645,9 +560,9 @@ aws-region = "us-west-1"
             color_by: ColoringMode::Service,
             events_only: false,
             trace_timeout: 5,
+            grep: None,
+            backtrace: None,
         };
-
-        // Create a profile with some settings
         let profile = ProfileConfig {
             log_group_pattern: Some(vec![
                 "profile-pattern-1".to_string(),
@@ -663,17 +578,14 @@ aws-region = "us-west-1"
             event_severity_attribute: Some("profile.severity".to_string()),
             poll_interval: Some(45),
             session_timeout: None,
-            monochrome: None,
             theme: Some("test-theme".to_string()),
             color_by: None,
             events_only: Some(true),
             trace_timeout: Some(10),
+            grep: Some("test-grep".to_string()),
+            backtrace: Some(60),
         };
-
-        // Apply the profile
         apply_profile_to_effective(&profile, &mut effective);
-
-        // Verify overrides happened correctly
         assert_eq!(
             effective.log_group_pattern,
             Some(vec![
@@ -706,20 +618,11 @@ aws-region = "us-west-1"
     fn test_load_and_resolve_config() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let config_path = create_test_config_file(temp_dir.path());
-
-        // Mock CLI args with a specific profile
         let mut args = mock_cli_args();
         args.config_profile = Some("dev".to_string());
-
-        // Since we can't easily override the get_config_path function,
-        // we need to reorganize our load_and_resolve_config to make it more testable
-        // For this test, we'll manually read the config and simulate load_and_resolve_config
-
         let config_file: ConfigFile =
             toml::from_str(&fs::read_to_string(&config_path).expect("Failed to read test config"))
                 .expect("Failed to parse test config");
-
-        // Start with CLI args
         let mut effective = EffectiveConfig {
             log_group_pattern: args.log_group_pattern.clone(),
             stack_name: args.stack_name.clone(),
@@ -737,20 +640,15 @@ aws-region = "us-west-1"
             color_by: args.color_by,
             events_only: args.events_only,
             trace_timeout: args.trace_timeout,
+            grep: args.grep.clone(),
+            backtrace: args.backtrace,
         };
-
-        // Apply global settings
         if let Some(global_config) = &config_file.global {
             apply_profile_to_effective(global_config, &mut effective);
         }
-
-        // Apply profile settings
         if let Some(profile_config) = config_file.profiles.get("dev") {
             apply_profile_to_effective(profile_config, &mut effective);
         }
-
-        // Verify the result has correct precedence
-        // Pattern from 'dev' profile should override CLI args
         assert_eq!(
             effective.log_group_pattern,
             Some(vec![
@@ -758,17 +656,11 @@ aws-region = "us-west-1"
                 "specific-dev-group".to_string()
             ])
         );
-
-        // otlp_endpoint from 'dev' profile should override CLI args
         assert_eq!(
             effective.otlp_endpoint,
             Some("http://dev-collector:4318".to_string())
         );
-
-        // aws_region from 'dev' profile should override global
         assert_eq!(effective.aws_region, Some("us-west-1".to_string()));
-
-        // event_severity_attribute from global (not overridden by 'dev')
         assert_eq!(effective.event_severity_attribute, "global.severity");
     }
 
@@ -790,32 +682,29 @@ aws-region = "us-west-1"
             color_by: Some(ColoringMode::Service),
             events_only: Some(false),
             trace_timeout: None,
-            monochrome: None,
+            grep: None,
+            backtrace: None,
         };
-
         let overrides = ProfileConfig {
-            log_group_pattern: None,                                         // Keep base
-            stack_name: Some("override-stack".to_string()),                  // Override base
-            otlp_endpoint: None,                                             // Keep base
-            otlp_headers: Some(vec!["override-header".to_string()]),         // Add new
-            aws_region: Some("us-west-2".to_string()),                       // Override base
-            aws_profile: None,                                               // Keep base (None)
-            forward_only: Some(true),                                        // Override base
-            attrs: None,                                                     // Keep base
-            event_severity_attribute: Some("override.severity".to_string()), // Add new
-            poll_interval: None,                                             // Keep base
-            session_timeout: Some(99),                                       // Add new
-            theme: None,                                                     // Keep base
-            color_by: Some(ColoringMode::Span),                              // Override base
-            events_only: None,                                               // Keep base
-            trace_timeout: Some(20),                                         // Add new
-            monochrome: None,
+            log_group_pattern: None,
+            stack_name: Some("override-stack".to_string()),
+            otlp_endpoint: None,
+            otlp_headers: Some(vec!["override-header".to_string()]),
+            aws_region: Some("us-west-2".to_string()),
+            aws_profile: None,
+            forward_only: Some(true),
+            attrs: None,
+            event_severity_attribute: Some("override.severity".to_string()),
+            poll_interval: None,
+            session_timeout: Some(99),
+            theme: None,
+            color_by: Some(ColoringMode::Span),
+            events_only: None,
+            trace_timeout: Some(20),
+            grep: Some("override-grep".to_string()),
+            backtrace: Some(120),
         };
-
         let merged = merge_into_profile_config(&base, &overrides);
-
-        // --- Assertions ---
-        // Kept from base
         assert_eq!(merged.log_group_pattern, base.log_group_pattern);
         assert_eq!(merged.otlp_endpoint, base.otlp_endpoint);
         assert_eq!(merged.aws_profile, base.aws_profile);
@@ -823,14 +712,10 @@ aws-region = "us-west-1"
         assert_eq!(merged.poll_interval, base.poll_interval);
         assert_eq!(merged.theme, base.theme);
         assert_eq!(merged.events_only, base.events_only);
-
-        // Overridden by overrides
         assert_eq!(merged.stack_name, overrides.stack_name);
         assert_eq!(merged.aws_region, overrides.aws_region);
         assert_eq!(merged.forward_only, overrides.forward_only);
         assert_eq!(merged.color_by, overrides.color_by);
-
-        // Added by overrides
         assert_eq!(merged.otlp_headers, overrides.otlp_headers);
         assert_eq!(
             merged.event_severity_attribute,

--- a/cli/livetrace/src/console_display.rs
+++ b/cli/livetrace/src/console_display.rs
@@ -14,8 +14,8 @@ use anyhow::Result;
 use chrono::{TimeZone, Utc};
 use colored::*;
 use comfy_table::{
-    presets, Attribute, Cell, CellAlignment, ColumnConstraint, ContentArrangement, Table,
-    TableComponent, Width::Fixed,
+    presets, Attribute, Cell, CellAlignment, Color as TableColor, ColumnConstraint,
+    ContentArrangement, Table, TableComponent, Width::Fixed,
 };
 use globset::GlobSet;
 use opentelemetry_proto::tonic::{
@@ -26,23 +26,23 @@ use opentelemetry_proto::tonic::{
 use prost::Message;
 use regex::Regex;
 use std::collections::HashMap;
-use std::str::FromStr;
 use terminal_size::{self, Height, Width};
+
+// Add clap::ValueEnum and serde imports
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 
 // Constants
 const SERVICE_NAME_WIDTH: usize = 25;
 const SPAN_NAME_WIDTH: usize = 40;
-const SPAN_ID_WIDTH: usize = 10;
+const SPAN_ID_WIDTH: usize = 12;
 const SPAN_KIND_WIDTH: usize = 10; // Width for the Span Kind column
-const STATUS_WIDTH: usize = 8; // Width for the Status column
+const STATUS_WIDTH: usize = 7; // Width for the Status column
 const DURATION_WIDTH: usize = 13; // Width for the Duration column
-
-// Define a bright red color for errors
-const ERROR_COLOR: (u8, u8, u8) = (255, 0, 0); // Bright red
 
 // Define all color palettes
 // Default color palette
-const SERVICE_COLORS: [(u8, u8, u8); 12] = [
+const DEFAULT_COLORS: [(u8, u8, u8); 12] = [
     (46, 134, 193), // Blue
     (142, 68, 173), // Purple
     (39, 174, 96),  // Green
@@ -62,7 +62,7 @@ const TABLEAU_12: [(u8, u8, u8); 12] = [
     (31, 119, 180),  // Blue
     (255, 127, 14),  // Orange
     (44, 160, 44),   // Green
-    (214, 39, 40),   // Red
+    (100, 100, 100), // Medium Gray (Replacement for Red)
     (148, 103, 189), // Purple
     (140, 86, 75),   // Brown
     (227, 119, 194), // Pink
@@ -89,18 +89,18 @@ const COLORBREWER_SET3_12: [(u8, u8, u8); 12] = [
 ];
 
 const MATERIAL_12: [(u8, u8, u8); 12] = [
-    (244, 67, 54),  // Red
-    (233, 30, 99),  // Pink
-    (156, 39, 176), // Purple
-    (103, 58, 183), // Deep Purple
-    (63, 81, 181),  // Indigo
-    (33, 150, 243), // Blue
-    (0, 188, 212),  // Cyan
-    (0, 150, 136),  // Teal
-    (76, 175, 80),  // Green
-    (205, 220, 57), // Lime
-    (255, 152, 0),  // Orange
-    (121, 85, 72),  // Brown
+    (100, 180, 100), // Muted Green (Replacement for Red)
+    (180, 100, 180), // Muted Purple (Replacement for Pink)
+    (156, 39, 176),  // Purple
+    (103, 58, 183),  // Deep Purple
+    (63, 81, 181),   // Indigo
+    (33, 150, 243),  // Blue
+    (0, 188, 212),   // Cyan
+    (0, 150, 136),   // Teal
+    (76, 175, 80),   // Green
+    (205, 220, 57),  // Lime
+    (255, 152, 0),   // Orange
+    (121, 85, 72),   // Brown
 ];
 
 const SOLARIZED_12: [(u8, u8, u8); 12] = [
@@ -109,7 +109,7 @@ const SOLARIZED_12: [(u8, u8, u8); 12] = [
     (42, 161, 152),  // Cyan
     (133, 153, 0),   // Green
     (203, 75, 22),   // Orange
-    (220, 50, 47),   // Red
+    (100, 100, 180), // Muted Blue (Replacement for Red)
     (181, 137, 0),   // Yellow
     (108, 113, 196), // Violet
     (147, 161, 161), // Base1 (Gray)
@@ -134,8 +134,10 @@ const MONOCHROME_12: [(u8, u8, u8); 12] = [
 ];
 
 // Theme enum to represent all available themes
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
 pub enum Theme {
+    #[default] // Default for the enum
     Default,
     Tableau,
     ColorBrewer,
@@ -144,29 +146,27 @@ pub enum Theme {
     Monochrome,
 }
 
-impl FromStr for Theme {
-    type Err = String; // Define an error type for parsing
-
-    // Parse a theme name string to an enum value
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "default" => Ok(Theme::Default),
-            "tableau" => Ok(Theme::Tableau),
-            "colorbrewer" => Ok(Theme::ColorBrewer),
-            "material" => Ok(Theme::Material),
-            "solarized" => Ok(Theme::Solarized),
-            "monochrome" => Ok(Theme::Monochrome),
-            _ => Err(format!("Invalid theme name: {}", s)),
-        }
-    }
-}
-
 // Keep the original methods for Theme, but from_str is now part of FromStr
 impl Theme {
+    // FNV-1a constants (32-bit)
+    const FNV_OFFSET_BASIS: usize = 2166136261;
+    const FNV_PRIME: usize = 16777619;
+
+    // Helper function for FNV-1a hashing
+    fn fnv1a_hash_str(input: &str) -> usize {
+        let mut hash = Self::FNV_OFFSET_BASIS;
+        for byte in input.as_bytes() {
+            // Process bytes for better distribution
+            hash ^= *byte as usize;
+            hash = hash.wrapping_mul(Self::FNV_PRIME);
+        }
+        hash
+    }
+
     // Get the color palette for the theme
     pub fn get_palette(&self) -> &'static [(u8, u8, u8); 12] {
         match self {
-            Theme::Default => &SERVICE_COLORS,
+            Theme::Default => &DEFAULT_COLORS,
             Theme::Tableau => &TABLEAU_12,
             Theme::ColorBrewer => &COLORBREWER_SET3_12,
             Theme::Material => &MATERIAL_12,
@@ -177,28 +177,16 @@ impl Theme {
 
     // Get a color for a service based on its name hash
     pub fn get_color_for_service(&self, service_name: &str) -> (u8, u8, u8) {
-        let service_hash = service_name.chars().fold(0, |acc, c| acc + (c as usize));
+        let service_hash = Self::fnv1a_hash_str(service_name);
         let palette = self.get_palette();
         palette[service_hash % palette.len()]
     }
 
     // Get a color for a span based on its ID hash
     pub fn get_color_for_span(&self, span_id: &str) -> (u8, u8, u8) {
-        // Use a different hashing approach for span IDs to avoid collisions with service names
-        let mut span_hash: usize = 5381; // Initial prime
-        for c in span_id.chars() {
-            span_hash = span_hash.wrapping_add(c as usize).wrapping_mul(33); // Basic multiplicative hash
-        }
+        let span_hash = Self::fnv1a_hash_str(span_id);
         let palette = self.get_palette();
         palette[span_hash % palette.len()]
-    }
-
-    // Helper method to check if a theme name is valid
-    pub fn is_valid_theme(theme_name: &str) -> bool {
-        matches!(
-            theme_name.to_lowercase().as_str(),
-            "default" | "tableau" | "colorbrewer" | "material" | "solarized" | "monochrome"
-        )
     }
 }
 
@@ -231,7 +219,6 @@ struct TimelineItem {
     span_id: String,
     name: String,              // Span Name or Event Name
     level_or_status: String,   // Formatted Level (e.g., INFO) or Status (e.g., OK)
-    is_error: bool,            // To help color span ID for SpanStart items
     attributes: Vec<KeyValue>, // Filtered attributes for the specific item
     // Optional: Store parent span attributes separately *only* for events
     parent_span_attributes: Option<Vec<KeyValue>>,
@@ -317,51 +304,85 @@ fn generate_timeline_scale(trace_duration_ns: u64, timeline_width: usize) -> Str
     buffer.into_iter().collect()
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn display_console(
-    batch: &[TelemetryData],
-    attr_globs: &Option<GlobSet>,
-    event_severity_attribute_name: &str,
-    theme: Theme,
-    color_by: ColoringMode,
-    events_only: bool,
-    root_span_received: bool, // New parameter to indicate if the root span was found
-    grep_regex: Option<&Regex>,
-) -> Result<()> {
-    // Debug logging with theme and coloring mode
-    tracing::debug!("Display console called with theme={:?}, color_by={:?}, events_only={}, root_span_received={}, has_grep_regex={}", 
-                  theme, color_by, events_only, root_span_received, grep_regex.is_some());
+// Helper function to convert AnyValue to a comprehensive string for grep matching
+fn get_string_value_for_grep(value_opt: &Option<AnyValue>) -> String {
+    if let Some(any_value) = value_opt {
+        if let Some(ref val_type) = any_value.value {
+            return match val_type {
+                ProtoValue::StringValue(s) => s.clone(),
+                ProtoValue::BoolValue(b) => b.to_string(),
+                ProtoValue::IntValue(i) => i.to_string(),
+                ProtoValue::DoubleValue(d) => d.to_string(),
+                ProtoValue::ArrayValue(arr) => arr
+                    .values
+                    .iter()
+                    .map(|v_val| get_string_value_for_grep(&Some(v_val.clone()))) // Recurse for elements
+                    .collect::<Vec<String>>()
+                    .join(", "),
+                ProtoValue::KvlistValue(kv_list) => kv_list
+                    .values
+                    .iter()
+                    .map(|kv| format!("{}:{}", kv.key, get_string_value_for_grep(&kv.value)))
+                    .collect::<Vec<String>>()
+                    .join(", "),
+                ProtoValue::BytesValue(b) => format!("bytes_len:{}", b.len()),
+            };
+        }
+    }
+    String::new()
+}
 
+// --- Helper function to prepare trace data from a batch ---
+fn prepare_trace_data_from_batch(
+    batch: &[TelemetryData],
+) -> Result<HashMap<String, Vec<(Span, String)>>> {
+    // Initialize a vector to store tuples of (Span, ServiceName).
+    // This will be populated by decoding each TelemetryData item in the batch.
     let mut spans_with_service: Vec<(Span, String)> = Vec::new();
 
+    // Iterate over each TelemetryData item in the input batch.
     for item in batch {
+        // Attempt to decode the payload of the TelemetryData item into an ExportTraceServiceRequest.
+        // The payload is expected to be a protobuf message.
         match ExportTraceServiceRequest::decode(item.payload.as_slice()) {
             Ok(request) => {
+                // If decoding is successful, iterate over the resource_spans in the request.
                 for resource_span in request.resource_spans {
+                    // Find the service name from the resource attributes.
+                    // Defaults to "<unknown>" if "service.name" attribute is not found.
                     let service_name = find_service_name(
                         resource_span
                             .resource
                             .as_ref()
                             .map_or(&[], |r| &r.attributes),
                     );
+                    // Iterate over scope_spans within the current resource_span.
                     for scope_span in resource_span.scope_spans {
+                        // Iterate over individual spans within the current scope_span.
                         for span in scope_span.spans {
+                            // Add the cloned span and its associated service name to the spans_with_service vector.
                             spans_with_service.push((span.clone(), service_name.clone()));
                         }
                     }
                 }
             }
             Err(e) => {
+                // If decoding fails, log a warning and skip this item.
+                // Processing continues with the next item in the batch.
                 tracing::warn!(error = %e, "Failed to decode payload for console display, skipping item.");
-                // Continue processing other items in the batch if possible
             }
         }
     }
 
+    // If no spans were successfully decoded and collected, return an empty map or handle as an error if preferred.
+    // For now, an empty map means no traces to display further down.
     if spans_with_service.is_empty() {
-        return Ok(());
+        return Ok(HashMap::new());
     }
 
+    // Group spans by trace ID.
+    // A HashMap is used where keys are trace IDs (hex encoded strings) and
+    // values are vectors of (Span, ServiceName) tuples belonging to that trace.
     let mut traces: HashMap<String, Vec<(Span, String)>> = HashMap::new();
     for (span, service_name) in spans_with_service {
         let trace_id_hex = hex::encode(&span.trace_id);
@@ -370,11 +391,15 @@ pub fn display_console(
             .or_default()
             .push((span, service_name));
     }
+    Ok(traces)
+}
 
-    // Calculate approximate total table width for header ruling
-    const SPACING: usize = 6; // Approx spaces between 7 columns
+// --- Helper function to calculate console layout widths ---
+fn calculate_layout_widths(default_terminal_width: usize) -> (usize, usize, usize) {
+    // Define fixed widths for various columns in the waterfall display.
+    const SPACING: usize = 6; // Approximate number of spaces for padding between 7 columns.
 
-    // Calculate the fixed width excluding the timeline
+    // Calculate the total width occupied by columns with fixed sizes.
     let fixed_width_excluding_timeline = SERVICE_NAME_WIDTH
         + SPAN_NAME_WIDTH
         + SPAN_KIND_WIDTH
@@ -383,370 +408,527 @@ pub fn display_console(
         + STATUS_WIDTH
         + SPACING;
 
-    // Get terminal width and calculate dynamic timeline width
-    let terminal_width = get_terminal_width(120); // Use a larger default fallback
-                                                  // Ensure timeline width is at least some minimum (e.g., 10) or doesn't cause overflow
+    // Get the current terminal width, defaulting to `default_terminal_width` if it cannot be determined.
+    let terminal_width = get_terminal_width(default_terminal_width);
+    // Calculate the width available for the timeline visualization.
+    // It's the terminal width minus the fixed column widths, with a minimum of 10 characters.
     let calculated_timeline_width = terminal_width
         .saturating_sub(fixed_width_excluding_timeline)
         .max(10);
 
-    // Total width is now just the terminal width for header padding
-    let total_table_width = terminal_width;
+    (terminal_width, calculated_timeline_width, terminal_width)
+}
 
-    for (trace_id, spans_in_trace_with_service) in traces {
-        // 1. Define base and suffix
-        let base_heading = format!("Trace ID: {}", trace_id);
-        let suffix = if root_span_received {
-            ""
-        } else {
-            " (Missing Root)"
-        };
+// --- Helper function to print the trace header ---
+fn print_trace_header(trace_id: &str, root_span_received: bool, total_table_width: usize) {
+    // Construct the base heading for the trace.
+    let base_heading = format!("Trace ID: {}", trace_id);
+    // Add a suffix if the root span for this trace was not received.
+    let suffix = if root_span_received {
+        ""
+    } else {
+        " (Missing Root)"
+    };
 
-        // 2. Calculate total visible length
-        let visible_heading_len = base_heading.len() + suffix.len();
+    // Calculate the visible length of the heading (base + suffix).
+    let visible_heading_len = base_heading.len() + suffix.len();
 
-        // 3. Apply styling
-        let styled_heading = format!("{}{}", base_heading.bold(), suffix.dimmed());
+    // Style the heading: bold for the base, dimmed for the suffix.
+    let styled_heading = format!("{}{}", base_heading.bold(), suffix.dimmed());
 
-        // 4. Calculate padding dashes needed
-        // Subtract heading length and 2 spaces (one before, one after heading)
-        let total_dash_len = total_table_width.saturating_sub(visible_heading_len + 2);
-        // Ensure at least one dash on each side if possible
-        let left_dashes = 1;
-        let right_dashes = total_dash_len.saturating_sub(left_dashes);
+    // Calculate the number of dashes needed for padding around the heading
+    // to make the header line span the `total_table_width`.
+    let total_dash_len = total_table_width.saturating_sub(visible_heading_len + 2); // +2 for spaces around heading
+    let left_dashes = 1; // At least one dash on the left.
+    let right_dashes = total_dash_len.saturating_sub(left_dashes);
 
-        // 5. Print the header
-        println!(
-            "\n{} {} {}\n\n",
-            "─".repeat(left_dashes).dimmed(),
-            styled_heading, // Already styled
-            "─".repeat(right_dashes).dimmed()
-        );
+    // Print the formatted trace header.
+    println!(
+        "\n{} {} {}\n\n",
+        "─".repeat(left_dashes).dimmed(),
+        styled_heading,
+        "─".repeat(right_dashes).dimmed()
+    );
+}
 
-        if spans_in_trace_with_service.is_empty() {
-            continue;
+// --- Helper function to collect and filter timeline items for a trace ---
+fn collect_and_filter_timeline_items_for_trace(
+    spans_in_trace_with_service: &[(Span, String)],
+    attr_globs: &Option<GlobSet>,
+    event_severity_attribute_name: &str,
+    events_only: bool,
+    grep_regex: Option<&Regex>,
+) -> Vec<TimelineItem> {
+    let mut timeline_items: Vec<TimelineItem> = Vec::new();
+
+    for (span, service_name) in spans_in_trace_with_service {
+        let span_id_hex = hex::encode(&span.span_id);
+        let status_code = span.status.as_ref().map_or(status::StatusCode::Unset, |s| {
+            status::StatusCode::try_from(s.code).unwrap_or(status::StatusCode::Unset)
+        });
+        let is_error = status_code == status::StatusCode::Error;
+
+        if !events_only {
+            let filtered_span_attrs: Vec<KeyValue> = match attr_globs {
+                Some(globs) => span
+                    .attributes
+                    .iter()
+                    .filter(|kv| globs.is_match(&kv.key))
+                    .cloned()
+                    .collect(),
+                None => span.attributes.clone(),
+            };
+
+            let span_start_item = TimelineItem {
+                timestamp_ns: span.start_time_unix_nano,
+                item_type: ItemType::SpanStart,
+                service_name: service_name.clone(),
+                span_id: span_id_hex.clone(),
+                name: span.name.clone(),
+                level_or_status: format_span_status(status_code),
+                attributes: filtered_span_attrs,
+                parent_span_attributes: None,
+            };
+
+            let mut include_item = true;
+            if let Some(re) = grep_regex {
+                include_item = false;
+                for attr in &span_start_item.attributes {
+                    let value_str = get_string_value_for_grep(&attr.value);
+                    if re.is_match(&value_str) {
+                        include_item = true;
+                        break;
+                    }
+                }
+            }
+            if include_item {
+                timeline_items.push(span_start_item);
+            }
         }
 
-        // Replace the trace_events and span_error_status with timeline_items
-        let mut timeline_items: Vec<TimelineItem> = Vec::new();
+        for event in &span.events {
+            let mut level = if is_error {
+                "ERROR".to_string()
+            } else {
+                "INFO".to_string()
+            };
 
-        for (span, service_name) in &spans_in_trace_with_service {
-            let span_id_hex = hex::encode(&span.span_id);
-            let status_code = span.status.as_ref().map_or(status::StatusCode::Unset, |s| {
-                status::StatusCode::try_from(s.code).unwrap_or(status::StatusCode::Unset)
-            });
-            let is_error = status_code == status::StatusCode::Error;
-
-            if !events_only {
-                // Only add span starts if not events_only mode
-                let filtered_span_attrs: Vec<KeyValue> = match attr_globs {
-                    Some(globs) => span
-                        .attributes
-                        .iter()
-                        .filter(|kv| globs.is_match(&kv.key))
-                        .cloned()
-                        .collect(),
-                    None => span.attributes.clone(), // Collect all if no globs
-                };
-
-                timeline_items.push(TimelineItem {
-                    timestamp_ns: span.start_time_unix_nano,
-                    item_type: ItemType::SpanStart,
-                    service_name: service_name.clone(),
-                    span_id: span_id_hex.clone(),
-                    name: span.name.clone(),
-                    level_or_status: format_span_status(status_code),
-                    is_error,
-                    attributes: filtered_span_attrs,
-                    parent_span_attributes: None, // Not applicable for SpanStart
-                });
+            for attr in &event.attributes {
+                if attr.key == event_severity_attribute_name {
+                    if let Some(val) = &attr.value {
+                        if let Some(ProtoValue::StringValue(s)) = &val.value {
+                            level = s.clone().to_uppercase();
+                            break;
+                        }
+                    }
+                }
             }
 
-            // Add events - similar to the existing events logic but store in timeline_items
-            for event in &span.events {
-                let mut level = if is_error {
-                    "ERROR".to_string()
-                } else {
-                    "INFO".to_string()
-                };
+            let filtered_event_attrs: Vec<KeyValue> = match attr_globs {
+                Some(globs) => event
+                    .attributes
+                    .iter()
+                    .filter(|kv| globs.is_match(&kv.key))
+                    .cloned()
+                    .collect(),
+                None => event.attributes.clone(),
+            };
+            let filtered_parent_span_attrs: Vec<KeyValue> = match attr_globs {
+                Some(globs) => span
+                    .attributes
+                    .iter()
+                    .filter(|kv| globs.is_match(&kv.key))
+                    .cloned()
+                    .collect(),
+                None => span.attributes.clone(),
+            };
 
-                for attr in &event.attributes {
-                    if attr.key == event_severity_attribute_name {
-                        if let Some(val) = &attr.value {
-                            if let Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) = &val.value {
-                                level = s.clone().to_uppercase();
+            let event_item = TimelineItem {
+                timestamp_ns: event.time_unix_nano,
+                item_type: ItemType::Event,
+                service_name: service_name.clone(),
+                span_id: span_id_hex.clone(),
+                name: event.name.clone(),
+                level_or_status: level,
+                attributes: filtered_event_attrs,
+                parent_span_attributes: Some(filtered_parent_span_attrs),
+            };
+
+            let mut include_event_item = true;
+            if let Some(re) = grep_regex {
+                include_event_item = false;
+                for attr in &event_item.attributes {
+                    let value_str = get_string_value_for_grep(&attr.value);
+                    if re.is_match(&value_str) {
+                        include_event_item = true;
+                        break;
+                    }
+                }
+                if !include_event_item {
+                    if let Some(parent_attrs_for_event) = &event_item.parent_span_attributes {
+                        for attr in parent_attrs_for_event {
+                            let value_str = get_string_value_for_grep(&attr.value);
+                            if re.is_match(&value_str) {
+                                include_event_item = true;
                                 break;
                             }
                         }
                     }
                 }
-
-                // Filter attributes based on globs
-                let filtered_event_attrs: Vec<KeyValue> = match attr_globs {
-                    Some(globs) => event
-                        .attributes
-                        .iter()
-                        .filter(|kv| globs.is_match(&kv.key))
-                        .cloned()
-                        .collect(),
-                    None => event.attributes.clone(),
-                };
-                let filtered_parent_span_attrs: Vec<KeyValue> = match attr_globs {
-                    Some(globs) => span
-                        .attributes
-                        .iter()
-                        .filter(|kv| globs.is_match(&kv.key))
-                        .cloned()
-                        .collect(),
-                    None => span.attributes.clone(),
-                };
-
-                timeline_items.push(TimelineItem {
-                    timestamp_ns: event.time_unix_nano,
-                    item_type: ItemType::Event,
-                    service_name: service_name.clone(),
-                    span_id: span_id_hex.clone(),
-                    name: event.name.clone(),
-                    level_or_status: level,
-                    is_error,
-                    attributes: filtered_event_attrs,
-                    parent_span_attributes: Some(filtered_parent_span_attrs),
-                });
             }
-        }
-
-        // Sort by timestamp
-        timeline_items.sort_by_key(|item| item.timestamp_ns);
-
-        let mut span_map: HashMap<String, Span> = HashMap::new();
-        let mut service_name_map: HashMap<String, String> = HashMap::new();
-        let mut parent_to_children_map: HashMap<String, Vec<String>> = HashMap::new();
-        let mut root_ids: Vec<String> = Vec::new();
-
-        for (span, service_name) in spans_in_trace_with_service {
-            let span_id_hex = hex::encode(&span.span_id);
-            span_map.insert(span_id_hex.clone(), span);
-            service_name_map.insert(span_id_hex.clone(), service_name);
-        }
-
-        for (span_id_hex, span) in &span_map {
-            let parent_id_hex = if span.parent_span_id.is_empty() {
-                None
-            } else {
-                Some(hex::encode(&span.parent_span_id))
-            };
-            match parent_id_hex {
-                Some(ref p_id) if span_map.contains_key(p_id) => {
-                    parent_to_children_map
-                        .entry(p_id.clone())
-                        .or_default()
-                        .push(span_id_hex.clone());
-                }
-                _ => {
-                    root_ids.push(span_id_hex.clone());
-                }
-            }
-        }
-
-        let mut roots: Vec<ConsoleSpan> = root_ids
-            .iter()
-            .map(|root_id| {
-                build_console_span(
-                    root_id,
-                    &span_map,
-                    &parent_to_children_map,
-                    &service_name_map,
-                )
-            })
-            .collect();
-        roots.sort_by_key(|s| s.start_time);
-
-        let min_start_time = roots.iter().map(|r| r.start_time).min().unwrap_or(0);
-        let max_end_time = span_map
-            .values()
-            .map(|s| s.end_time_unix_nano)
-            .max()
-            .unwrap_or(0);
-        let trace_duration_ns = max_end_time.saturating_sub(min_start_time);
-
-        let mut table = Table::new();
-        // Apply comfy-table preset and dynamic arrangement
-        table
-            .load_preset(presets::NOTHING)
-            .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-            .set_width(total_table_width as u16)
-            .set_style(TableComponent::MiddleHeaderIntersections, '┴')
-            .set_style(TableComponent::BottomBorder, '─')
-            .set_style(TableComponent::BottomBorderIntersections, '─')
-            .set_style(TableComponent::HeaderLines, '─');
-
-        // Add table headers using comfy-table API with bold attribute
-        table.set_header(vec![
-            Cell::new("Service").add_attribute(Attribute::Bold),
-            Cell::new("Span Name").add_attribute(Attribute::Bold),
-            Cell::new("Kind").add_attribute(Attribute::Bold),
-            Cell::new("Duration (ms)").add_attribute(Attribute::Bold),
-            Cell::new("Span ID").add_attribute(Attribute::Bold),
-            Cell::new("Status").add_attribute(Attribute::Bold),
-            Cell::new("Timeline").add_attribute(Attribute::Bold),
-        ]);
-
-        // Define column widths for constraints
-        let column_widths: [(usize, u16); 6] = [
-            (0, SERVICE_NAME_WIDTH as u16),
-            (1, SPAN_NAME_WIDTH as u16),
-            (2, SPAN_KIND_WIDTH as u16),
-            (3, DURATION_WIDTH as u16),
-            (4, SPAN_ID_WIDTH as u16),
-            (5, STATUS_WIDTH as u16),
-        ];
-
-        // Apply constraints to fixed-width columns (0-5)
-        for (index, width) in &column_widths {
-            if let Some(column) = table.column_mut(*index) {
-                column.set_constraint(ColumnConstraint::UpperBoundary(Fixed(*width)));
-            }
-        }
-
-        // --- Add the timeline scale row ---
-        if trace_duration_ns > 0 {
-            let scale_content =
-                generate_timeline_scale(trace_duration_ns, calculated_timeline_width);
-            if !scale_content.trim().is_empty() {
-                // Add the scale row using comfy_table Cells
-                table.add_row(vec![
-                    Cell::new(""),            // Service
-                    Cell::new(""),            // Span Name
-                    Cell::new(""),            // Kind
-                    Cell::new(""),            // Duration (ms)
-                    Cell::new(""),            // Span ID
-                    Cell::new(""),            // Status
-                    Cell::new(scale_content), // Timeline scale content
-                ]);
-            }
-        }
-        // --- End timeline scale row ---
-
-        for root in roots {
-            add_span_to_table(
-                &mut table,
-                &root,
-                0,
-                min_start_time,
-                trace_duration_ns,
-                calculated_timeline_width,
-                theme,
-                &span_map,
-                color_by,
-            )?;
-        }
-
-        println!("{}", table);
-
-        if !timeline_items.is_empty() {
-            // Print Header
-            // let header_text = if events_only {
-            //     format!("Events for Trace: {}", trace_id)
-            // } else {
-            //     format!("Timeline Log for Trace: {}", trace_id)
-            // };
-            // let events_padding = total_table_width.saturating_sub(header_text.len() + 3);
-            // println!(
-            //     "\n{} {} {}",
-            //     "─".dimmed(),
-            //     header_text.bold(),
-            //     "─".repeat(events_padding)
-            // );
-
-            // Print each item
-            for item in timeline_items {
-                let timestamp = Utc.timestamp_nanos(item.timestamp_ns as i64);
-                let formatted_time = timestamp.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string();
-
-                // Get color for span ID prefix
-                let (prefix_r, prefix_g, prefix_b) = match color_by {
-                    ColoringMode::Service => theme.get_color_for_service(&item.service_name),
-                    ColoringMode::Span => theme.get_color_for_span(&item.span_id),
-                };
-
-                let span_id_prefix = item.span_id.chars().take(8).collect::<String>();
-
-                // Color span ID
-                let colored_span_id_prefix = if item.is_error {
-                    span_id_prefix
-                        .truecolor(ERROR_COLOR.0, ERROR_COLOR.1, ERROR_COLOR.2)
-                        .to_string()
-                } else {
-                    span_id_prefix
-                        .truecolor(prefix_r, prefix_g, prefix_b)
-                        .to_string()
-                };
-
-                // Type tag
-                let type_tag = match item.item_type {
-                    ItemType::SpanStart => "[SPAN]".to_string(),
-                    ItemType::Event => "[EVENT]".to_string(),
-                };
-
-                // Format and color level/status
-                let colored_level_status = match item.level_or_status.to_uppercase().as_str() {
-                    "ERROR" => item
-                        .level_or_status
-                        .truecolor(ERROR_COLOR.0, ERROR_COLOR.1, ERROR_COLOR.2)
-                        .bold(),
-                    "WARN" | "WARNING" => item.level_or_status.yellow().bold(),
-                    "OK" => item.level_or_status.green(), // For span status OK
-                    "UNSET" => item.level_or_status.dimmed(), // For span status UNSET
-                    _ => item.level_or_status.bright_black().bold(), // Default for INFO etc.
-                };
-                let level_status_tag = format!("[{}]", colored_level_status);
-
-                // Format attributes
-                let mut attrs_to_display: Vec<String> = Vec::new();
-
-                // Add the item's own attributes
-                for attr in &item.attributes {
-                    attrs_to_display.push(format_keyvalue(attr, grep_regex));
-                }
-
-                // If it's an Event, also add parent span attributes
-                if let Some(parent_attrs) = &item.parent_span_attributes {
-                    for attr in parent_attrs {
-                        // For parent attributes, we might not want to highlight them based on the event's grep match,
-                        // or we might. For simplicity now, format them without highlighting or pass grep_regex if needed.
-                        // Let's assume for now we only highlight direct attributes of the item that matched.
-                        let value_str = format_anyvalue(&attr.value);
-                        attrs_to_display.push(format!(
-                            "{}: {}",
-                            attr.key.bright_black(),
-                            value_str
-                        ));
-                    }
-                }
-
-                // Format the attrs suffix
-                let attrs_suffix = if !attrs_to_display.is_empty() {
-                    format!(" - {}", attrs_to_display.join(", "))
-                } else {
-                    String::new()
-                };
-
-                // Assemble and print the final line
-                println!(
-                    "{} {} [{}] {} {} {}{}",
-                    formatted_time.bright_black(),
-                    colored_span_id_prefix,
-                    item.service_name,
-                    type_tag,
-                    level_status_tag,
-                    item.name,
-                    attrs_suffix
-                );
+            if include_event_item {
+                timeline_items.push(event_item);
             }
         }
     }
 
+    timeline_items.sort_by_key(|item| item.timestamp_ns);
+    timeline_items
+}
+
+// --- Helper function to build waterfall hierarchy and gather metadata ---
+fn build_waterfall_hierarchy_and_meta(
+    spans_in_trace_with_service: &[(Span, String)],
+) -> (Vec<ConsoleSpan>, u64, u64, HashMap<String, Span>) {
+    // `span_map`: Maps span ID (hex string) to the `Span` object.
+    // `service_name_map`: Maps span ID (hex string) to its service name.
+    // `parent_to_children_map`: Maps parent span ID (hex string) to a list of its child span IDs.
+    // `root_ids`: A list of span IDs that are roots (have no parent or parent is not in this trace batch).
+    let mut span_map: HashMap<String, Span> = HashMap::new();
+    let mut service_name_map: HashMap<String, String> = HashMap::new();
+    let mut parent_to_children_map: HashMap<String, Vec<String>> = HashMap::new();
+    let mut root_ids: Vec<String> = Vec::new();
+
+    // Populate `span_map` and `service_name_map`.
+    for (span, service_name) in spans_in_trace_with_service {
+        let span_id_hex = hex::encode(&span.span_id);
+        // Clone span and service_name before inserting, as `spans_in_trace_with_service` is a slice of tuples.
+        span_map.insert(span_id_hex.clone(), span.clone());
+        service_name_map.insert(span_id_hex.clone(), service_name.clone());
+    }
+
+    // Populate `parent_to_children_map` and identify `root_ids`.
+    for (span_id_hex, span) in &span_map {
+        // Iterate over the populated span_map.
+        let parent_id_hex = if span.parent_span_id.is_empty() {
+            None
+        } else {
+            Some(hex::encode(&span.parent_span_id))
+        };
+        match parent_id_hex {
+            Some(ref p_id) if span_map.contains_key(p_id) => {
+                // If span has a parent and the parent is in our map, add it to children list.
+                parent_to_children_map
+                    .entry(p_id.clone())
+                    .or_default()
+                    .push(span_id_hex.clone());
+            }
+            _ => {
+                // Otherwise, it's a root span (or its parent is missing from this batch).
+                root_ids.push(span_id_hex.clone());
+            }
+        }
+    }
+
+    // Build `ConsoleSpan` structures (hierarchical representation for waterfall) from root spans.
+    let mut roots: Vec<ConsoleSpan> = root_ids
+        .iter()
+        .map(|root_id| {
+            build_console_span(
+                root_id,
+                &span_map,
+                &parent_to_children_map,
+                &service_name_map,
+            )
+        })
+        .collect();
+    // Sort root spans by their start time.
+    roots.sort_by_key(|s| s.start_time);
+
+    // Determine the overall start time and end time of the trace from all spans.
+    let min_start_time_ns = roots.iter().map(|r| r.start_time).min().unwrap_or(0);
+    let max_end_time_ns = span_map // Uses the span_map which contains all spans in this trace
+        .values()
+        .map(|s| s.end_time_unix_nano)
+        .max()
+        .unwrap_or(0);
+    // Calculate the total duration of the trace.
+    let trace_duration_ns = max_end_time_ns.saturating_sub(min_start_time_ns);
+
+    (roots, min_start_time_ns, trace_duration_ns, span_map)
+}
+
+// --- Helper function to render the waterfall table ---
+#[allow(clippy::too_many_arguments)]
+fn render_waterfall_table(
+    roots: &[ConsoleSpan],
+    min_start_time_ns: u64,
+    trace_duration_ns: u64,
+    calculated_timeline_width: usize,
+    total_table_width: usize, // For table.set_width()
+    theme: Theme,
+    color_by: ColoringMode,
+    span_map: &HashMap<String, Span>, // For add_span_to_table
+) -> Result<()> {
+    let mut table = Table::new();
+    table
+        .load_preset(presets::NOTHING)
+        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+        .set_width(total_table_width as u16)
+        .set_style(TableComponent::MiddleHeaderIntersections, '┴')
+        .set_style(TableComponent::BottomBorder, '─')
+        .set_style(TableComponent::BottomBorderIntersections, '─')
+        .set_style(TableComponent::HeaderLines, '─');
+
+    table.set_header(vec![
+        Cell::new("Service")
+            .add_attribute(Attribute::Bold)
+            .fg(comfy_table::Color::Rgb {
+                r: 128,
+                g: 255,
+                b: 128,
+            }),
+        Cell::new("Span Name").add_attribute(Attribute::Bold),
+        Cell::new("Kind").add_attribute(Attribute::Bold),
+        Cell::new("Duration (ms)").add_attribute(Attribute::Bold),
+        Cell::new("Span ID").add_attribute(Attribute::Bold),
+        Cell::new("Status").add_attribute(Attribute::Bold),
+        Cell::new("Timeline").add_attribute(Attribute::Bold),
+    ]);
+
+    let column_widths: [(usize, u16); 6] = [
+        (0, SERVICE_NAME_WIDTH as u16),
+        (1, SPAN_NAME_WIDTH as u16),
+        (2, SPAN_KIND_WIDTH as u16),
+        (3, DURATION_WIDTH as u16),
+        (4, SPAN_ID_WIDTH as u16),
+        (5, STATUS_WIDTH as u16),
+    ];
+
+    for (index, width) in &column_widths {
+        if let Some(column) = table.column_mut(*index) {
+            column.set_constraint(ColumnConstraint::UpperBoundary(Fixed(*width)));
+        }
+    }
+
+    if trace_duration_ns > 0 {
+        let scale_content = generate_timeline_scale(trace_duration_ns, calculated_timeline_width);
+        if !scale_content.trim().is_empty() {
+            table.add_row(vec![
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(""),
+                Cell::new(scale_content),
+            ]);
+        }
+    }
+
+    for root_span in roots {
+        // Changed variable name to avoid conflict with `roots` parameter in outer scope if this was inlined
+        add_span_to_table(
+            &mut table,
+            root_span,
+            0, // Initial depth
+            min_start_time_ns,
+            trace_duration_ns,
+            calculated_timeline_width,
+            theme,
+            span_map, // Pass the original `Span` map
+            color_by,
+        )?;
+    }
+
+    println!("{}", table);
     Ok(())
+}
+
+// --- Helper function to print the timeline log ---
+fn print_timeline_log(
+    timeline_items: &[TimelineItem],
+    color_by: ColoringMode,
+    theme: Theme,
+    grep_regex: Option<&Regex>,
+) {
+    if timeline_items.is_empty() {
+        return;
+    }
+
+    // First pass: determine maximum lengths for service_name and item.name
+    let mut max_service_name_len = 0;
+    let mut max_item_name_len = 0;
+
+    for item in timeline_items {
+        max_service_name_len = max_service_name_len.max(item.service_name.len());
+        max_item_name_len = max_item_name_len.max(item.name.len());
+    }
+
+    // Second pass: print timeline items with padding
+    for item in timeline_items {
+        // Iterate over the sorted `TimelineItem`s.
+        // Format timestamp into a readable string.
+        let timestamp = Utc.timestamp_nanos(item.timestamp_ns as i64);
+        let formatted_time = timestamp.format("%Y-%m-%dT%H:%M:%S%.6fZ").to_string();
+
+        // Get color for the span ID prefix based on `color_by` setting (service or span ID).
+        let (prefix_r, prefix_g, prefix_b) = match color_by {
+            ColoringMode::Service => theme.get_color_for_service(&item.service_name),
+            ColoringMode::Span => theme.get_color_for_span(&item.span_id),
+        };
+
+        // Take the first 8 characters of the span ID for display.
+        let span_id_prefix = item.span_id.chars().take(8).collect::<String>();
+
+        // Determine the type tag ("SPAN" or "EVENT").
+        let type_tag = match item.item_type {
+            ItemType::SpanStart => "SPAN".to_string(),
+            ItemType::Event => "EVENT".to_string(),
+        };
+
+        // --- Logic to get raw status/level text for consistent processing ---
+        let raw_text_for_status_or_level = if item.item_type == ItemType::SpanStart {
+            if item.level_or_status.contains("UNSET") {
+                "UNSET".to_string()
+            } else if item.level_or_status.contains("ERROR") {
+                "ERROR".to_string()
+            } else if item.level_or_status.contains("OK") {
+                "OK".to_string()
+            } else {
+                "STATUS?".to_string()
+            }
+        } else {
+            item.level_or_status.to_uppercase()
+        };
+
+        let text_to_format_and_color = format!("{} {:5}", type_tag, raw_text_for_status_or_level);
+
+        // --- Re-apply coloring for the actual output based on the raw status/level text ---
+        let level_status_colored = match raw_text_for_status_or_level.as_str() {
+            "ERROR" => text_to_format_and_color.red(),
+            "WARN" | "WARNING" => text_to_format_and_color.yellow(),
+            "INFO" | "OK" => text_to_format_and_color.green(),
+            "UNSET" => text_to_format_and_color.dimmed(),
+            _ => text_to_format_and_color.dimmed(),
+        };
+
+        let colored_span_id_for_print = span_id_prefix
+            .truecolor(prefix_r, prefix_g, prefix_b)
+            .to_string();
+
+        // Pad service_name and item.name to their respective maximum lengths for alignment
+        let service_name_padded = format!(
+            "{:<width$}",
+            item.service_name,
+            width = max_service_name_len
+        );
+        let item_name_padded = format!("{:<width$}", item.name, width = max_item_name_len);
+
+        let mut attrs_to_display: Vec<String> = Vec::new();
+        for attr in &item.attributes {
+            attrs_to_display.push(format_keyvalue(attr, grep_regex));
+        }
+        if let Some(parent_attrs) = &item.parent_span_attributes {
+            for attr in parent_attrs {
+                let value_str = format_anyvalue(&attr.value);
+                attrs_to_display.push(format!("{}: {}", attr.key.dimmed(), value_str));
+            }
+        }
+
+        let attrs_suffix = if !attrs_to_display.is_empty() {
+            format!(" - {}", attrs_to_display.join(", "))
+        } else {
+            String::new()
+        };
+
+        println!(
+            "{}  {:12} {} {} {} {}", // Adjusted for padded names and attrs_suffix structure
+            formatted_time.dimmed(),
+            level_status_colored,
+            colored_span_id_for_print,
+            service_name_padded, // Use padded service name
+            item_name_padded,    // Use padded item name
+            attrs_suffix         // attrs_suffix includes " - " or is empty
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn display_console(
+    batch: &[TelemetryData], // A collection of telemetry data items, each potentially containing multiple spans.
+    attr_globs: &Option<GlobSet>, // Optional set of glob patterns for filtering attributes to display.
+    event_severity_attribute_name: &str, // The attribute key used to determine event severity (e.g., "event.severity").
+    theme: Theme,                        // The color theme to use for console output.
+    color_by: ColoringMode,              // How to color items: by service name or by span ID.
+    events_only: bool, // If true, only events are shown in the timeline log (spans are hidden).
+    root_span_received: bool, // Indicates if the root span for the trace was found.
+    grep_regex: Option<&Regex>, // Optional regex for filtering timeline items by attribute values.
+) -> Result<()> {
+    // Debug logging with theme and coloring mode
+    tracing::debug!("Display console called with theme={:?}, color_by={:?}, events_only={}, root_span_received={}, has_grep_regex={}",
+                  theme, color_by, events_only, root_span_received, grep_regex.is_some());
+
+    // Prepare trace data: decode batch, extract spans, and group by trace ID.
+    let traces = prepare_trace_data_from_batch(batch)?;
+
+    // If no traces were found after preparation, exit early.
+    if traces.is_empty() {
+        tracing::debug!("No traces found in batch after preparation.");
+        return Ok(());
+    }
+
+    // Calculate console layout widths.
+    let (_terminal_width, calculated_timeline_width, total_table_width) =
+        calculate_layout_widths(120);
+
+    // Iterate over each trace collected in the `traces` HashMap.
+    // `trace_id` is the hex string of the trace ID.
+    // `spans_in_trace_with_service` is a vector of (Span, ServiceName) for this trace.
+    for (trace_id, spans_in_trace_with_service) in traces {
+        // ---- Print Trace Header ----
+        print_trace_header(&trace_id, root_span_received, total_table_width);
+
+        // If there are no spans in this particular trace (e.g., after filtering or if data was empty),
+        // skip to the next trace.
+        if spans_in_trace_with_service.is_empty() {
+            continue;
+        }
+
+        // Collect and filter timeline items (span starts and events) for the current trace.
+        let timeline_items = collect_and_filter_timeline_items_for_trace(
+            &spans_in_trace_with_service,
+            attr_globs,
+            event_severity_attribute_name,
+            events_only,
+            grep_regex,
+        );
+
+        // Build the waterfall hierarchy (ConsoleSpans) and get timing metadata.
+        let (roots, min_start_time_ns, trace_duration_ns, span_map) =
+            build_waterfall_hierarchy_and_meta(&spans_in_trace_with_service);
+
+        // Render and print the waterfall table.
+        render_waterfall_table(
+            &roots, // Pass roots as a slice
+            min_start_time_ns,
+            trace_duration_ns,
+            calculated_timeline_width,
+            total_table_width,
+            theme,
+            color_by,
+            &span_map,
+        )?;
+
+        // ---- Print Timeline Log ----
+        // If there are sorted timeline items (span starts or events), print them.
+        if !timeline_items.is_empty() {
+            print_timeline_log(&timeline_items, color_by, theme, grep_regex);
+        }
+    }
+    // End of loop for each trace.
+
+    Ok(()) // Indicate successful display.
 }
 
 // Private Helper Functions
@@ -839,19 +1021,17 @@ fn add_span_to_table(
         ColoringMode::Span => theme.get_color_for_span(&node.id),
     };
 
-    // --- Create Uncolored Cell Content ---
+    // --- Create Cell Content ---
     let service_name_content = node
         .service_name
         .chars()
         .take(SERVICE_NAME_WIDTH)
         .collect::<String>();
 
-    let span_name_width = SPAN_NAME_WIDTH.saturating_sub(indent.len());
-    let truncated_span_name = node.name.chars().take(span_name_width).collect::<String>();
-    let span_name_cell_content = format!("{} {}", indent, truncated_span_name);
-
-    let duration_ms = node.duration_ns as f64 / 1_000_000.0;
-    let duration_content = format!("{:.2}", duration_ms);
+    let span_name_cell_content = format!("{} {}", indent, node.name)
+        .chars()
+        .take(SPAN_NAME_WIDTH)
+        .collect::<String>();
 
     // Timeline bar remains colored
     let bar_cell_content = render_bar(
@@ -860,38 +1040,31 @@ fn add_span_to_table(
         trace_start_time_ns,
         trace_duration_ns,
         timeline_width,
-        (r, g, b), // Pass color to render_bar
     );
 
     // Get the actual span object for additional data
     let span_obj = span_map.get(&node.id);
 
-    // Format span kind (uncolored)
+    // Format span kind
     let kind_cell_content = span_obj
         .map_or("UNKNOWN".to_string(), |span| format_span_kind(span.kind))
         .chars()
         .take(SPAN_KIND_WIDTH)
         .collect::<String>();
 
-    let span_id_prefix = node.id.chars().take(8).collect::<String>();
-    let colored_span_id_str = if node.status_code == status::StatusCode::Error {
-        span_id_prefix
-            .truecolor(ERROR_COLOR.0, ERROR_COLOR.1, ERROR_COLOR.2)
-            .to_string()
-    } else {
-        span_id_prefix.truecolor(r, g, b).to_string()
-    };
+    let span_id_prefix = node.id.chars().take(SPAN_ID_WIDTH).collect::<String>();
 
     let status_content_str = format_span_status(node.status_code);
+    let formatted_duration = format!("{:.2}", node.duration_ns as f64 / 1_000_000.0);
 
     table.add_row(vec![
         Cell::new(service_name_content),
         Cell::new(span_name_cell_content),
         Cell::new(kind_cell_content),
-        Cell::new(duration_content).set_alignment(CellAlignment::Right), // Right-align duration
-        Cell::new(colored_span_id_str),
-        Cell::new(status_content_str),
-        Cell::new(bar_cell_content),
+        Cell::new(formatted_duration).set_alignment(CellAlignment::Right), // Right-align duration
+        Cell::new(span_id_prefix).fg(TableColor::Rgb { r, g, b }),
+        format_cell_level_color(&status_content_str),
+        Cell::new(bar_cell_content).fg(TableColor::Rgb { r, g, b }),
     ]);
 
     let mut children = node.children.clone();
@@ -920,7 +1093,6 @@ fn render_bar(
     trace_start_time_ns: u64,
     trace_duration_ns: u64,
     timeline_width: usize,
-    service_color: (u8, u8, u8),
 ) -> String {
     // If there's no duration, return empty space
     if trace_duration_ns == 0 {
@@ -945,9 +1117,7 @@ fn render_bar(
         }
     }
 
-    // Apply color to the entire bar string
-    let (r, g, b) = service_color;
-    bar_content.truecolor(r, g, b).to_string()
+    bar_content
 }
 
 fn format_span_kind(kind: i32) -> String {
@@ -974,10 +1144,10 @@ fn format_keyvalue(kv: &KeyValue, grep_regex: Option<&Regex>) -> String {
                 last_end = mat.end();
             }
             highlighted_value.push_str(&value_str[last_end..]);
-            return format!("{}: {}", kv.key.bright_black(), highlighted_value);
+            return format!("{}: {}", kv.key.dimmed(), highlighted_value);
         }
     }
-    format!("{}: {}", kv.key.bright_black(), value_str)
+    format!("{}: {}", kv.key.dimmed(), value_str)
 }
 
 fn format_anyvalue(av: &Option<AnyValue>) -> String {
@@ -998,11 +1168,17 @@ fn format_anyvalue(av: &Option<AnyValue>) -> String {
 
 fn format_span_status(status_code: status::StatusCode) -> String {
     match status_code {
-        status::StatusCode::Ok => "OK".green().to_string(),
-        status::StatusCode::Error => "ERROR"
-            .truecolor(ERROR_COLOR.0, ERROR_COLOR.1, ERROR_COLOR.2)
-            .bold()
-            .to_string(),
-        status::StatusCode::Unset => "UNSET".dimmed().to_string(),
+        status::StatusCode::Ok => "OK",
+        status::StatusCode::Error => "ERROR",
+        status::StatusCode::Unset => "UNSET",
+    }
+    .to_string()
+}
+
+fn format_cell_level_color(value: &str) -> Cell {
+    match value {
+        "OK" => Cell::new(value).fg(TableColor::Green),
+        "ERROR" => Cell::new(value).fg(TableColor::Red),
+        _ => Cell::new(value).fg(TableColor::DarkGrey),
     }
 }

--- a/cli/livetrace/src/console_display.rs
+++ b/cli/livetrace/src/console_display.rs
@@ -719,7 +719,7 @@ fn render_waterfall_table(
             ]);
         }
     }
-    
+
     for root_span in roots {
         // Changed variable name to avoid conflict with `roots` parameter in outer scope if this was inlined
         add_span_to_table(

--- a/cli/livetrace/src/console_display.rs
+++ b/cli/livetrace/src/console_display.rs
@@ -146,6 +146,19 @@ pub enum Theme {
     Monochrome,
 }
 
+impl std::fmt::Display for Theme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Theme::Default => write!(f, "default"),
+            Theme::Tableau => write!(f, "tableau"),
+            Theme::ColorBrewer => write!(f, "color-brewer"),
+            Theme::Material => write!(f, "material"),
+            Theme::Solarized => write!(f, "solarized"),
+            Theme::Monochrome => write!(f, "monochrome"),
+        }
+    }
+}
+
 // Keep the original methods for Theme, but from_str is now part of FromStr
 impl Theme {
     // FNV-1a constants (32-bit)

--- a/cli/livetrace/src/lib.rs
+++ b/cli/livetrace/src/lib.rs
@@ -550,12 +550,5 @@ pub async fn run_livetrace(args: CliArgs) -> Result<()> {
         }
     }
     spinner.finish_and_clear();
-
-    // Wait for any outstanding send_batch tasks to complete
-    for handle in send_batch_handles {
-        if let Err(e) = handle.await {
-            tracing::error!("Error in send_batch task: {:?}", e);
-        }
-    }
     Ok(())
 }

--- a/cli/livetrace/src/lib.rs
+++ b/cli/livetrace/src/lib.rs
@@ -552,5 +552,10 @@ pub async fn run_livetrace(args: CliArgs) -> Result<()> {
     spinner.finish_and_clear();
 
     // Wait for any outstanding send_batch tasks to complete
+    for handle in send_batch_handles {
+        if let Err(e) = handle.await {
+            tracing::error!("Error in send_batch task: {:?}", e);
+        }
+    }
     Ok(())
 }

--- a/cli/livetrace/src/lib.rs
+++ b/cli/livetrace/src/lib.rs
@@ -268,17 +268,21 @@ pub async fn run_livetrace(args: CliArgs) -> Result<()> {
         println!("  {:<18}: {}", "CloudFormation".dimmed(), stack);
     }
     println!();
-    if let Some(poll_secs) = config.poll_interval_ms {
+    if let Some(poll_interval_value_ms) = config.poll_interval_ms {
         println!("  {:<18}: Polling", "Mode".dimmed());
-        println!("  {:<18}: {} seconds", "Poll Interval".dimmed(), poll_secs);
+        println!(
+            "  {:<18}: {}",
+            "Poll Interval".dimmed(),
+            format_millis_to_duration_string(poll_interval_value_ms)
+        );
     } else {
         println!("  {:<18}: Live Tail", "Mode".dimmed());
-        println!(
-            "  {:<18}: {} minutes",
-            "Session Timeout".dimmed(),
-            config.session_timeout_ms / 1000 // Display as seconds for readability
-        );
     }
+    println!(
+        "  {:<18}: {}",
+        "Session Timeout".dimmed(),
+        format_millis_to_duration_string(config.session_timeout_ms)
+    );
     println!(
         "  {:<18}: {}",
         "Forward Only".dimmed(),

--- a/cli/livetrace/src/lib.rs
+++ b/cli/livetrace/src/lib.rs
@@ -300,7 +300,7 @@ pub async fn run_livetrace(args: CliArgs) -> Result<()> {
             resolved_headers_vec.len()
         );
     }
-    println!("  {:<18}: {:?}", "Theme".dimmed(), config.theme);
+    println!("  {:<18}: {}", "Theme".dimmed(), config.theme);
     println!(
         "  {:<18}: {}",
         "Color By".dimmed(),

--- a/cli/livetrace/src/poller.rs
+++ b/cli/livetrace/src/poller.rs
@@ -144,7 +144,7 @@ async fn filter_log_events_for_group(
 
                         if let Some(msg) = event.message {
                             match process_log_event_message(&msg) {
-                                // Corrected call
+                                // Process the log event message and send telemetry data if available
                                 Ok(Some(telemetry)) => {
                                     if sender.send(Ok(telemetry)).await.is_err() {
                                         tracing::warn!("Polling Adapter: MPSC channel closed by receiver while sending data.");

--- a/cli/livetrace/src/poller.rs
+++ b/cli/livetrace/src/poller.rs
@@ -27,7 +27,7 @@ pub fn start_polling_task(
     arns: Vec<String>,
     interval_millis: u64,
     sender: mpsc::Sender<Result<TelemetryData>>,
-    backtrace_seconds: Option<u64>,
+    backtrace_ms: Option<u64>,
     session_timeout_millis: u64,
 ) {
     tokio::spawn(async move {
@@ -44,7 +44,7 @@ pub fn start_polling_task(
         );
 
         let mut initial_start_time_ms = Utc::now().timestamp_millis();
-        if let Some(backtrace_ms_val) = backtrace_seconds {
+        if let Some(backtrace_ms_val) = backtrace_ms {
             initial_start_time_ms -= backtrace_ms_val as i64;
             tracing::info!(
                 backtrace_duration_ms = backtrace_ms_val,

--- a/cli/livetrace/src/processing.rs
+++ b/cli/livetrace/src/processing.rs
@@ -45,7 +45,6 @@ impl Default for SpanCompactionConfig {
 
 /// Processes a single CloudWatch Live Tail log event message string.
 pub fn process_log_event_message(message: &str) -> Result<Option<TelemetryData>> {
-    // grep_regex parameter removed
     tracing::trace!(message, "Processing log event message");
     let record: ExporterOutput = match serde_json::from_str::<ExporterOutput>(message) {
         Ok(output) => {

--- a/cli/livetrace/src/processing.rs
+++ b/cli/livetrace/src/processing.rs
@@ -14,8 +14,10 @@ use anyhow::{anyhow, Context, Result};
 use base64::{engine::general_purpose, Engine};
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use opentelemetry_proto::tonic::common::v1::any_value::Value as OTLPValue;
 use otlp_stdout_span_exporter::ExporterOutput;
 use prost::Message;
+use regex::Regex;
 use reqwest::header::HeaderMap;
 use reqwest::Client as ReqwestClient;
 use reqwest::Url;
@@ -43,8 +45,99 @@ impl Default for SpanCompactionConfig {
     }
 }
 
+fn otlp_any_value_to_string_for_grep(
+    av: &opentelemetry_proto::tonic::common::v1::AnyValue,
+) -> String {
+    // This function should be comprehensive for all types to ensure effective grep.
+    // It might differ from a display-oriented formatter.
+    if let Some(ref val_type) = av.value {
+        match val_type {
+            OTLPValue::StringValue(s) => s.clone(),
+            OTLPValue::BoolValue(b) => b.to_string(),
+            OTLPValue::IntValue(i) => i.to_string(),
+            OTLPValue::DoubleValue(d) => d.to_string(),
+            OTLPValue::ArrayValue(arr) => {
+                // For arrays, concatenate string representations of elements
+                arr.values
+                    .iter()
+                    .map(otlp_any_value_to_string_for_grep)
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            }
+            OTLPValue::KvlistValue(kv_list) => {
+                // For KV lists, format as "key1:value1, key2:value2"
+                kv_list
+                    .values
+                    .iter()
+                    .map(|kv| {
+                        format!(
+                            "{}:{}",
+                            kv.key,
+                            otlp_any_value_to_string_for_grep(
+                                &kv.value.clone().unwrap_or_default()
+                            )
+                        )
+                    })
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            }
+            OTLPValue::BytesValue(b) => format!("bytes_len:{}", b.len()), // Or hex/base64, but length might be enough for grep
+                                                                          // The _ pattern is unreachable because all variants of OTLPValue are covered above.
+                                                                          // If new variants are added to OTLPValue in the future, this match would need to be updated.
+        }
+    } else {
+        String::new()
+    }
+}
+
+fn check_attributes_match(
+    kvs: &[opentelemetry_proto::tonic::common::v1::KeyValue],
+    grep_regex: &Regex,
+) -> bool {
+    kvs.iter().any(|kv| {
+        // Grep should match on attribute *values*
+        if let Some(ref value) = kv.value {
+            let value_str = otlp_any_value_to_string_for_grep(value);
+            if grep_regex.is_match(&value_str) {
+                return true;
+            }
+        }
+        // Optionally, match on keys as well:
+        // if grep_regex.is_match(&kv.key) {
+        //     return true;
+        // }
+        false
+    })
+}
+
+fn check_request_attributes_match(request: &ExportTraceServiceRequest, grep_regex: &Regex) -> bool {
+    for rs in &request.resource_spans {
+        if let Some(ref resource) = rs.resource {
+            if check_attributes_match(&resource.attributes, grep_regex) {
+                return true;
+            }
+        }
+        for ss in &rs.scope_spans {
+            for span in &ss.spans {
+                if check_attributes_match(&span.attributes, grep_regex) {
+                    return true;
+                }
+                for event in &span.events {
+                    if check_attributes_match(&event.attributes, grep_regex) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Processes a single CloudWatch Live Tail log event message string.
-pub fn process_log_event_message(message: &str) -> Result<Option<TelemetryData>> {
+pub fn process_log_event_message(
+    message: &str,
+    grep_regex: Option<&Regex>,
+) -> Result<Option<TelemetryData>> {
     tracing::trace!(message, "Processing log event message");
     let record: ExporterOutput = match serde_json::from_str::<ExporterOutput>(message) {
         Ok(output) => {
@@ -80,6 +173,24 @@ pub fn process_log_event_message(message: &str) -> Result<Option<TelemetryData>>
         Some(&record.content_encoding),
     )
     .context("Failed to convert payload to protobuf")?;
+
+    if let Some(re) = grep_regex {
+        match ExportTraceServiceRequest::decode(protobuf_payload.as_slice()) {
+            Ok(request) => {
+                if !check_request_attributes_match(&request, re) {
+                    tracing::trace!(
+                        "Log message's telemetry data did not match grep regex, skipping."
+                    );
+                    return Ok(None); // Discard if no attribute matches
+                }
+                // If it matches, proceed to return Some(TelemetryData)
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to decode protobuf payload for grep checking, skipping.");
+                return Ok(None);
+            }
+        }
+    }
 
     Ok(Some(TelemetryData {
         payload: protobuf_payload,
@@ -344,7 +455,9 @@ mod tests {
 
         let json_message = serde_json::to_string(&exporter_output).unwrap();
 
-        let result = process_log_event_message(&json_message).unwrap();
+        let result = process_log_event_message(&json_message, None); // Added None for grep_regex
+        assert!(result.is_ok());
+        let result = result.unwrap();
 
         assert!(result.is_some());
         let telemetry_data = result.unwrap();
@@ -461,8 +574,9 @@ mod tests {
     #[test]
     fn test_process_log_event_message_invalid_json() {
         let invalid_json_message = "{ not json \"";
-        let result = process_log_event_message(invalid_json_message).unwrap();
-        assert!(result.is_none()); // Expect Ok(None) for parsing errors
+        let result = process_log_event_message(invalid_json_message, None); // Added None
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none()); // Expect Ok(None) for parsing errors
     }
 
     #[test]
@@ -485,7 +599,7 @@ mod tests {
         let json_message = serde_json::to_string(&exporter_output).unwrap();
 
         // Expect an Err result because base64 decoding fails
-        let result = process_log_event_message(&json_message);
+        let result = process_log_event_message(&json_message, None); // Added None
         assert!(result.is_err());
         // Optionally check the error message content
         assert!(result
@@ -515,7 +629,7 @@ mod tests {
         let json_message = serde_json::to_string(&exporter_output).unwrap();
 
         // Expect an Err result because gzip decoding fails
-        let result = process_log_event_message(&json_message);
+        let result = process_log_event_message(&json_message, None); // Added None
         assert!(result.is_err()); // Just check that it errors, context might be less specific
                                   // assert!(result.unwrap_err().to_string().contains("Failed to decompress Gzip payload")); // Removed specific context check
     }


### PR DESCRIPTION
This pull request introduces version `0.2.0` of the `livetrace` CLI tool, bringing significant new features, usability enhancements, bug fixes, and code refactoring. Key highlights include new CLI options for filtering and log fetching, improved color palettes, better handling of defaults in configuration, and modularized code for maintainability. The documentation has also been updated to reflect these changes.

### New Features and Enhancements:
* **CLI Options**: Added `--grep <REGEX>` for filtering spans/events using regex with highlighted matches, and `--backtrace <DURATION>` for fetching logs from a specified duration ago in polling mode. Duration-based arguments now support units like `s`, `m`, `h`. [[1]](diffhunk://#diff-c451b7e6fddedec09135853b8dcba814a2a3f6235787c31db7de9b2549b95f4bR8-R37) [[2]](diffhunk://#diff-5263851340de113687a23605778c884a62eac37c88d13870f62921948664f623L104-R166) [[3]](diffhunk://#diff-5263851340de113687a23605778c884a62eac37c88d13870f62921948664f623L149-R212)
* **Color Palettes**: Introduced "red-safe" alternatives in color palettes (`TABLEAU_12`, `MATERIAL_12`, `SOLARIZED_12`) to avoid confusion with error indicators.

### Documentation Updates:
* **README.md**: Added examples for `--grep` and `--backtrace`, improved shell completion instructions, and expanded the Table of Contents. [[1]](diffhunk://#diff-5263851340de113687a23605778c884a62eac37c88d13870f62921948664f623R5-R31) [[2]](diffhunk://#diff-5263851340de113687a23605778c884a62eac37c88d13870f62921948664f623L104-R166) [[3]](diffhunk://#diff-5263851340de113687a23605778c884a62eac37c88d13870f62921948664f623L272-R327)

### Code Refactoring:
* **CLI Codebase**: Centralized default values for CLI arguments as constants, refactored `cli.rs` for readability, and modularized the `console_display` function into smaller helper functions. [[1]](diffhunk://#diff-c451b7e6fddedec09135853b8dcba814a2a3f6235787c31db7de9b2549b95f4bR8-R37) [[2]](diffhunk://#diff-0aa1c491fa74752e81c4b4c0962df8b0e2b65edf4f706a1a9e9bed1187c221beR66)

### Bug Fixes:
* **Configuration and Display**: Fixed an issue where default values from `clap` incorrectly overrode configuration profiles, and resolved missing fields for `SpanStart` items in the timeline log.

### Miscellaneous:
* **Version Update**: Updated `livetrace` version to `0.2.0` in `Cargo.toml` and added the `regex` crate as a dependency for the `--grep` feature. [[1]](diffhunk://#diff-0aa1c491fa74752e81c4b4c0962df8b0e2b65edf4f706a1a9e9bed1187c221beL3-R3) [[2]](diffhunk://#diff-0aa1c491fa74752e81c4b4c0962df8b0e2b65edf4f706a1a9e9bed1187c221beR66)