### PR TITLE
release: node/otlp-stdout-span-exporter v0.17.3

### DIFF
--- a/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/node/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.3] - 2025-06-19
+
+### Fixed
+- Fixed missing ESM wrapper in published package by integrating build-esm-wrapper into main build process
+- This ensures the `/esm` subpath export actually works in the published npm package
+
 ## [0.17.2] - 2025-06-19
 
 ### Fixed

--- a/packages/node/otlp-stdout-span-exporter/README.md
+++ b/packages/node/otlp-stdout-span-exporter/README.md
@@ -76,6 +76,9 @@ const { OTLPStdoutSpanExporter } = require('@dev7a/otlp-stdout-span-exporter');
 
 This package provides experimental ESM support via a subpath export. Due to bundler compatibility issues, ESM is not available via the main export.
 
+>[!NOTE]
+>ESM support via the `/esm` subpath was broken in v0.17.2 but has been fixed in v0.17.3.
+
 To use ESM in native Node.js environments:
 
 ```javascript

--- a/packages/node/otlp-stdout-span-exporter/package.json
+++ b/packages/node/otlp-stdout-span-exporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/otlp-stdout-span-exporter",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "OpenTelemetry OTLP Span Exporter that writes to stdout",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "npm run clean && npm run generate:version && tsc -p tsconfig.json && echo 'Build completed successfully'",
+    "build": "npm run clean && npm run generate:version && tsc -p tsconfig.json && npm run build-esm-wrapper && echo 'Build completed successfully'",
     "clean": "rm -rf dist",
     "generate:version": "echo '// This file is auto-generated. Do not edit manually.\nexport const VERSION = \"'$(node -p \"require('./package.json').version\")'\";' > src/version.ts",
     "build-esm-wrapper": "node scripts/build-esm-wrapper.js",


### PR DESCRIPTION
This pull request addresses a critical issue with the ESM support in the `@dev7a/otlp-stdout-span-exporter` package. The changes ensure that the `/esm` subpath export works correctly in the published npm package by integrating the ESM wrapper into the main build process. Additionally, the documentation and versioning have been updated to reflect these fixes.

### Fixes to ESM support:

* [`packages/node/otlp-stdout-span-exporter/package.json`](diffhunk://#diff-de9bcc5499221be2efd6fb53ecc3d3967208154d47830f6f69e94693d1ffafbeL24-R24): Updated the `build` script to include `build-esm-wrapper`, ensuring the `/esm` subpath export functions correctly in the published package.
* [`packages/node/otlp-stdout-span-exporter/CHANGELOG.md`](diffhunk://#diff-98d7656b1775668a361eb259643823fb60356e4f05cc19ce00f0d804403e6012R8-R13): Added a changelog entry for version `0.17.3`, documenting the fix to the missing ESM wrapper.

### Documentation updates:

* [`packages/node/otlp-stdout-span-exporter/README.md`](diffhunk://#diff-d2345cbdfe13c980dc77f7ca9215ac6695f0dfa58951f16698e00bf324e0c752R79-R81): Added a note explaining the resolution of the broken ESM support in version `0.17.3`.

### Versioning update:

* [`packages/node/otlp-stdout-span-exporter/package.json`](diffhunk://#diff-de9bcc5499221be2efd6fb53ecc3d3967208154d47830f6f69e94693d1ffafbeL3-R3): Updated the package version from `0.17.2` to `0.17.3`.…published package