### PR TITLE
release: node/lambda-otel-lite v0.16.1

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2025-06-20
+
+### Fixed
+- **Critical**: Fixed timeout issue in Lambda Extensions API long-polling that caused extensions to fail with "HTTP request timeout" errors
+- Made HTTP timeout optional in `syncHttpRequest` function - long-polling requests (event polling) no longer have timeouts while admin operations (registration) retain 5-second timeouts
+- Improved error handling and documentation for different types of HTTP requests in the extension
+
 ## [0.16.0] - 2025-06-20
 
 ### Changed

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION

This pull request addresses a critical timeout issue in the Lambda Extensions API and introduces improvements to HTTP request handling. The changes ensure more robust behavior for long-polling and admin operations, enhance error handling, and update the package version to reflect these fixes.

### Fixes and Improvements to Timeout Handling:
* **Critical Fix**: Resolved timeout issue in Lambda Extensions API long-polling, preventing "HTTP request timeout" errors for extensions.
* Updated `syncHttpRequest` function to make HTTP timeout optional, allowing long-polling requests to proceed without timeouts while retaining a 5-second timeout for admin operations. [[1]](diffhunk://#diff-8f5fbf11d191e06c65ad7e26891eeb134e3b5998679d1695a54f8620b072148aR34-R45) [[2]](diffhunk://#diff-8f5fbf11d191e06c65ad7e26891eeb134e3b5998679d1695a54f8620b072148aL66-R78)
* Enhanced documentation and error handling for different types of HTTP requests, clarifying behavior for long-polling and admin operations. [[1]](diffhunk://#diff-8f5fbf11d191e06c65ad7e26891eeb134e3b5998679d1695a54f8620b072148aR94-R102) [[2]](diffhunk://#diff-8f5fbf11d191e06c65ad7e26891eeb134e3b5998679d1695a54f8620b072148aR167)

### Version Update:
* Incremented package version from `0.16.0` to `0.16.1` to reflect the critical fixes and improvements.