### PR TITLE
release: cli/startled v0.5.1

### DIFF
--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-06-21
+
+### Added
+- `--suffix` option to `report` command for customizing the file extension of generated reports (default: html)
+  - Enables generating reports in different formats (Markdown, plain text, etc.) when combined with custom templates
+  - Applies to both landing pages and individual chart pages
+  - Fully backward compatible - defaults to `.html` for existing users
+
+### Changed
+- Updated README.md examples to demonstrate generating reports with different file formats
+
 ## [0.5.0] - 2025-06-21
 
 ### Added

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/startled/README.md
+++ b/cli/startled/README.md
@@ -251,9 +251,10 @@ Generates HTML reports from previously collected JSON benchmark results.
 
 **Key Options:**
 -   `--input-dir <PATH>` (`-d <PATH>`): (Required) Directory containing the JSON benchmark result files. `startled` expects a structure like `<input_dir>/{group_name}/{subgroup_name}/*.json` (e.g., `/tmp/startled_results/my-app/prod/1024mb/*.json`).
--   `--output-dir <PATH>` (`-o <PATH>`): (Required) Directory where the HTML report files will be generated. An `index.html` file and associated assets will be created in this directory. The generated reports will now include charts for new platform metrics and display Standard Deviation.
+-   `--output-dir <PATH>` (`-o <PATH>`): (Required) Directory where the report files will be generated. An `index.{suffix}` file and associated assets will be created in this directory. The generated reports will now include charts for new platform metrics and display Standard Deviation.
 -   `--title <TITLE>`: (Optional) Custom title for the report landing page. If not specified, defaults to "Benchmark Reports".
 -   `--description <DESCRIPTION>`: (Optional) Descriptive text to display below the title on the report landing page. Useful for providing context about the benchmark results.
+-   `--suffix <SUFFIX>`: (Optional) File extension for generated files (default: html). When using custom templates, this allows generating Markdown (.md), plain text (.txt), or any other file format.
 -   `--screenshot <THEME>`: (Optional) Generates PNG screenshots of the charts. `<THEME>` can be `Light` or `Dark`. This requires the `screenshots` compile-time feature and a properly configured headless Chrome environment.
 -   `--readme <MARKDOWN_FILE>`: (Optional) Specifies a markdown file whose content will be rendered as HTML and included on the landing page of the report. This allows for adding custom documentation, explanations, or findings to the benchmark report.
 -   `--template-dir <PATH>`: (Optional) Specifies a custom directory containing templates for report generation. This allows for complete customization of the report appearance and behavior. The directory should contain HTML templates (`index.html`, `chart.html`, `_sidebar.html`), CSS (`css/style.css`), and a single JavaScript file (`js/lib.js`) that handles all chart rendering functionality.
@@ -262,6 +263,7 @@ Generates HTML reports from previously collected JSON benchmark results.
 
 **Example:**
 ```bash
+# Generate standard HTML reports
 startled report \
     --input-dir /tmp/startled_results/my-application-services \
     --output-dir /var/www/benchmarks/my-application-services \
@@ -272,8 +274,16 @@ startled report \
     --template-dir /path/to/custom-templates \
     --base-url "/benchmarks/my-application-services" \
     --local-browsing
+
+# Generate Markdown reports with custom templates
+startled report \
+    --input-dir /tmp/startled_results/my-application-services \
+    --output-dir /tmp/markdown-reports \
+    --title "Lambda Performance Analysis" \
+    --suffix md \
+    --template-dir /path/to/markdown-templates
 ```
