### PR TITLE
release cli/livetrace v0.2.1

### DIFF
--- a/cli/livetrace/CHANGELOG.md
+++ b/cli/livetrace/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-05-18
+
+### Changed
+- Updated `livetrace` version to `0.2.1` in `Cargo.toml`.
+- Updated `README.md` to include a new screenshot of the `livetrace` CLI in action.
+
 ## [0.2.0] - 2025-05-14
 
 ### Added

--- a/cli/livetrace/Cargo.toml
+++ b/cli/livetrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livetrace"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/livetrace/README.md
+++ b/cli/livetrace/README.md
@@ -4,6 +4,9 @@
 
 `livetrace` is a command-line tool designed to enhance local development workflows when working with distributed tracing in serverless environments using the [Serverless OTLP Forwarder Architecture](https://dev7a.github.io/serverless-otlp-forwarder/architecture/).
 
+![livetracing a demo app](https://github.com/user-attachments/assets/a407781b-cf19-4612-accc-b97da9e5cdd7)
+---
+
 ## Table of Contents
 
 *   [Overview](#overview)
@@ -29,9 +32,6 @@
 *   [License](#license)
 
 ## Overview
-
-![livetracing a demo app](https://github.com/user-attachments/assets/a407781b-cf19-4612-accc-b97da9e5cdd7)
----
 
 In the [Serverless OTLP Forwarder architecture](https://dev7a.github.io/serverless-otlp-forwarder/architecture/), Lambda functions (or other compute resources) emit OpenTelemetry (OTLP) trace data to standard output. This tool enables you to correlate and visualize complete traces—especially valuable during development. Because logs from different services involved in a single request may be distributed across multiple Log Groups, _livetrace_ can tail several log groups simultaneously and reconstruct traces spanning all participating services.
 

--- a/cli/livetrace/RELEASE_NOTES.md
+++ b/cli/livetrace/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## livetrace v0.2.1 - 2025-05-18
+
+This minor release of `livetrace` introduces a new screenshot of the `livetrace` CLI in action.
+
+### New Features and Enhancements:
+
+*   **README.md:**
+    *   Added a new screenshot of the `livetrace` CLI in action.
+
 ## livetrace v0.2.0 - 2025-05-17
 
 This release of `livetrace` introduces powerful new filtering and log fetching capabilities, enhances usability with improved CLI arguments and color palettes, and includes important bug fixes and code refactoring for better maintainability.


### PR DESCRIPTION
This pull request updates the `livetrace` CLI tool to version `0.2.1`, introduces a new screenshot in the documentation, and provides corresponding updates to metadata and release notes.

### Version and Metadata Updates:
* Updated the `livetrace` version from `0.2.0` to `0.2.1` in `Cargo.toml` to reflect the new release.

### Documentation Enhancements:
* Added a new screenshot of the `livetrace` CLI in action to the `README.md` file to improve user understanding of the tool.
* Removed a duplicate screenshot from the `Overview` section of the `README.md` for better clarity.

### Changelog and Release Notes:
* Updated `CHANGELOG.md` to include details about the `0.2.1` release, including the updated version and documentation changes.
* Added release notes for version `0.2.1` in `RELEASE_NOTES.md`, highlighting the inclusion of the new screenshot.