### PR TITLE
release: python/otlp-stdout-span-exporter v0.16.0

### DIFF
--- a/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [0.16.0] - 2025-06-14
 
 ### Added
-- Added entry points for OpenTelemetry auto-discovery (oltpstdout)
+- Added entry points for OpenTelemetry auto-discovery (otlpstdout)
 
 ### Changed
 - Updated development dependencies to newer versions:

--- a/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/python/otlp-stdout-span-exporter/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2025-06-14
+
+### Added
+- Added entry points for OpenTelemetry auto-discovery (oltpstdout)
+
+### Changed
+- Updated development dependencies to newer versions:
+  - pytest>=8.4.0 (from 7.4.0)
+  - pytest-asyncio>=1.0.0 (from 0.21.0)
+  - pytest-cov>=6.2.1 (from 4.1.0)
+  - ruff>=0.9.6 (from 0.1.0)
+  - mypy>=1.15.0 (from 1.7.0)
+
 ## [0.15.0] - 2025-04-28
 
 ### Added

--- a/packages/python/otlp-stdout-span-exporter/pyproject.toml
+++ b/packages/python/otlp-stdout-span-exporter/pyproject.toml
@@ -8,7 +8,7 @@ path = "src/otlp_stdout_span_exporter/version.py"
 
 [project]
 name = "otlp-stdout-span-exporter"
-version = "0.15.0"
+version = "0.16.0"
 description = "OpenTelemetry span exporter that writes to stdout in OTLP format"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -36,12 +36,16 @@ repository = "https://github.com/dev7a/serverless-otlp-forwarder/tree/main/packa
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=7.4.0",
-    "pytest-asyncio>=0.21.0",
-    "pytest-cov>=4.1.0",
-    "ruff>=0.1.0",
-    "mypy>=1.7.0",
+    "pytest>=8.4.0",
+    "pytest-asyncio>=1.0.0",
+    "pytest-cov>=6.2.1",
+    "ruff>=0.9.6",
+    "mypy>=1.15.0",
 ]
+
+# Entry points for OpenTelemetry auto-discovery
+[project.entry-points."opentelemetry_traces_exporter"]
+otlpstdout = "otlp_stdout_span_exporter:OTLPStdoutSpanExporter"
 
 [tool.hatch.build]
 only-packages = true


### PR DESCRIPTION
This pull request updates the `otlp-stdout-span-exporter` package to version 0.16.0, introducing new features, upgrading dependencies, and adding entry points for OpenTelemetry auto-discovery. Below are the most significant changes:

### Version Update:

* Updated the package version from `0.15.0` to `0.16.0` in `pyproject.toml`.

### Dependency Upgrades:

* Upgraded development dependencies in `pyproject.toml`:
  - `pytest` to `>=8.4.0` (from `>=7.4.0`).
  - `pytest-asyncio` to `>=1.0.0` (from `>=0.21.0`).
  - `pytest-cov` to `>=6.2.1` (from `>=4.1.0`).
  - `ruff` to `>=0.9.6` (from `>=0.1.0`).
  - `mypy` to `>=1.15.0` (from `>=1.7.0`).

### OpenTelemetry Auto-Discovery:

* Added entry points for OpenTelemetry auto-discovery in `pyproject.toml`:
  - Defined `otlpstdout` entry point under `opentelemetry_traces_exporter`.

### Documentation Update:

* Updated `CHANGELOG.md` to reflect changes in version 0.16.0, including added entry points and upgraded dependencies.