### PR TITLE
release: node/otlp-stdout-span-exporter v0.17.1

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2025-06-19
+
+### Fixed
+- Fixed webpack bundling compatibility by using Node.js-specific export condition
+- ESM wrapper now only loads in native Node.js environments, preventing `MODULE_NOT_FOUND` errors in bundled applications
+- Bundlers like webpack will now use CommonJS version by default for better compatibility
+
 ## [0.17.0] - 2025-06-19
 
 ### Added

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -77,6 +77,9 @@ import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
 import OTLPStdoutSpanExporter from '@dev7a/otlp-stdout-span-exporter';
 ```
 
+>[!NOTE]
+>When using bundlers like webpack, the package will use CommonJS by default to ensure compatibility. Native Node.js environments will automatically use the ESM wrapper when importing.
+
 The recommended way to use this exporter is with the standard OpenTelemetry `BatchSpanProcessor`, which provides better performance by buffering and exporting spans in batches, or, in conjunction with the [lambda-otel-lite](https://www.npmjs.com/package/@dev7a/lambda-otel-lite) package, with the `LambdaSpanProcessor`, which is particularly optimized for AWS Lambda.
 
 You can create a simple tracer provider with the BatchSpanProcessor and the OTLPStdoutSpanExporter:

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
+      "node": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js"
+      },
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
This pull request updates the `@dev7a/otlp-stdout-span-exporter` package to version `0.17.1`, addressing bundling compatibility issues and improving the handling of ESM and CommonJS exports. The changes ensure better support for both native Node.js environments and bundlers like webpack.

### Compatibility Improvements:

* [`packages/node/otlp-stdout-span-exporter/package.json`](diffhunk://#diff-de9bcc5499221be2efd6fb53ecc3d3967208154d47830f6f69e94693d1ffafbeL3-R13): Updated the `exports` field to include a Node.js-specific condition, ensuring that the ESM wrapper is used only in native Node.js environments while bundlers default to the CommonJS version.

### Documentation Updates:

* [`packages/node/otlp-stdout-span-exporter/CHANGELOG.md`](diffhunk://#diff-98d7656b1775668a361eb259643823fb60356e4f05cc19ce00f0d804403e6012R8-R14): Added a changelog entry for version `0.17.1`, detailing fixes for webpack bundling compatibility and the selective loading of ESM wrappers.
* [`packages/node/otlp-stdout-span-exporter/README.md`](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752R80-R82): Added a note explaining the behavior of the package when used with bundlers like webpack, emphasizing the default use of CommonJS for compatibility.