### PR TITLE
release: node/otlp-stdout-span-exporter v0.17.2

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2025-06-19
+
+### Fixed
+- Fixed webpack bundling issue properly by removing ESM from main export path
+- ESM support now available via `/esm` subpath export for native Node.js environments
+- Main export now always uses CommonJS to ensure compatibility with all bundlers
+
 ## [0.17.1] - 2025-06-19
 
 ### Fixed

--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.2] - 2025-06-19
 
 ### Fixed
-- Fixed webpack bundling issue properly by removing ESM from main export path
-- ESM support now available via `/esm` subpath export for native Node.js environments
-- Main export now always uses CommonJS to ensure compatibility with all bundlers
+- Fixed webpack bundling issue by changing export strategy
+- Main export now always provides CommonJS for compatibility
+- ESM support moved to `/esm` subpath export for native Node.js environments only
+
+### Changed
+- ESM is no longer available via the main export due to webpack incompatibility
+- Added error detection for webpack bundling in ESM wrapper
 
 ## [0.17.1] - 2025-06-19
 

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -63,23 +63,44 @@ npm install @dev7a/otlp-stdout-span-exporter @opentelemetry/api @opentelemetry/c
 
 ## Usage
 
-The exporter works with both CommonJS and ES modules:
+The exporter works with CommonJS:
 
-### CommonJS
 ```javascript
 const { OTLPStdoutSpanExporter } = require('@dev7a/otlp-stdout-span-exporter');
 ```
 
-### ES Modules
+>[!NOTE]
+>ESM support has been temporarily removed due to bundler compatibility issues. This package currently only supports CommonJS imports.
+
+### ESM Support
+
+This package provides experimental ESM support via a subpath export. Due to bundler compatibility issues, ESM is not available via the main export.
+
+To use ESM in native Node.js environments:
+
 ```javascript
-// For native ESM support (not bundled)
+// Use the /esm subpath
 import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter/esm';
-// or
-import OTLPStdoutSpanExporter from '@dev7a/otlp-stdout-span-exporter/esm';
 ```
 
->[!NOTE]
->When using bundlers like webpack, the package will use CommonJS by default to ensure compatibility. Native Node.js environments can use the `/esm` subpath for true ES module imports.
+>[!WARNING]
+>The ESM export is not compatible with webpack bundling. If you're using webpack, please use the CommonJS syntax instead.
+
+### Webpack Configuration
+
+If you're using webpack and encountering module resolution issues, add this package to your externals:
+
+```javascript
+module.exports = {
+  // ... your config
+  externals: [
+    '@dev7a/otlp-stdout-span-exporter',
+    // ... other externals
+  ],
+};
+```
+
+This ensures webpack doesn't try to bundle the package and uses Node.js's native module resolution at runtime.
 
 The recommended way to use this exporter is with the standard OpenTelemetry `BatchSpanProcessor`, which provides better performance by buffering and exporting spans in batches, or, in conjunction with the [lambda-otel-lite](https://www.npmjs.com/package/@dev7a/lambda-otel-lite) package, with the `LambdaSpanProcessor`, which is particularly optimized for AWS Lambda.
 

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -72,13 +72,14 @@ const { OTLPStdoutSpanExporter } = require('@dev7a/otlp-stdout-span-exporter');
 
 ### ES Modules
 ```javascript
-import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter';
+// For native ESM support (not bundled)
+import { OTLPStdoutSpanExporter } from '@dev7a/otlp-stdout-span-exporter/esm';
 // or
-import OTLPStdoutSpanExporter from '@dev7a/otlp-stdout-span-exporter';
+import OTLPStdoutSpanExporter from '@dev7a/otlp-stdout-span-exporter/esm';
 ```
 
 >[!NOTE]
->When using bundlers like webpack, the package will use CommonJS by default to ensure compatibility. Native Node.js environments will automatically use the ESM wrapper when importing.
+>When using bundlers like webpack, the package will use CommonJS by default to ensure compatibility. Native Node.js environments can use the `/esm` subpath for true ES module imports.
 
 The recommended way to use this exporter is with the standard OpenTelemetry `BatchSpanProcessor`, which provides better performance by buffering and exporting spans in batches, or, in conjunction with the [lambda-otel-lite](https://www.npmjs.com/package/@dev7a/lambda-otel-lite) package, with the `LambdaSpanProcessor`, which is particularly optimized for AWS Lambda.
 

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
-      },
+      "require": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./esm": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -11,8 +11,7 @@
       "default": "./dist/index.js"
     },
     "./esm": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts", 
       "default": "./dist/index.mjs"
     }
   },
