### PR TITLE
release: node/lambda-otel-lite v0.16.2

### DIFF
--- a/packages/node/lambda-otel-lite/CHANGELOG.md
+++ b/packages/node/lambda-otel-lite/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2025-06-20
+
+### Fixed
+- Fixed shutdown order issue in `LambdaSpanProcessor` where `isShutdown` flag was set before calling `forceFlush()`, causing buffered spans to be lost during shutdown
+- Spans are now properly flushed before the processor is marked as shutdown, ensuring no data loss during Lambda function termination
+
 ## [0.16.1] - 2025-06-20
 
 ### Fixed

--- a/packages/node/lambda-otel-lite/package.json
+++ b/packages/node/lambda-otel-lite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dev7a/lambda-otel-lite",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Lightweight OpenTelemetry instrumentation for AWS Lambda",
   "license": "MIT",
   "keywords": [

--- a/packages/node/lambda-otel-lite/src/internal/telemetry/processor.ts
+++ b/packages/node/lambda-otel-lite/src/internal/telemetry/processor.ts
@@ -241,8 +241,8 @@ export class LambdaSpanProcessor implements SpanProcessor {
    * @returns Promise that resolves when shutdown is complete
    */
   async shutdown(): Promise<void> {
-    this.isShutdown = true;
     await this.forceFlush();
+    this.isShutdown = true;
     await this.exporter.shutdown();
   }
 }


### PR DESCRIPTION
This pull request addresses a critical issue in the `LambdaSpanProcessor` related to the shutdown process, ensuring that spans are properly flushed before marking the processor as shutdown. It also updates the package version and corresponding tests to reflect this fix.

### Fixes to shutdown behavior in `LambdaSpanProcessor`:

* [`packages/node/lambda-otel-lite/src/internal/telemetry/processor.ts`](diffhunk://#diff-485c81f552d648e9494fc693b1832bc2034279aaf85daac21693d2c5cc164877L244-R245): Adjusted the shutdown order to call `forceFlush()` before setting the `isShutdown` flag, preventing data loss during Lambda function termination.
* [`packages/node/lambda-otel-lite/__tests__/test_processor.ts`](diffhunk://#diff-96baf5cd6e4355a9c5e628c8e16989aab85a1dcd445f3d86eeec55021ddf4adfL69-R77): Updated tests to verify that buffered spans are exported during shutdown and that subsequent shutdown calls are no-ops without duplicate exports. [[1]](diffhunk://#diff-96baf5cd6e4355a9c5e628c8e16989aab85a1dcd445f3d86eeec55021ddf4adfL69-R77) [[2]](diffhunk://#diff-96baf5cd6e4355a9c5e628c8e16989aab85a1dcd445f3d86eeec55021ddf4adfL103-R110)

### Documentation updates:

* [`packages/node/lambda-otel-lite/CHANGELOG.md`](diffhunk://#diff-639c39db47031fa119e62d0d1eb34488b39daf098c3a267200c598fd8989384dR8-R13): Added a changelog entry for version `0.16.2`, documenting the fix to the shutdown order issue in `LambdaSpanProcessor`.

### Version update:

* [`packages/node/lambda-otel-lite/package.json`](diffhunk://#diff-5816b4f7130d9fd72e716b0a8a8b5f10ae23ac4add56516d6afb81d7fe31e2d0L3-R3): Bumped the package version from `0.16.1` to `0.16.2` to reflect the new changes.