-The main HTML report will be accessible at `/var/www/benchmarks/my-application-services/index.html` and can be hosted at `http://example.com/benchmarks/my-application-services/`.
+The main HTML report will be accessible at `/var/www/benchmarks/my-application-services/index.html` and can be hosted at `http://example.com/benchmarks/my-application-services/`. The Markdown example would generate `index.md` files instead.
 
 ## How It Works
 

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,3 +1,49 @@
+# Release Notes for startled v0.5.1
+
+## 🎯 New Features
+
+### Custom File Extensions for Reports
+
+The `report` command now supports a `--suffix` option that allows you to generate reports with custom file extensions. This enhancement enables generating reports in different formats when combined with custom templates:
+
+- **Default behavior unchanged**: Reports continue to generate as `.html` files by default
+- **Flexible output formats**: Generate `.md`, `.txt`, `.json`, or any other format
+- **Template integration**: Works seamlessly with the existing `--template-dir` feature
+
+### Usage Examples
+
+```bash
+# Generate standard HTML reports (default)
+startled report -d input/ -o output/
+
+# Generate Markdown reports with custom templates
+startled report -d input/ -o output/ --suffix md --template-dir ./markdown-templates
+
+# Generate plain text reports
+startled report -d input/ -o output/ --suffix txt --template-dir ./text-templates
+```
+
+This feature is particularly useful for:
+- Generating Markdown documentation from benchmark results
+- Creating plain text reports for CLI tools
+- Producing custom formats for integration with other systems
+
+## 📦 Installation
+
+```bash
+cargo install startled --version 0.5.1
+```
+
+## 📝 What's Changed
+
+- Added `--suffix` CLI option to the `report` command
+- Updated file generation logic to use `index.{suffix}` instead of hardcoded `index.html`
+- Enhanced documentation with examples of generating different file formats
+
+## 🙏 Acknowledgments
+
+Thank you to all contributors and users who provide feedback to make startled better!
+
 # Release Notes - startled v0.5.0
 
 **Release Date:** 2025-06-21

