### PR TITLE
release: cli/startled v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4397,7 +4397,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "startled"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-06-21
+
+### Fixed
+- Fixed JavaScript file embedding issue that caused "Failed to copy default lib.js" error when using distributed binaries from GitHub releases. The JS file is now properly embedded at compile time using `include_str!()` instead of relying on `CARGO_MANIFEST_DIR`.
+
 ## [0.4.0] - 2025-06-21
 
 ### Added

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,32 +1,23 @@
-# Release Notes - startled v0.4.0
+# Release Notes - startled v0.4.1
 
 **Release Date:** 2025-06-21
 
-This release enhances the `report` command with new customization options and improves the landing page UI.
+This is a **critical bug fix release** that resolves an issue preventing distributed binaries from functioning properly.
 
-## New Features
+## Bug Fix
 
-### Enhanced Report Customization
-- **`--title` option**: Customize the title of your benchmark report landing page
-- **`--description` option**: Add descriptive text to provide context about your benchmark results
+### JavaScript File Embedding Issue
+- **Fixed**: Resolved "Failed to copy default lib.js" error that occurred when using startled binaries downloaded from GitHub releases
+- **Root Cause**: The JavaScript file copying logic was using `env!("CARGO_MANIFEST_DIR")` which only exists during compilation, not in distributed binaries
+- **Solution**: Changed to use `include_str!()` to properly embed the JavaScript file at compile time, consistent with how CSS files are handled
 
-## Improvements
+## Impact
 
-### User Interface
-- **Cleaner Landing Page**: Removed the duplicative items-grid section from the report landing page in favor of the existing sidebar navigation, resulting in a cleaner and less cluttered interface
+This fix ensures that the `report` command works correctly in all deployment scenarios:
+- ✅ **Development**: Works when building from source
+- ✅ **CI/CD**: Works when downloaded from GitHub releases
+- ✅ **Distribution**: Works for all binary distribution methods
 
-### Documentation
-- **Updated Examples**: CLI usage examples now demonstrate the new `--title` and `--description` options
+## Migration
 
-## Example Usage
-
-```bash
-startled report \
-  --input-dir ./benchmark_results \
-  --output-dir ./reports \
-  --title "Lambda Performance Analysis" \
-  --description "Comprehensive comparison of different OpenTelemetry configurations across Node.js, Python, and Rust runtimes" \
-  --screenshot dark
-```
-
-This release maintains full backward compatibility with existing workflows while providing new options for creating more professional and informative benchmark reports.
+No action required - this is a drop-in replacement for v0.4.0. All existing functionality remains unchanged.

--- a/cli/startled/src/report.rs
+++ b/cli/startled/src/report.rs
@@ -595,8 +595,8 @@ pub async fn generate_reports(
 
         println!("✓ lib.js copied (contains all chart generation code).");
     } else {
-        let js_lib_src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/templates/js/lib.js");
-        fs::copy(&js_lib_src, &js_lib_dst).context("Failed to copy default lib.js")?;
+        let js_lib_content = include_str!("templates/js/lib.js");
+        fs::write(&js_lib_dst, js_lib_content).context("Failed to write default lib.js")?;
         println!("✓ Default lib.js copied (contains all chart generation code).");
     }
     // -------------------------


### PR DESCRIPTION
Fix: JavaScript file embedding issue for distributed binaries

- Fixed 'Failed to copy default lib.js' error in GitHub releases
- Changed from env!(CARGO_MANIFEST_DIR) to include_str!() for JS embedding
- Ensures report command works in all deployment scenarios