@@ -22,10 +21,10 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "npm run clean && npm run generate:version && tsc -p tsconfig.json && npm run build:esm-wrapper && echo 'Build completed successfully'",
-    "build:esm-wrapper": "node scripts/build-esm-wrapper.js",
+    "build": "npm run clean && npm run generate:version && tsc -p tsconfig.json && echo 'Build completed successfully'",
     "clean": "rm -rf dist",
     "generate:version": "echo '// This file is auto-generated. Do not edit manually.\nexport const VERSION = \"'$(node -p \"require('./package.json').version\")'\";' > src/version.ts",
+    "build-esm-wrapper": "node scripts/build-esm-wrapper.js",
     "test": "jest",
     "lint": "eslint src/*.ts src/**/*.ts --quiet",
     "prepare": "npm run build",

--- a/packages/node/otlp-stdout-span-exporter/scripts/build-esm-wrapper.js
+++ b/packages/node/otlp-stdout-span-exporter/scripts/build-esm-wrapper.js
@@ -2,16 +2,47 @@
 const fs = require('fs');
 const path = require('path');
 
-// ESM wrapper content
+// ESM wrapper content with webpack compatibility
 const esmWrapper = `// ESM wrapper for CommonJS module
 import { createRequire } from "module";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const require = createRequire(import.meta.url);
-const mod = require("./index.js");
+
+// Try to load the CommonJS module with multiple strategies
+let mod;
+try {
+  // First try: Direct relative path (works in normal Node.js)
+  mod = require("./index.js");
+} catch (e1) {
+  try {
+    // Second try: Absolute path (might work in some bundlers)
+    mod = require(join(__dirname, "index.js"));
+  } catch (e2) {
+    try {
+      // Third try: Load via package name (for bundled environments)
+      mod = require("@dev7a/otlp-stdout-span-exporter");
+    } catch (e3) {
+      // Last resort: If we're in a webpack bundle, the CommonJS module might be available globally
+      if (typeof __webpack_require__ !== 'undefined') {
+        throw new Error("ESM wrapper is not compatible with webpack bundling. Please use CommonJS require() instead of import.");
+      }
+      throw new Error(\`Failed to load CommonJS module. Tried:
+1. ./index.js - \${e1.message}
+2. \${join(__dirname, "index.js")} - \${e2.message}  
+3. @dev7a/otlp-stdout-span-exporter - \${e3.message}\`);
+    }
+  }
+}
 
 // Re-export all named exports
 export const OTLPStdoutSpanExporter = mod.OTLPStdoutSpanExporter;
 export const LogLevel = mod.LogLevel;
 export const OutputType = mod.OutputType;
+export const VERSION = mod.VERSION;
 
 // Default export
 export default mod.OTLPStdoutSpanExporter;


### PR DESCRIPTION
This pull request introduces changes to address webpack bundling issues and improve compatibility for the `@dev7a/otlp-stdout-span-exporter` package. The main updates include modifying the export strategy, adding experimental ESM support via a subpath, and enhancing error handling in the ESM wrapper. Below is a breakdown of the most important changes.

### Compatibility Updates

* **Changelog Update**: Documented changes in `packages/node/otlp-stdout-span-exporter/CHANGELOG.md` to reflect the new version `0.17.2`, highlighting fixes for webpack bundling issues and the introduction of ESM support via the `/esm` subpath.
* **README Update**: Updated `packages/node/otlp-stdout-span-exporter/README.md` to clarify that ESM support is now experimental and available via a subpath, with warnings about incompatibility with webpack bundling. Added instructions for configuring webpack externals to avoid module resolution issues.

### Export Strategy Changes

* **Package.json Updates**: Modified `packages/node/otlp-stdout-span-exporter/package.json` to adjust the `exports` field, removing ESM from the main export and introducing a `/esm` subpath for native Node.js environments.
* **Build Script Adjustments**: Updated build scripts in `packages/node/otlp-stdout-span-exporter/package.json` to decouple the ESM wrapper build process, ensuring it is optional and can be run separately.

### ESM Wrapper Enhancements

* **Improved Error Handling**: Enhanced `packages/node/otlp-stdout-span-exporter/scripts/build-esm-wrapper.js` to include multiple strategies for loading the CommonJS module and detailed error messages for failures. Added explicit handling for webpack compatibility issues.