--- a/cli/startled/src/report.rs
+++ b/cli/startled/src/report.rs
@@ -92,6 +92,7 @@ async fn generate_chart(
     name: &str,
     chart_render_data: &ChartRenderData,
     config: &BenchmarkConfig,
+    suffix: &str,
     screenshot_theme: Option<&str>,
     pb: &ProgressBar,
     report_structure: &ReportStructure,
@@ -182,8 +183,8 @@ async fn generate_chart(
         if local_browsing { "index.html" } else { "" },
     );
 
-    // Render the index.html file inside the chart directory
-    let html_path = chart_dir.join("index.html");
+    // Render the index file inside the chart directory
+    let html_path = chart_dir.join(format!("index.{}", suffix));
     pb.set_message(format!("Rendering {}...", html_path.display()));
     let html = tera_html.render("chart.html", &ctx)?;
     fs::write(&html_path, html)?;
@@ -297,13 +298,14 @@ fn scan_report_structure(base_input_dir: &str) -> Result<ReportStructure> {
     Ok(structure)
 }
 
-/// Generates the main landing page (index.html) for the reports.
+/// Generates the main landing page for the reports.
 #[allow(clippy::too_many_arguments)]
 async fn generate_landing_page(
     output_directory: &str,
     report_structure: &ReportStructure,
     custom_title: Option<&str>,
     description: Option<&str>,
+    suffix: &str,
     pb: &ProgressBar,
     template_dir: Option<&String>,
     readme_file: Option<&str>,
@@ -429,7 +431,7 @@ async fn generate_landing_page(
     }
     ctx.insert("items", &items);
 
-    let index_path = Path::new(output_directory).join("index.html");
+    let index_path = Path::new(output_directory).join(format!("index.{}", suffix));
     pb.set_message(format!("Generating landing page: {}", index_path.display()));
     let html = tera.render("index.html", &ctx)?;
     fs::write(&index_path, html)?;
@@ -442,6 +444,7 @@ pub async fn generate_reports(
     output_directory: &str,
     custom_title: Option<&str>,
     description: Option<&str>,
+    suffix: &str,
     base_url: Option<&str>,
     screenshot_theme: Option<&str>,
     template_dir: Option<String>,
@@ -507,6 +510,7 @@ pub async fn generate_reports(
                 current_input_dir.to_str().unwrap(),
                 current_output_dir.to_str().unwrap(),
                 custom_title,
+                suffix,
                 screenshot_theme,
                 &main_pb,
                 &report_structure, // Pass full structure for sidebar
@@ -537,6 +541,7 @@ pub async fn generate_reports(
         &report_structure,
         custom_title,
         description,
+        suffix,
         &landing_pb,
         template_dir.as_ref(),
         readme_file.as_deref(),
@@ -619,6 +624,7 @@ pub async fn generate_reports_for_directory(
     input_directory: &str,
     output_directory: &str,
     custom_title: Option<&str>,
+    suffix: &str,
     screenshot_theme: Option<&str>,
     pb: &ProgressBar,
     report_structure: &ReportStructure,
@@ -817,6 +823,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_init",
             &cold_init_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -844,6 +851,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_server",
             &cold_server_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -877,6 +885,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_extension_overhead",
             &cold_ext_overhead_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -910,6 +919,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_total_duration",
             &cold_total_duration_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -944,6 +954,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_response_latency",
             &cold_resp_latency_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -977,6 +988,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_response_duration",
             &cold_resp_duration_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1010,6 +1022,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_runtime_overhead",
             &cold_runtime_overhead_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1043,6 +1056,7 @@ pub async fn generate_reports_for_directory(
             "cold_start_runtime_done_duration",
             &cold_runtime_done_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1080,6 +1094,7 @@ pub async fn generate_reports_for_directory(
             "client_duration",
             &client_duration_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1110,6 +1125,7 @@ pub async fn generate_reports_for_directory(
             "server_duration",
             &server_duration_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1150,6 +1166,7 @@ pub async fn generate_reports_for_directory(
             "extension_overhead",
             &ext_overhead_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1183,6 +1200,7 @@ pub async fn generate_reports_for_directory(
             "memory_usage",
             &memory_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1217,6 +1235,7 @@ pub async fn generate_reports_for_directory(
             "warm_start_response_latency",
             &warm_resp_latency_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1250,6 +1269,7 @@ pub async fn generate_reports_for_directory(
             "warm_start_response_duration",
             &warm_resp_duration_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1283,6 +1303,7 @@ pub async fn generate_reports_for_directory(
             "warm_start_runtime_overhead",
             &warm_runtime_overhead_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1316,6 +1337,7 @@ pub async fn generate_reports_for_directory(
             "warm_start_runtime_done_duration",
             &warm_runtime_done_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,
@@ -1349,6 +1371,7 @@ pub async fn generate_reports_for_directory(
             "produced_bytes",
             &produced_bytes_combined,
             &results[0].config,
+            suffix,
             screenshot_theme,
             pb,
             report_structure,


### PR DESCRIPTION
This pull request introduces a new feature to the `startled` CLI tool, allowing users to specify custom file extensions for generated reports using the `--suffix` option. This enhancement improves flexibility in report generation and integrates seamlessly with custom templates. Additionally, telemetry initialization has been refined to optimize performance by limiting it to commands requiring AWS access.

### New Feature: Custom File Extensions for Reports
* Added `--suffix` option to the `report` command, enabling users to customize the file extension for generated reports (default: `.html`). This supports formats like `.md`, `.txt`, and `.json when used with custom templates. (`cli/startled/src/main.rs` - [[1]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886R160-R163) [[2]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886R339) [[3]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550L185-R187) [[4]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550L432-R434) [[5]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550R544)
* Updated logic to dynamically generate `index.{suffix}` files instead of hardcoded `index.html` files. (`cli/startled/src/report.rs` - [[1]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550L185-R187) [[2]](diffhunk://#diff-cf5a77c542971afe74e9afa350d67cb8676c3402f54374bad52106535c17f550L432-R434)
* Enhanced documentation in `README.md` and `RELEASE_NOTES.md` with examples showcasing the new functionality. (`cli/startled/README.md` - [[1]](diffhunk://#diff-aff33bf4e337463eb1a6180a9b58b944752069b10f5ca6a932555ac84afe0573L254-R257) [[2]](diffhunk://#diff-aff33bf4e337463eb1a6180a9b58b944752069b10f5ca6a932555ac84afe0573R277-R286); `cli/startled/RELEASE_NOTES.md` - [[3]](diffhunk://#diff-355350d3a7fa2003a39ec9494c944acb48edffadf500b4cd0b27e322927cf8eaR1-R46)

### Telemetry Optimization
* Modified telemetry initialization to only activate for commands that require AWS access (`Function` and `Stack` commands), skipping it for `Report` and `GenerateCompletions`. (`cli/startled/src/main.rs` - [[1]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886L220-R228) [[2]](diffhunk://#diff-5fb52f72c3daaba5adfbdfaddaf0e2bc6b28ebbb5e4d9e8a4082eaf66b5d8886L360-R376)

### Documentation Updates
* Updated `CHANGELOG.md` to reflect the addition of the `--suffix` option and its backward compatibility. (`cli/startled/CHANGELOG.md` - [cli/startled/CHANGELOG.mdR8-R18](diffhunk://#diff-bd0cb949bb67fcfa38060059b5016cdb217ed459714094210b87496f0714b453R8-R18))
* Bumped the version in `Cargo.toml` from `0.5.0` to `0.5.1` to reflect the new release. (`cli/startled/Cargo.toml` - [cli/startled/Cargo.tomlL3-R3](diffhunk://#diff-112c3857fa8d5706869ef8ba5fdaee05097cf93d95f849ab39a4c1457fafa30bL3-R3))