### PR TITLE
release: cli/startled v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,6 @@ dependencies = [
  "opentelemetry-aws",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest",
  "serde_json",
  "tokio",
  "tracing",
@@ -2415,7 +2414,7 @@ dependencies = [
  "opentelemetry-aws",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter",
+ "otlp-stdout-span-exporter 0.15.0",
  "pin-project",
  "rand 0.9.1",
  "reqwest",
@@ -2551,7 +2550,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "livetrace"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2571,8 +2570,9 @@ dependencies = [
  "indexmap 2.9.0",
  "indicatif",
  "opentelemetry-proto",
- "otlp-stdout-span-exporter",
+ "otlp-stdout-span-exporter 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -2704,6 +2704,18 @@ dependencies = [
  "rand_distr",
  "simba",
  "typenum",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2989,12 +3001,12 @@ dependencies = [
  "hex",
  "lambda-extension",
  "lambda-otel-lite",
- "nix",
+ "nix 0.30.1",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions 0.29.0",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter",
+ "otlp-stdout-span-exporter 0.15.0",
  "prost",
  "rand 0.9.1",
  "serde",
@@ -3022,7 +3034,7 @@ dependencies = [
  "opentelemetry_sdk",
  "otlp-sigv4-client 0.11.0",
  "otlp-stdout-logs-processor",
- "otlp-stdout-span-exporter",
+ "otlp-stdout-span-exporter 0.15.0",
  "prost",
  "reqwest",
  "serde_json",
@@ -3049,7 +3061,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "otlp-sigv4-client 0.11.0",
- "otlp-stdout-span-exporter",
+ "otlp-stdout-span-exporter 0.15.0",
  "prost",
  "regex",
  "reqwest",
@@ -3071,7 +3083,7 @@ dependencies = [
  "doc-comment",
  "flate2",
  "log",
- "nix",
+ "nix 0.30.1",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -3079,6 +3091,28 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tokio",
+]
+
+[[package]]
+name = "otlp-stdout-span-exporter"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e99400e5c5164f32408fb43dd15127951194aa29c3dd345984c807abf70cf23"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bon",
+ "doc-comment",
+ "flate2",
+ "log",
+ "nix 0.29.0",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -4186,19 +4220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.9.0",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4221,6 +4242,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "serverless-otlp-forwarder-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "aws_lambda_events",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "lambda-otel-lite",
+ "lambda_runtime",
+ "opentelemetry-proto",
+ "otlp-stdout-span-exporter 0.15.0",
+ "prost",
+ "reqwest",
+ "reqwest-middleware",
+ "reqwest-tracing",
+ "sealed_test",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tokio",
+ "tracing",
+ "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -4348,7 +4397,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "startled"
-version = "0.1.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4376,7 +4425,6 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "serde_yaml",
  "statrs",
  "tempfile",
  "tera",
@@ -5039,12 +5087,6 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2025-06-21
+
+### Added
+- `--title` option to `report` command for customizing the report landing page title
+- `--description` option to `report` command for adding descriptive text to the landing page
+
+### Changed
+- Removed duplicative items-grid section from landing page template in favor of cleaner sidebar navigation
+- Updated CLI usage examples to demonstrate new `--title` and `--description` options
+
 ## [0.3.3] - 2025-05-18
 
 ### Changed

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.3.3"
+version = "0.4.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/startled/README.md
+++ b/cli/startled/README.md
@@ -251,6 +251,8 @@ Generates HTML reports from previously collected JSON benchmark results.
 **Key Options:**
 -   `--input-dir <PATH>` (`-d <PATH>`): (Required) Directory containing the JSON benchmark result files. `startled` expects a structure like `<input_dir>/{group_name}/{subgroup_name}/*.json` (e.g., `/tmp/startled_results/my-app/prod/1024mb/*.json`).
 -   `--output-dir <PATH>` (`-o <PATH>`): (Required) Directory where the HTML report files will be generated. An `index.html` file and associated assets will be created in this directory. The generated reports will now include charts for new platform metrics and display Standard Deviation.
+-   `--title <TITLE>`: (Optional) Custom title for the report landing page. If not specified, defaults to "Benchmark Reports".
+-   `--description <DESCRIPTION>`: (Optional) Descriptive text to display below the title on the report landing page. Useful for providing context about the benchmark results.
 -   `--screenshot <THEME>`: (Optional) Generates PNG screenshots of the charts. `<THEME>` can be `Light` or `Dark`. This requires the `screenshots` compile-time feature and a properly configured headless Chrome environment.
 -   `--readme <MARKDOWN_FILE>`: (Optional) Specifies a markdown file whose content will be rendered as HTML and included on the landing page of the report. This allows for adding custom documentation, explanations, or findings to the benchmark report.
 -   `--template-dir <PATH>`: (Optional) Specifies a custom directory containing templates for report generation. This allows for complete customization of the report appearance and behavior. The directory should contain HTML templates (`index.html`, `chart.html`, `_sidebar.html`), CSS (`css/style.css`), and a single JavaScript file (`js/lib.js`) that handles all chart rendering functionality.
@@ -262,6 +264,8 @@ Generates HTML reports from previously collected JSON benchmark results.
 startled report \
     --input-dir /tmp/startled_results/my-application-services \
     --output-dir /var/www/benchmarks/my-application-services \
+    --title "Lambda Performance Analysis" \
+    --description "Comprehensive comparison of different OpenTelemetry configurations across Node.js, Python, and Rust runtimes" \
     --screenshot dark \
     --readme benchmark-notes.md \
     --template-dir /path/to/custom-templates \

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,8 +1,32 @@
-# Release Notes - startled v0.3.3
+# Release Notes - startled v0.4.0
 
-**Release Date:** 2025-05-13
+**Release Date:** 2025-06-21
 
-This release includes the following changes:
-- Updated the README.md for better clarity.
-- Bumped the version to 0.3.3.
-- Removed the `serde_yaml` and `reqwest` dependencies to streamline the project.
+This release enhances the `report` command with new customization options and improves the landing page UI.
+
+## New Features
+
+### Enhanced Report Customization
+- **`--title` option**: Customize the title of your benchmark report landing page
+- **`--description` option**: Add descriptive text to provide context about your benchmark results
+
+## Improvements
+
+### User Interface
+- **Cleaner Landing Page**: Removed the duplicative items-grid section from the report landing page in favor of the existing sidebar navigation, resulting in a cleaner and less cluttered interface
+
+### Documentation
+- **Updated Examples**: CLI usage examples now demonstrate the new `--title` and `--description` options
+
+## Example Usage
+
+```bash
+startled report \
+  --input-dir ./benchmark_results \
+  --output-dir ./reports \
+  --title "Lambda Performance Analysis" \
+  --description "Comprehensive comparison of different OpenTelemetry configurations across Node.js, Python, and Rust runtimes" \
+  --screenshot dark
+```
+
+This release maintains full backward compatibility with existing workflows while providing new options for creating more professional and informative benchmark reports.

--- a/cli/startled/src/main.rs
+++ b/cli/startled/src/main.rs
@@ -32,7 +32,8 @@ EXAMPLES:
     startled function my-lambda-function --memory 512 --payload-file ./payload.json
 
     # Generate HTML reports from benchmark results in a directory
-    startled report -d ./benchmark_results -o ./reports --screenshot light
+    startled report -d ./benchmark_results -o ./reports --screenshot light \\
+        --title \"Performance Analysis\" --description \"Comparison of OTEL configurations\"
 
     # Generate shell completions for bash
     startled generate-completions bash";
@@ -147,6 +148,14 @@ enum Commands {
         /// Output directory for report files
         #[arg(short = 'o', long = "output", required = true)]
         output_dir: String,
+
+        /// Title for the report landing page
+        #[arg(long = "title")]
+        title: Option<String>,
+
+        /// Description text to display on the landing page
+        #[arg(long = "description")]
+        description: Option<String>,
 
         /// Generate screenshots with specified theme
         #[arg(long, value_name = "THEME")]
@@ -317,6 +326,8 @@ async fn run() -> Result<()> {
         Commands::Report {
             input_dir,
             output_dir,
+            title,
+            description,
             screenshot,
             template_dir,
             readme_file,
@@ -330,7 +341,8 @@ async fn run() -> Result<()> {
             generate_reports(
                 &input_dir,
                 &output_dir,
-                None,
+                title.as_deref(),
+                description.as_deref(),
                 base_url.as_deref(),
                 screenshot_theme,
                 template_dir,

--- a/cli/startled/src/report.rs
+++ b/cli/startled/src/report.rs
@@ -300,6 +300,7 @@ async fn generate_landing_page(
     output_directory: &str,
     report_structure: &ReportStructure,
     custom_title: Option<&str>,
+    description: Option<&str>,
     pb: &ProgressBar,
     template_dir: Option<&String>,
     readme_file: Option<&str>,
@@ -343,6 +344,9 @@ async fn generate_landing_page(
 
     let mut ctx = TeraContext::new();
     ctx.insert("title", custom_title.unwrap_or("Benchmark Reports"));
+    if let Some(desc) = description {
+        ctx.insert("description", desc);
+    }
     // Landing page specific context
     ctx.insert("is_landing_page", &true);
     // Add link_suffix for local browsing
@@ -434,6 +438,7 @@ pub async fn generate_reports(
     input_directory: &str,
     output_directory: &str,
     custom_title: Option<&str>,
+    description: Option<&str>,
     base_url: Option<&str>,
     screenshot_theme: Option<&str>,
     template_dir: Option<String>,
@@ -528,6 +533,7 @@ pub async fn generate_reports(
         output_directory,
         &report_structure,
         custom_title,
+        description,
         &landing_pb,
         template_dir.as_ref(),
         readme_file.as_deref(),

--- a/cli/startled/src/templates/index.html
+++ b/cli/startled/src/templates/index.html
@@ -33,20 +33,6 @@
                  {% if description %}
                  <p class="description">{{ description }}</p>
                  {% endif %}
-                
-                <div class="items-grid">
-                    {% for group_name, subgroups in report_structure %}
-                        <div class="item-card">
-                             <h2 class="item-title">{{ group_name }}</h2>
-                             <ul class="landing-subgroup-list"> {# Simple list for subgroups #}
-                                 {% for subgroup_name in subgroups %}
-                                     {% set link_path = base_path ~ group_name ~ "/" ~ subgroup_name ~ "/cold-start-init/" ~ link_suffix %}
-                                     <li><a href="{{ link_path | safe }}" class="subgroup-link">{{ subgroup_name | replace(from="mb", to=" MB") }}</a></li>
-                                 {% endfor %}
-                             </ul>
-                        </div>
-                     {% endfor %}
-                 </div>
                  {% if has_readme %}
                  <div class="readme-content">
                     {{ readme_html | safe }}


### PR DESCRIPTION
This pull request introduces version `0.4.0` of the `startled` CLI tool, focusing on enhancing the `report` command with new customization options and improving the landing page UI. The changes include updates to the command-line interface, internal functionality, and documentation to support these new features.

### New Features and Enhancements:

**CLI Customization Options:**
- Added `--title` option to set a custom title for the report landing page. [[1]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886R152-R159) [[2]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886R329-R330) [[3]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550R303) [[4]](diffhunk://#diff-aff33bf4e337463eb1a6180a9b58b944752069b10f5ca6a932555ac84afe0573R254-R255)
- Added `--description` option to include descriptive text below the title for additional context. [[1]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886R152-R159) [[2]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886R329-R330) [[3]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550R303) [[4]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550R347-R349)

**Landing Page Improvements:**
- Removed the duplicative items-grid section from the landing page template, resulting in a cleaner interface with sidebar navigation.

### Documentation Updates:

**Usage Examples:**
- Updated examples in `README.md` and `main.rs` to demonstrate the new `--title` and `--description` options. [[1]](diffhunk://#diff-aff33bf4e337463eb1a6180a9b58b944752069b10f5ca6a932555ac84afe0573R267-R268) [[2]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886L35-R36)

**Release Notes:**
- Added detailed release notes for version `0.4.0`, highlighting new features and improvements.

### Version Update:
- Bumped version from `0.3.3` to `0.4.0` in `Cargo.toml`.