### PR TITLE
release: rust/serverless-otlp-forwarder-core v0.1.0

### DIFF
--- a/.github/workflows/publish-rust-serverless-otlp-forwarder-core.yml
+++ b/.github/workflows/publish-rust-serverless-otlp-forwarder-core.yml
@@ -1,0 +1,111 @@
+name: Publish Rust Serverless OTLP Forwarder Core
+
+on:
+  # Trigger on PRs that touch the Rust package
+  pull_request:
+    paths:
+      - 'packages/rust/serverless-otlp-forwarder-core/**'
+    types: [opened, synchronize, labeled]
+  # Trigger on merges to main that touch the Rust package
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/rust/serverless-otlp-forwarder-core/**'
+
+# Add permissions needed for the workflow
+permissions:
+  contents: write  # Needed for pushing tags
+  id-token: write  # Needed for publishing to crates.io
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        include:
+          # x64 runner
+          - os: ubuntu-24.04
+            arch: x64
+            rust-version: stable
+          # arm64 runner
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            rust-version: stable
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: packages/rust/serverless-otlp-forwarder-core
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'approved')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust-version }}
+          components: rustfmt, clippy
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+
+      - name: Run quality checks
+        run: |
+          cargo fmt --check
+          cargo clippy -- -D warnings
+          cargo test
+          cargo build --release
+
+  publish:
+    needs: test
+    # Only run on pushes to main, never on PRs
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: crates-publish
+      url: https://crates.io/crates/serverless-otlp-forwarder-core
+    defaults:
+      run:
+        working-directory: packages/rust/serverless-otlp-forwarder-core
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Set up Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/rust/serverless-otlp-forwarder-core
+
+      - name: Build package
+        run: cargo build --release
+
+      - name: Verify package version
+        id: version_check
+        run: |
+          PACKAGE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "serverless-otlp-forwarder-core") | .version')
+          TAG_NAME="packages/rust/serverless-otlp-forwarder-core-v$PACKAGE_VERSION"
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          
+          if git tag -l | grep -q "$TAG_NAME"; then
+            echo "Version $PACKAGE_VERSION already published"
+            exit 1
+          fi
+          echo "Publishing version $PACKAGE_VERSION with tag $TAG_NAME"
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish
+
+      - name: Create and push tag
+        run: |
+          git tag "${{ steps.version_check.outputs.tag_name }}"
+          git push origin "${{ steps.version_check.outputs.tag_name }}" 

--- a/packages/rust/serverless-otlp-forwarder-core/CHANGELOG.md
+++ b/packages/rust/serverless-otlp-forwarder-core/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-01-26
+
+### Added
+- Initial release of the serverless-otlp-forwarder-core crate
+- Core `TelemetryData` struct for standardized telemetry representation
+- `EventParser` trait for pluggable event parsing from different AWS sources
+- Span compaction functionality to merge multiple OTLP messages into single batches
+- HTTP sender with configurable OTLP export (supports standard OpenTelemetry environment variables)
+- Generic `process_event_batch` orchestrator function
+- Zero-boilerplate HTTP client implementations (simple, with timeout, instrumented)
+- Optional instrumented client with request tracing and middleware support
+- Support for standard OTLP environment variables (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, etc.)
+- Configurable compression with environment variable support (`OTEL_EXPORTER_OTLP_COMPRESSION`, `OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL`)
+- Comprehensive test suite with 83+ tests
+- Complete API documentation with usage examples
+- Support for both JSON and protobuf payload conversion
+- Built-in gzip compression and decompression utilities 

--- a/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
+++ b/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 rust-version.workspace = true
 description = "Core library for Serverless OTLP Forwarders on AWS Lambda"
 repository = "https://github.com/dev7a/serverless-otlp-forwarder/packages/rust/serverless-otlp-forwarder-core"
+homepage = "https://github.com/dev7a/serverless-otlp-forwarder"
 readme = "README.md"
 documentation = "https://docs.rs/serverless-otlp-forwarder-core"
 keywords = ["aws", "lambda", "opentelemetry", "tracing", "telemetry"]

--- a/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
+++ b/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "serverless-otlp-forwarder-core"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Core library for Serverless OTLP Forwarders on AWS Lambda"
+repository = "https://github.com/dev7a/serverless-otlp-forwarder/packages/rust/serverless-otlp-forwarder-core"
+readme = "README.md"
+documentation = "https://docs.rs/serverless-otlp-forwarder-core"
+keywords = ["aws", "lambda", "opentelemetry", "tracing", "telemetry"]
+categories = ["network-programming", "web-programming", "development-tools::debugging"]
+
+[dependencies]
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+reqwest = { workspace = true, features = ["json", "blocking"] }
+tracing = { workspace = true }
+url = { workspace = true }
+
+# OTLP and Protobuf related
+opentelemetry-proto = { workspace = true, features = ["trace"] }
+prost = { workspace = true }
+
+# Encoding/Decoding/Compression
+base64 = { workspace = true }
+flate2 = { workspace = true }
+bytes = "1.0"
+
+# OTLP Exporter needs to be pinned to 0.16.0 for publishing to crates.io
+otlp-stdout-span-exporter = { version = "0.16.0" }
+
+async-trait = "0.1"
+
+# Optional dependencies for instrumented client
+reqwest-middleware = { workspace = true, optional = true }
+reqwest-tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+wiremock = { workspace = true }
+sealed_test = { workspace = true }
+serial_test = { workspace = true }
+
+# for doctests
+aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }
+lambda-otel-lite = { workspace = true }
+lambda_runtime = { workspace = true }
+
+[features]
+default = []
+instrumented-client = ["reqwest-middleware", "reqwest-tracing"]

--- a/packages/rust/serverless-otlp-forwarder-core/PUBLISHING.md
+++ b/packages/rust/serverless-otlp-forwarder-core/PUBLISHING.md
@@ -1,0 +1,107 @@
+# Publishing Checklist
+
+Before publishing a new version of `serverless-otlp-forwarder-core`, ensure all these items are checked:
+
+## Cargo.toml Verification
+- [ ] `version` is correctly incremented (following semver)
+- [ ] `name` is correct
+- [ ] `description` is clear and up-to-date
+- [ ] `license` is specified
+- [ ] `keywords` are defined and relevant
+- [ ] `categories` are appropriate
+- [ ] `repository` information is complete and correct
+- [ ] `homepage` URL is valid
+- [ ] `documentation` URL is specified
+- [ ] Dependencies are up-to-date and correct (currently using OpenTelemetry 0.30.0)
+- [ ] No extraneous dependencies
+- [ ] Development dependencies are in `[dev-dependencies]`
+- [ ] Feature flags are correctly defined (`instrumented-client`)
+- [ ] Minimum supported Rust version (MSRV) is specified if needed
+
+## Documentation
+- [ ] `README.md` is up-to-date
+- [ ] Version number in documentation matches Cargo.toml
+- [ ] All examples in documentation work
+- [ ] API documentation is complete (all public items have doc comments)
+- [ ] Breaking changes are clearly documented
+- [ ] `CHANGELOG.md` is updated
+- [ ] Feature flags are documented
+- [ ] All public APIs have usage examples
+- [ ] All environment variables are documented (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXPORTER_OTLP_COMPRESSION`, `OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL`)
+
+## Code Quality
+- [ ] All tests pass (`cargo test`)
+- [ ] Code is properly formatted (`cargo fmt`)
+- [ ] Format check passes (`cargo fmt --check`)
+- [ ] Linting passes (`cargo clippy -- -D warnings`)
+- [ ] No debug code or println! macros (except in logging)
+- [ ] Test coverage is satisfactory (83+ tests currently)
+- [ ] All public APIs have proper documentation
+- [ ] No unsafe code (or if present, properly documented and justified)
+- [ ] All compiler warnings are addressed
+- [ ] Documentation tests (`cargo test --doc`) pass
+
+## Git Checks
+- [ ] Working on the correct branch
+- [ ] All changes are committed
+- [ ] No unnecessary files in git
+- [ ] Git tags are ready to be created
+- [ ] `.gitignore` is up-to-date
+
+## Version Management
+- [ ] Update version in `Cargo.toml` only (or in workspace Cargo.toml if using workspace version)
+- [ ] This is the single source of truth for the version
+
+## Publishing Steps
+1. Update version in `Cargo.toml`
+2. Update `CHANGELOG.md`
+3. Run quality checks:
+   ```bash
+   cargo fmt
+   cargo fmt --check
+   cargo clippy -- -D warnings
+   cargo test
+   cargo test --doc
+   ```
+4. Build in release mode:
+   ```bash
+   cargo build --release
+   cargo doc --no-deps
+   cargo package # Verify package contents
+   ```
+5. Create a branch for the release following the pattern `release/rust/<package-name>-v<version>`
+6. Commit changes to the release branch and push to GitHub, with a commit message of `release: rust/serverless-otlp-forwarder-core v<version>`
+7. Create a Pull Request to merge your changes to the main branch
+8. Once the PR is approved and merged, tagging and publishing is done automatically by the CI pipeline
+
+## Post-Publishing
+- [ ] Verify package installation works: `cargo add serverless-otlp-forwarder-core`
+- [ ] Verify documentation appears correctly on docs.rs
+- [ ] Test the package in a new project
+- [ ] Update any dependent crates
+- [ ] Verify examples compile and run correctly
+
+## Common Issues to Check
+- Missing files in the published package
+- Incorrect feature flags
+- Missing or incorrect documentation
+- Broken links in documentation
+- Incorrect version numbers
+- Missing changelog entries
+- Unintended breaking changes
+- Incomplete crate metadata
+- Platform-specific issues
+- MSRV compatibility issues
+
+## Notes
+- Test the package with different feature combinations (default, instrumented-client)
+- Consider cross-platform compatibility
+- Test with the minimum supported Rust version
+- Consider running `cargo audit` for security vulnerabilities
+- Use `cargo clippy` with all relevant feature combinations
+- Remember to update any related documentation or examples in the main repository
+- Consider testing on different architectures (x86_64, aarch64)
+- Ensure HTTP client implementations work correctly across different configurations
+- Verify span compaction functionality works with various OTLP payloads
+- Test environment variable precedence and configuration resolution
+- Verify instrumented client feature works with middleware stacks 

--- a/packages/rust/serverless-otlp-forwarder-core/README.md
+++ b/packages/rust/serverless-otlp-forwarder-core/README.md
@@ -1,0 +1,381 @@
+# Serverless OTLP Forwarder Core
+
+[![Crates.io](https://img.shields.io/crates/v/serverless-otlp-forwarder-core.svg)](https://crates.io/crates/serverless-otlp-forwarder-core)
+
+The `serverless-otlp-forwarder-core` crate provides essential, shared components for building AWS Lambda functions that process and forward OpenTelemetry (OTLP) data. It is a core part of the [Serverless OTLP Forwarder project](https://github.com/dev7a/serverless-otlp-forwarder).
+
+This crate is designed to be used by specific Lambda processor implementations, offering a standardized way to parse, compact, and send OTLP telemetry batches.
+
+## Table of Contents
+
+- [Features](#features)
+- [Core Components](#core-components)
+    - [`TelemetryData`](#telemetrydata)
+    - [`EventParser` Trait](#eventparser-trait)
+    - [Span Compaction](#span-compaction)
+    - [HTTP Sender](#http-sender)
+    - [HTTP Client Options](#http-client-options)
+    - [`process_event_batch` Orchestrator](#process_event_batch-orchestrator)
+- [Installation](#installation)
+- [Usage Example](#usage-example)
+- [Environment Variables](#environment-variables)
+- [License](#license)
+
+## Features
+
+- **Standardized Telemetry Handling**: Defines a common `TelemetryData` struct for internal OTLP representation.
+- **Pluggable Event Parsing**: Uses an `EventParser` trait to allow different Lambda processors for different event sources to implement their specific event decoding logic.
+- **Efficient Batching**: Includes a `span_compactor` module to merge multiple OTLP messages into a single batch.
+- **Configurable OTLP Export**: Provides an HTTP sender that respects standard OpenTelemetry environment variables for endpoint and header configuration (e.g., `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`).
+- **Simplified Processor Logic**: Offers a generic `process_event_batch` function to orchestrate the parse-compact-send workflow.
+- **Zero-Boilerplate HTTP Clients**: Built-in HTTP client implementations eliminate the need for custom trait implementations in your Lambda functions.
+- **Optional Instrumentation**: Feature-gated support for request tracing and middleware integration.
+
+## Core Components
+
+### `TelemetryData`
+
+(Located in `src/telemetry.rs`)
+
+The central struct representing a unit of telemetry data. It normalizes incoming data into an OTLP protobuf format (uncompressed initially) and includes methods for final compression (Gzip). Its fields include `source`, `endpoint` (primarily for context, as the actual target is resolved from env vars), `payload`, `content_type`, and `content_encoding`.
+
+### `EventParser` Trait
+
+(Located in `src/core_parser.rs`)
+
+A trait that specific Lambda processors must implement to convert their incoming AWS event payloads into a `Vec<TelemetryData>`.
+
+```rust,no_run
+use anyhow;
+use serverless_otlp_forwarder_core::TelemetryData;
+
+pub trait EventParser {
+    type EventInput; // The specific AWS event type
+    fn parse(&self, event_payload: Self::EventInput, source_identifier: &str) -> anyhow::Result<Vec<TelemetryData>>;
+}
+```
+
+### Span Compaction
+
+(Located in `src/span_compactor.rs`)
+
+- `SpanCompactionConfig`: Configuration for enabling/disabling compaction, setting max payload size, and Gzip compression level.
+- `compact_telemetry_payloads()`: Takes a `Vec<TelemetryData>` (expected to contain uncompressed OTLP protobuf payloads) and merges them into a single `TelemetryData` object, then applies Gzip compression according to the config.
+
+### HTTP Sender
+
+(Located in `src/http_sender.rs`)
+
+- `resolve_otlp_endpoint()`: Determines the target OTLP HTTP endpoint by checking `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, then `OTEL_EXPORTER_OTLP_ENDPOINT`, and finally defaulting to `http://localhost:4318/v1/traces`. It correctly appends `/v1/traces` if a base URL is provided via `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- `resolve_otlp_headers()`: Parses custom HTTP headers from `OTEL_EXPORTER_OTLP_TRACES_HEADERS` or `OTEL_EXPORTER_OTLP_HEADERS` (comma-separated `key=value` format).
+- `send_telemetry_batch()`: Asynchronously sends a (compacted and compressed) `TelemetryData` payload to the resolved endpoint using the resolved headers.
+
+### HTTP Client Options
+
+The crate provides multiple HTTP client options to minimize boilerplate in your Lambda implementations:
+
+#### Simple ReqwestClient (Recommended for most use cases)
+```rust,no_run
+use reqwest::Client as ReqwestClient;
+use std::sync::Arc;
+
+// ReqwestClient implements HttpOtlpForwarderClient out of the box
+let http_client = Arc::new(ReqwestClient::new());
+```
+
+#### Builder Functions
+```rust,no_run
+use serverless_otlp_forwarder_core::client_builder;
+use std::sync::Arc;
+use std::time::Duration;
+
+// Simple client
+let http_client = Arc::new(client_builder::simple());
+
+// With custom timeout
+let http_client = Arc::new(client_builder::with_timeout(Duration::from_secs(30)));
+```
+
+#### Instrumented Client (Feature: `instrumented-client`)
+For Lambda functions that need request tracing and middleware support:
+
+```rust,ignore
+use reqwest::Client as ReqwestClient;
+use reqwest_middleware::ClientBuilder;
+use reqwest_tracing::TracingMiddleware;
+use serverless_otlp_forwarder_core::InstrumentedHttpClient;
+use std::sync::Arc;
+
+// Create with custom middleware
+let base_client = ReqwestClient::new();
+let middleware_client = ClientBuilder::new(base_client)
+    .with(TracingMiddleware::default())
+    .build();
+let http_client = Arc::new(InstrumentedHttpClient::new(middleware_client));
+
+// Or use the builder (when instrumented-client feature is enabled)
+// let http_client = Arc::new(client_builder::instrumented());
+```
+
+**Use Case**: The instrumented client is particularly useful when you want to instrument the forwarder's own HTTP requests to OTLP collectors. This aligns with the [OpenTelemetry Collector's internal telemetry capabilities](https://opentelemetry.io/docs/collector/internal-telemetry/#activate-internal-telemetry-in-the-collector), allowing you to observe the forwarder's performance, request patterns, and potential issues when sending data to collectors.
+
+**Note**: OpenTelemetry's tracing instrumentation for collectors is still under active development and considered experimental. The instrumented client provides HTTP request tracing that can complement the collector's internal telemetry when debugging data flow issues or monitoring forwarder performance.
+
+### `process_event_batch` Orchestrator
+
+(Located in `src/processor.rs`)
+
+The main generic function that orchestrates the telemetry processing pipeline:
+
+1. Calls the provided `EventParser`'s `parse` method.
+2. If telemetry items are produced, calls `compact_telemetry_payloads`.
+3. Sends the resulting batch using `send_telemetry_batch`.
+
+Handles errors at each step.
+
+## Installation
+
+This crate is intended to be used as a dependency by other Lambda functions implementing the Serverless OTLP Forwarder architecture. It can be added with the following command:
+
+```bash
+cargo add serverless-otlp-forwarder-core
+```
+
+### Optional Features
+
+- **`instrumented-client`**: Enables the `InstrumentedHttpClient` for advanced middleware support
+  ```toml
+  [dependencies]
+  serverless-otlp-forwarder-core = { version = "0.1.0", features = ["instrumented-client"] }
+  ```
+
+## Usage Example
+
+Implementing a forwarder for AWS CloudWatch Logs containing `ExporterOutput` JSON from the `otlp-stdout-span-exporter` crate:
+
+**1. Define your parser (`src/parser.rs` in your Lambda crate):**
+
+```rust,no_run
+use aws_lambda_events::cloudwatch_logs::LogsEvent;
+use anyhow::Result;
+use serverless_otlp_forwarder_core::{EventParser, TelemetryData};
+
+pub struct MyLogsEventParser;
+
+impl EventParser for MyLogsEventParser {
+    type EventInput = LogsEvent;
+
+    fn parse(&self, _event_payload: Self::EventInput, _source_identifier: &str) -> Result<Vec<TelemetryData>> {
+        // Simplified example - in real usage you'd parse log events containing OTLP data
+        let items = Vec::new();
+        // Example parsing logic would go here:
+        // for log_event in event_payload.aws_logs.data.log_events {
+        //     // Parse JSON containing OTLP data and convert to TelemetryData
+        // }
+        Ok(items)
+    }
+}
+```
+
+**2. Use in your Lambda's `main.rs`:**
+
+```rust,no_run
+use anyhow::Result;
+use lambda_runtime::{Error as LambdaError, LambdaEvent, Runtime, service_fn};
+use reqwest::Client as ReqwestClient;
+use serverless_otlp_forwarder_core::{
+    process_event_batch, 
+    SpanCompactionConfig,
+    client_builder,
+    EventParser,
+    TelemetryData,
+};
+use std::sync::Arc;
+use aws_lambda_events::cloudwatch_logs::LogsEvent;
+
+// Define the parser inline instead of as a separate module
+pub struct MyLogsEventParser;
+
+impl EventParser for MyLogsEventParser {
+    type EventInput = LogsEvent;
+
+    fn parse(&self, _event_payload: Self::EventInput, _source_identifier: &str) -> Result<Vec<TelemetryData>> {
+        // Simplified example - in real usage you'd parse the actual event
+        Ok(vec![])
+    }
+} 
+
+async fn function_handler(
+    event: LambdaEvent<LogsEvent>, 
+    http_client: Arc<ReqwestClient>,
+) -> Result<(), LambdaError> {
+    let log_group = event.payload.aws_logs.data.log_group.clone();
+    let parser = MyLogsEventParser;
+    let compaction_config = SpanCompactionConfig::default();
+
+    process_event_batch(
+        event.payload,
+        &parser,
+        &log_group,
+        http_client.as_ref(),
+        &compaction_config,
+    )
+    .await
+    .map_err(|e| LambdaError::from(e.to_string()))?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), LambdaError> {
+    // Initialize telemetry (optional)
+    // ... telemetry setup code ...
+    
+    // Create HTTP client - Zero boilerplate required!
+    let http_client = Arc::new(client_builder::simple());
+    
+    // Alternative options:
+    // let http_client = Arc::new(ReqwestClient::new());
+    // let http_client = Arc::new(client_builder::with_timeout(Duration::from_secs(30)));
+    
+    // Initialize the Lambda runtime
+    Runtime::new(service_fn(move |event: LambdaEvent<LogsEvent>| {
+        let client = Arc::clone(&http_client);
+        async move { function_handler(event, client).await }
+    })).run().await
+}
+```
+
+### Advanced Example with Instrumentation
+
+For more advanced use cases requiring request tracing and observability of the forwarder itself:
+
+```toml
+# Cargo.toml
+[dependencies]
+serverless-otlp-forwarder-core = { version = "0.1.0", features = ["instrumented-client"] }
+reqwest-middleware = "0.3"
+reqwest-tracing = "0.5"
+```
+
+```rust,ignore
+use reqwest::Client as ReqwestClient;
+use reqwest_middleware::ClientBuilder;
+use reqwest_tracing::TracingMiddleware;
+use serverless_otlp_forwarder_core::InstrumentedHttpClient;
+use lambda_runtime::Error as LambdaError;
+use anyhow::Result;
+use std::sync::Arc;
+
+#[tokio::main]
+async fn main() -> Result<(), LambdaError> {
+    // Create instrumented HTTP client to trace forwarder's own requests
+    let base_client = ReqwestClient::new();
+    let middleware_client = ClientBuilder::new(base_client)
+        .with(TracingMiddleware::default())
+        .build();
+    let http_client = Arc::new(InstrumentedHttpClient::new(middleware_client));
+    
+    // Or use the builder function:
+    // let http_client = Arc::new(client_builder::instrumented());
+    
+    // Rest of setup is identical...
+    Ok(())
+}
+```
+
+This setup enables distributed tracing of the forwarder's HTTP requests to OTLP collectors, which is valuable for:
+- **Debugging data flow issues** between the forwarder and collectors
+- **Monitoring forwarder performance** and request latency patterns  
+- **Correlating forwarder behavior** with the [OpenTelemetry Collector's internal telemetry](https://opentelemetry.io/docs/collector/internal-telemetry/#activate-internal-telemetry-in-the-collector)
+- **Identifying bottlenecks** in the telemetry pipeline
+
+**Note**: Since collector tracing instrumentation is experimental, this instrumented client provides a stable way to observe the forwarder's side of the telemetry pipeline.
+
+### Manual Implementation vs. Built-in HTTP Clients
+
+**Manual/Custom Setup (Without this crate's built-in clients):**
+```rust,ignore
+use reqwest::{Client as ReqwestClient, Response};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_tracing::TracingMiddleware;
+use async_trait::async_trait;
+use anyhow::{Result, Context};
+use url::Url;
+use reqwest::header::HeaderMap;
+use bytes::Bytes;
+use std::time::Duration;
+use std::sync::Arc;
+
+// Custom wrapper type required
+pub struct InstrumentedOtlpClient(ClientWithMiddleware);
+
+// Manual trait implementation required (15+ lines per Lambda)
+#[async_trait]
+trait HttpOtlpForwarderClient {
+    async fn post_telemetry(
+        &self,
+        target_url: Url,
+        headers: HeaderMap,
+        payload: Bytes,
+        timeout: Duration,
+    ) -> Result<Response>;
+}
+
+#[async_trait]
+impl HttpOtlpForwarderClient for InstrumentedOtlpClient {
+    async fn post_telemetry(
+        &self,
+        target_url: Url,
+        headers: HeaderMap,
+        payload: Bytes,
+        timeout: Duration,
+    ) -> Result<Response> {
+        self.0
+            .post(target_url)
+            .headers(headers)
+            .body(payload)
+            .timeout(timeout)
+            .send()
+            .await
+            .context("HTTP request failed via InstrumentedOtlpClient for OTLP export")
+    }
+}
+
+// Complex setup in main()
+let base_client = ReqwestClient::new();
+let middleware_client = ClientBuilder::new(base_client)
+    .with(TracingMiddleware::default())
+    .build();
+let http_client = Arc::new(InstrumentedOtlpClient(middleware_client));
+```
+
+**Built-in Options (Using this crate's provided clients):**
+```rust,no_run
+use reqwest::Client as ReqwestClient;
+use serverless_otlp_forwarder_core::client_builder;
+use std::sync::Arc;
+
+// Option 1: Simple
+let http_client = Arc::new(ReqwestClient::new());
+
+// Option 2: Builder functions
+let http_client = Arc::new(client_builder::simple());
+
+// Option 3: Instrumented (with feature flag)
+// let http_client = Arc::new(client_builder::instrumented());
+```
+
+## Environment Variables
+
+The `http_sender` module within this crate respects the following standard OpenTelemetry environment variables for configuring the OTLP export endpoint and headers:
+
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`: The target URL for traces. If not set, `OTEL_EXPORTER_OTLP_ENDPOINT` is used. Defaults to `http://localhost:4318/v1/traces`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: A base URL for OTLP exports. `/v1/traces` will be appended if not present in the path.
+- `OTEL_EXPORTER_OTLP_TRACES_HEADERS`: Custom headers for trace exports (e.g., `key1=value1,key2=value2`).
+- `OTEL_EXPORTER_OTLP_HEADERS`: Custom general OTLP headers, used if trace-specific headers are not set.
+- `OTEL_EXPORTER_OTLP_COMPRESSION`: Whether to compress the payload. Valid values are `gzip` or `none`. Defaults to `none`.
+- `OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL`: The compression level for Gzip compression. Valid values are `0` to `9`. Please note that this is not part of the OTLP specification and is not supported by all OTLP exporters. We are adding support for it because it's useful in a be able to tune it in a constrained Lambda environment. Defaults to `9`.
+
+## License
+
+Licensed under the MIT License. See workspace root.

--- a/packages/rust/serverless-otlp-forwarder-core/src/core_parser.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/core_parser.rs
@@ -1,0 +1,14 @@
+use crate::telemetry::TelemetryData;
+use anyhow::Result;
+
+pub trait EventParser {
+    // The specific AWS event type (e.g., LogsEvent, KinesisEvent)
+    // that this parser instance knows how to handle.
+    type EventInput;
+
+    fn parse(
+        &self,
+        event_payload: Self::EventInput,
+        source_identifier: &str,
+    ) -> Result<Vec<TelemetryData>>;
+}

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -60,7 +60,7 @@ fn parse_otlp_headers(headers_str: &str) -> Result<HeaderMap> {
 }
 
 /// Resolves OTLP headers from environment variables.
-/// Priotity: OTEL_EXPORTER_OTLP_TRACES_HEADERS, then OTEL_EXPORTER_OTLP_HEADERS.
+/// Priority: OTEL_EXPORTER_OTLP_TRACES_HEADERS, then OTEL_EXPORTER_OTLP_HEADERS.
 fn resolve_otlp_headers() -> Result<HeaderMap> {
     let traces_headers_var = env::var("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
     let generic_headers_var = env::var("OTEL_EXPORTER_OTLP_HEADERS");

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -1,0 +1,798 @@
+use crate::telemetry::TelemetryData;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_ENCODING, CONTENT_TYPE};
+use reqwest::Client as ReqwestClient;
+use std::env;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, instrument, warn, Span};
+use url::Url;
+
+const DEFAULT_OTLP_ENDPOINT: &str = "http://localhost:4318/v1/traces";
+const OTLP_TRACES_PATH: &str = "/v1/traces";
+const DEFAULT_OTLP_EXPORT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Parses OTLP headers from a comma-separated key=value string.
+fn parse_otlp_headers(headers_str: &str) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    if headers_str.is_empty() {
+        return Ok(headers);
+    }
+    for pair_str in headers_str.split(',') {
+        let pair_str = pair_str.trim();
+        if pair_str.is_empty() {
+            continue;
+        }
+        match pair_str.split_once('=') {
+            Some((key_str, value_str)) => {
+                let key = key_str.trim();
+                let value = value_str.trim();
+                if key.is_empty() {
+                    warn!("Empty header key found in OTLP headers string part: '{}' from full string: '{}'", pair_str, headers_str);
+                    continue;
+                }
+                match HeaderName::from_str(key) {
+                    Ok(header_name) => match HeaderValue::from_str(value) {
+                        Ok(header_value) => {
+                            headers.append(header_name, header_value);
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Invalid header value '{}' for key '{}': {}. Skipping header.",
+                                value, key, e
+                            );
+                        }
+                    },
+                    Err(e) => {
+                        warn!("Invalid header name '{}': {}. Skipping header.", key, e);
+                    }
+                }
+            }
+            None => {
+                warn!("Malformed header pair (missing '='): '{}' in OTLP headers string: '{}'. Skipping.", pair_str, headers_str);
+            }
+        }
+    }
+    Ok(headers)
+}
+
+/// Resolves OTLP headers from environment variables.
+/// Priotity: OTEL_EXPORTER_OTLP_TRACES_HEADERS, then OTEL_EXPORTER_OTLP_HEADERS.
+fn resolve_otlp_headers() -> Result<HeaderMap> {
+    let traces_headers_var = env::var("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
+    let generic_headers_var = env::var("OTEL_EXPORTER_OTLP_HEADERS");
+
+    match traces_headers_var {
+        Ok(headers_str) if !headers_str.is_empty() => {
+            debug!("Using OTEL_EXPORTER_OTLP_TRACES_HEADERS: {}", headers_str);
+            return parse_otlp_headers(&headers_str);
+        }
+        _ => { // Fall through if TRACES_HEADERS is not set or empty
+        }
+    }
+
+    match generic_headers_var {
+        Ok(headers_str) if !headers_str.is_empty() => {
+            debug!("Using OTEL_EXPORTER_OTLP_HEADERS: {}", headers_str);
+            return parse_otlp_headers(&headers_str);
+        }
+        _ => { // Fall through if HEADERS is not set or empty
+        }
+    }
+
+    Ok(HeaderMap::new()) // No headers from env vars
+}
+
+/// Resolves the OTLP endpoint URL based on OpenTelemetry environment variables.
+/// Priorities:
+/// 1. OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (used as is)
+/// 2. OTEL_EXPORTER_OTLP_ENDPOINT (base URL, /v1/traces might be appended)
+/// 3. Default: http://localhost:4318/v1/traces
+fn resolve_otlp_endpoint() -> Result<Url> {
+    if let Ok(traces_endpoint) = env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") {
+        if !traces_endpoint.is_empty() {
+            debug!(
+                "Using OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: {}",
+                traces_endpoint
+            );
+            return Url::parse(&traces_endpoint).with_context(|| {
+                format!("Invalid URL from OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: {traces_endpoint}")
+            });
+        }
+    }
+
+    if let Ok(generic_endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
+        if !generic_endpoint.is_empty() {
+            debug!("Using OTEL_EXPORTER_OTLP_ENDPOINT: {}", generic_endpoint);
+            let mut url = Url::parse(&generic_endpoint).with_context(|| {
+                format!("Invalid URL from OTEL_EXPORTER_OTLP_ENDPOINT: {generic_endpoint}")
+            })?;
+
+            let current_path = url.path();
+            if !current_path.ends_with(OTLP_TRACES_PATH) {
+                let new_path = if current_path == "/" || current_path.is_empty() {
+                    OTLP_TRACES_PATH.to_string()
+                } else {
+                    format!("{}{}", current_path.trim_end_matches('/'), OTLP_TRACES_PATH)
+                };
+                url.set_path(&new_path);
+            }
+            return Ok(url);
+        }
+    }
+
+    debug!("Using default OTLP endpoint: {}", DEFAULT_OTLP_ENDPOINT);
+    Url::parse(DEFAULT_OTLP_ENDPOINT)
+        .with_context(|| format!("Failed to parse default OTLP endpoint: {DEFAULT_OTLP_ENDPOINT}"))
+}
+
+/// Parses an OTLP timeout string (expected to be milliseconds) into a Duration.
+fn parse_otlp_timeout_millis(duration_ms_str: &str) -> Result<Duration> {
+    let millis = duration_ms_str.parse::<u64>().with_context(|| {
+        format!("Invalid OTLP timeout value: '{duration_ms_str}'. Expected integer milliseconds.")
+    })?;
+    Ok(Duration::from_millis(millis))
+}
+
+/// Resolves the OTLP export timeout from environment variables.
+/// Value is expected to be in milliseconds.
+fn resolve_otlp_timeout() -> Duration {
+    let traces_timeout_var = env::var("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT");
+    let generic_timeout_var = env::var("OTEL_EXPORTER_OTLP_TIMEOUT");
+
+    let timeout_str_to_parse = match traces_timeout_var {
+        Ok(val) if !val.is_empty() => {
+            debug!("Using OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: {}", val);
+            Some(val)
+        }
+        _ => match generic_timeout_var {
+            Ok(val) if !val.is_empty() => {
+                debug!("Using OTEL_EXPORTER_OTLP_TIMEOUT: {}", val);
+                Some(val)
+            }
+            _ => None,
+        },
+    };
+
+    if let Some(s) = timeout_str_to_parse {
+        match parse_otlp_timeout_millis(&s) {
+            Ok(duration) => {
+                debug!("Parsed OTLP export timeout duration: {:?}", duration);
+                return duration;
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to parse OTLP timeout value '{}': {}. Using default timeout.",
+                    s, e
+                );
+            }
+        }
+    }
+    debug!(
+        "Using default OTLP export timeout: {:?}",
+        DEFAULT_OTLP_EXPORT_TIMEOUT
+    );
+    DEFAULT_OTLP_EXPORT_TIMEOUT
+}
+
+/// Trait for an HTTP client capable of sending OTLP telemetry batches for the forwarder.
+#[async_trait]
+pub trait HttpOtlpForwarderClient: Send + Sync {
+    async fn post_telemetry(
+        &self,
+        target_url: Url,
+        headers: HeaderMap,
+        payload: Bytes,
+        timeout: Duration,
+    ) -> Result<reqwest::Response>;
+}
+
+#[async_trait]
+impl HttpOtlpForwarderClient for ReqwestClient {
+    async fn post_telemetry(
+        &self,
+        target_url: Url,
+        headers: HeaderMap,
+        payload: Bytes,
+        timeout: Duration,
+    ) -> Result<reqwest::Response> {
+        self.post(target_url)
+            .headers(headers)
+            .body(payload)
+            .timeout(timeout)
+            .send()
+            .await
+            .context("HTTP request failed during OTLP export")
+    }
+}
+
+/// A convenience type alias for Arc\<dyn HttpOtlpForwarderClient\>
+pub type HttpClient = Arc<dyn HttpOtlpForwarderClient + Send + Sync>;
+
+/// Sends a batch of OTLP telemetry data.
+/// The TelemetryData payload is assumed to be a compacted, possibly compressed, OTLP protobuf batch.
+#[instrument(name="http_sender/send_telemetry_batch", skip_all, fields(
+    otel.kind = "client",
+    http.method = "POST",
+    http.url = %telemetry_data.endpoint,
+    http.status_code
+    // error details will be added on error
+))]
+pub async fn send_telemetry_batch(
+    client: &impl HttpOtlpForwarderClient,
+    telemetry_data: TelemetryData,
+) -> Result<()> {
+    let resolved_target_url = resolve_otlp_endpoint()?;
+    Span::current().record("http.url", resolved_target_url.as_str());
+    let timeout = resolve_otlp_timeout();
+
+    let mut headers = resolve_otlp_headers()?;
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(&telemetry_data.content_type)
+            .context("Invalid Content-Type in TelemetryData")?,
+    );
+    if let Some(encoding) = &telemetry_data.content_encoding {
+        headers.insert(
+            CONTENT_ENCODING,
+            HeaderValue::from_str(encoding).context("Invalid Content-Encoding in TelemetryData")?,
+        );
+    } else {
+        headers.remove(CONTENT_ENCODING);
+    }
+
+    let payload_bytes = Bytes::from(telemetry_data.payload); // Convert Vec<u8> to Bytes
+
+    debug!(
+        name = "sending telemetry batch",
+        target_url = %resolved_target_url,
+        timeout_ms = timeout.as_millis(),
+        headers = ?headers,
+        payload_size_bytes = payload_bytes.len(), // Use length of Bytes
+        "Request details"
+    );
+
+    let response = match client
+        .post_telemetry(resolved_target_url.clone(), headers, payload_bytes, timeout)
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            Span::current().record("otel.status_code", "ERROR");
+            Span::current().record("error", true);
+            Span::current().record("error.message", e.to_string());
+            warn!(target_url = %resolved_target_url, error = %e, "OTLP HTTP post_telemetry failed");
+            return Err(e);
+        }
+    };
+
+    let status = response.status();
+    Span::current().record("http.status_code", status.as_u16());
+
+    if !status.is_success() {
+        Span::current().record("otel.status_code", "ERROR");
+        let error_body = response.text().await.unwrap_or_else(|e| {
+            warn!("Failed to read error response body: {}", e);
+            format!("Failed to read response body. Status: {status}")
+        });
+        Span::current().record("error.message", error_body.clone());
+        warn!(
+            target_url = %resolved_target_url,
+            status = %status,
+            response_body = %error_body,
+            "OTLP export failed with non-success status"
+        );
+        return Err(anyhow::anyhow!(
+            "OTLP export failed to {}. Status: {}. Body: {}",
+            resolved_target_url,
+            status,
+            error_body
+        ));
+    }
+
+    debug!(target_url = %resolved_target_url, status = %status, "Telemetry batch sent successfully");
+    Ok(())
+}
+
+#[cfg(feature = "instrumented-client")]
+pub mod instrumented {
+    use super::*;
+    use reqwest_middleware::ClientWithMiddleware;
+
+    /// A pre-configured HTTP client that wraps ClientWithMiddleware and implements HttpOtlpForwarderClient
+    pub struct InstrumentedHttpClient {
+        inner: ClientWithMiddleware,
+    }
+
+    impl InstrumentedHttpClient {
+        /// Creates a new instrumented HTTP client from a ClientWithMiddleware
+        ///
+        /// # Example
+        /// ```rust,ignore
+        /// use reqwest::Client;
+        /// use reqwest_middleware::ClientBuilder;
+        /// use reqwest_tracing::TracingMiddleware;
+        /// use serverless_otlp_forwarder_core::InstrumentedHttpClient;
+        ///
+        /// let base_client = Client::new();
+        /// let middleware_client = ClientBuilder::new(base_client)
+        ///     .with(TracingMiddleware::default())
+        ///     .build();
+        /// let instrumented_client = InstrumentedHttpClient::new(middleware_client);
+        /// ```
+        pub fn new(client: ClientWithMiddleware) -> Self {
+            Self { inner: client }
+        }
+    }
+
+    #[async_trait]
+    impl HttpOtlpForwarderClient for InstrumentedHttpClient {
+        async fn post_telemetry(
+            &self,
+            target_url: Url,
+            headers: HeaderMap,
+            payload: Bytes,
+            timeout: Duration,
+        ) -> Result<reqwest::Response> {
+            self.inner
+                .post(target_url)
+                .headers(headers)
+                .body(payload)
+                .timeout(timeout)
+                .send()
+                .await
+                .context("HTTP request failed during instrumented OTLP export")
+        }
+    }
+}
+
+/// Utility functions for creating HTTP clients with common configurations
+pub mod client_builder {
+    use super::*;
+
+    /// Creates a simple ReqwestClient that implements HttpOtlpForwarderClient
+    pub fn simple() -> ReqwestClient {
+        ReqwestClient::new()
+    }
+
+    /// Creates a ReqwestClient with custom timeout
+    pub fn with_timeout(timeout: Duration) -> ReqwestClient {
+        ReqwestClient::builder()
+            .timeout(timeout)
+            .build()
+            .expect("Failed to build HTTP client")
+    }
+
+    #[cfg(feature = "instrumented-client")]
+    /// Creates an instrumented client with tracing middleware
+    pub fn instrumented() -> crate::InstrumentedHttpClient {
+        use reqwest_middleware::ClientBuilder;
+        use reqwest_tracing::TracingMiddleware;
+
+        let base_client = ReqwestClient::new();
+        let middleware_client = ClientBuilder::new(base_client)
+            .with(TracingMiddleware::default())
+            .build();
+        crate::InstrumentedHttpClient::new(middleware_client)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::TelemetryData;
+    use reqwest::Client as ReqwestClient;
+    use sealed_test::prelude::*;
+    use std::time::Duration as StdDuration;
+    use wiremock::matchers::{body_bytes, header, method, path};
+    use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+    // Helper struct to ensure env vars are cleaned up.
+    struct EnvVarGuard {
+        name: String,
+        original_value: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        #[allow(dead_code)]
+        fn set(name: &str, value: &str) -> Self {
+            let original_value = env::var(name).ok();
+            env::set_var(name, value);
+            Self {
+                name: name.to_string(),
+                original_value,
+            }
+        }
+
+        #[allow(dead_code)]
+        fn remove(name: &str) -> Self {
+            let original_value = env::var(name).ok();
+            env::remove_var(name);
+            Self {
+                name: name.to_string(),
+                original_value,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(val) = &self.original_value {
+                env::set_var(&self.name, val);
+            } else {
+                env::remove_var(&self.name);
+            }
+        }
+    }
+
+    fn test_client() -> ReqwestClient {
+        ReqwestClient::new()
+    }
+
+    #[tokio::test]
+    async fn test_parse_otlp_headers_empty() {
+        let headers = parse_otlp_headers("").unwrap();
+        assert!(headers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_parse_otlp_headers_single() {
+        let headers = parse_otlp_headers("key1=value1").unwrap();
+        assert_eq!(headers.get("key1").unwrap(), "value1");
+    }
+
+    #[tokio::test]
+    async fn test_parse_otlp_headers_multiple() {
+        let headers = parse_otlp_headers("key1=value1,key2=value2, key3 = value3 ").unwrap();
+        assert_eq!(headers.get("key1").unwrap(), "value1");
+        assert_eq!(headers.get("key2").unwrap(), "value2");
+        assert_eq!(headers.get("key3").unwrap(), "value3");
+    }
+
+    #[tokio::test]
+    async fn test_parse_otlp_headers_invalid_pair() {
+        let headers = parse_otlp_headers("key1=value1,invalid,key2=value2").unwrap();
+        assert_eq!(headers.get("key1").unwrap(), "value1");
+        assert_eq!(headers.get("key2").unwrap(), "value2");
+        assert!(headers.get("invalid").is_none());
+        assert_eq!(headers.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_parse_otlp_headers_empty_key_value() {
+        let headers = parse_otlp_headers("key1=, =value2 , key3=value3").unwrap();
+        assert_eq!(headers.get("key1").unwrap(), "");
+        assert_eq!(headers.get("key3").unwrap(), "value3");
+        assert_eq!(headers.len(), 2);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_headers_none_set() {
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_HEADERS");
+        let headers = resolve_otlp_headers().unwrap();
+        assert!(headers.is_empty());
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_headers_traces_set() {
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "tracekey=traceval");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_HEADERS");
+        let headers = resolve_otlp_headers().unwrap();
+        assert_eq!(headers.get("tracekey").unwrap(), "traceval");
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_headers_generic_set() {
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_HEADERS", "generalkey=generalval");
+        let headers = resolve_otlp_headers().unwrap();
+        assert_eq!(headers.get("generalkey").unwrap(), "generalval");
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_headers_traces_takes_precedence() {
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "tracekey=traceval");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_HEADERS", "generalkey=generalval");
+        let headers = resolve_otlp_headers().unwrap();
+        assert_eq!(headers.get("tracekey").unwrap(), "traceval");
+        assert!(headers.get("generalkey").is_none());
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_default() {
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+        assert_eq!(
+            resolve_otlp_endpoint().unwrap().to_string(),
+            DEFAULT_OTLP_ENDPOINT
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_traces_var() {
+        let custom_endpoint = "http://custom-traces.local:4318/v1/traces";
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", custom_endpoint);
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+        assert_eq!(
+            resolve_otlp_endpoint().unwrap().to_string(),
+            custom_endpoint
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_traces_var_no_path() {
+        let custom_endpoint = "http://custom-traces.local:4318";
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", custom_endpoint);
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+        let expected_url = if custom_endpoint.ends_with('/') {
+            custom_endpoint.to_string()
+        } else {
+            format!("{custom_endpoint}/")
+        };
+        assert_eq!(resolve_otlp_endpoint().unwrap().to_string(), expected_url);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_generic_var_no_path() {
+        let base_endpoint = "http://generic.local:4318";
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_ENDPOINT", base_endpoint);
+        let expected_url = format!("{}/v1/traces", base_endpoint.trim_end_matches('/'));
+        assert_eq!(resolve_otlp_endpoint().unwrap().to_string(), expected_url);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_generic_var_with_path() {
+        let base_endpoint = "http://generic.local:4318/custom/path";
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_ENDPOINT", base_endpoint);
+        let expected_url = format!("{}/v1/traces", base_endpoint.trim_end_matches('/'));
+        assert_eq!(resolve_otlp_endpoint().unwrap().to_string(), expected_url);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_generic_var_with_traces_path_already() {
+        let full_endpoint = "http://generic.local:4318/v1/traces";
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_ENDPOINT", full_endpoint);
+        assert_eq!(resolve_otlp_endpoint().unwrap().to_string(), full_endpoint);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_traces_takes_precedence() {
+        let traces_specific = "http://traces-specific.local:4318/v1/traces";
+        let generic_val = "http://generic-ignored.local:4318";
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", traces_specific);
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_ENDPOINT", generic_val);
+        assert_eq!(
+            resolve_otlp_endpoint().unwrap().to_string(),
+            traces_specific
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_timeout_default() {
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TIMEOUT");
+        assert_eq!(resolve_otlp_timeout(), DEFAULT_OTLP_EXPORT_TIMEOUT);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_timeout_traces_var_millis_val() {
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "1500");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TIMEOUT");
+        assert_eq!(resolve_otlp_timeout(), Duration::from_millis(1500));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_timeout_generic_var_millis_val() {
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TIMEOUT", "7000");
+        assert_eq!(resolve_otlp_timeout(), Duration::from_millis(7000));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_timeout_traces_takes_precedence_millis_val() {
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "3000");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TIMEOUT", "12000");
+        assert_eq!(resolve_otlp_timeout(), Duration::from_millis(3000));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_timeout_invalid_value_uses_default() {
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "invalid");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TIMEOUT");
+        assert_eq!(resolve_otlp_timeout(), DEFAULT_OTLP_EXPORT_TIMEOUT);
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_timeout_invalid_value_suffixed_uses_default() {
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "5s");
+        assert_eq!(resolve_otlp_timeout(), DEFAULT_OTLP_EXPORT_TIMEOUT);
+    }
+
+    struct SlowServerMatcher {
+        delay: StdDuration,
+    }
+    impl Match for SlowServerMatcher {
+        fn matches(&self, _request: &Request) -> bool {
+            std::thread::sleep(self.delay);
+            true
+        }
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_send_telemetry_batch_respects_timeout() {
+        let server = MockServer::start().await;
+        let client = ReqwestClient::builder().build().unwrap();
+        let telemetry = TelemetryData::default();
+        Mock::given(SlowServerMatcher {
+            delay: StdDuration::from_millis(200),
+        })
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+        let _g1 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}{}", server.uri(), OTLP_TRACES_PATH),
+        );
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", "100");
+        let result = send_telemetry_batch(&client, telemetry).await;
+        assert!(
+            result.is_err(),
+            "Expected send_telemetry_batch to fail due to timeout"
+        );
+        let err = result.unwrap_err();
+
+        let is_timeout_error = err.chain().any(|cause| {
+            if let Some(req_err) = cause.downcast_ref::<reqwest::Error>() {
+                req_err.is_timeout()
+            } else {
+                cause.to_string().to_lowercase().contains("timeout")
+                    || cause.to_string().to_lowercase().contains("timed out")
+            }
+        });
+        assert!(
+            is_timeout_error,
+            "Error was not a timeout error. Actual error: {:?}\nCause chain: {:#?}",
+            err,
+            err.chain().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_send_telemetry_batch_success_with_env_headers() {
+        let server = MockServer::start().await;
+        let client = test_client();
+        let telemetry = TelemetryData {
+            payload: b"payload_for_headers_test".to_vec(),
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None,
+            ..Default::default()
+        };
+        Mock::given(method("POST"))
+            .and(path(OTLP_TRACES_PATH))
+            .and(header(CONTENT_TYPE, "application/x-protobuf"))
+            .and(header("customkey", "customvalue"))
+            .and(header("anotherkey", "anotherval"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let _g1 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}{}", server.uri(), OTLP_TRACES_PATH),
+        );
+        let _g2 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+            "customkey=customvalue,anotherkey=anotherval",
+        );
+        let result = send_telemetry_batch(&client, telemetry).await;
+        assert!(
+            result.is_ok(),
+            "send_telemetry_batch failed: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_send_telemetry_batch_success() {
+        let server = MockServer::start().await;
+        let client = test_client();
+        let telemetry = TelemetryData {
+            payload: b"test_payload".to_vec(),
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: Some("gzip".to_string()),
+            ..Default::default()
+        };
+        Mock::given(method("POST"))
+            .and(path(OTLP_TRACES_PATH))
+            .and(body_bytes(telemetry.payload.clone()))
+            .and(header(CONTENT_TYPE, "application/x-protobuf"))
+            .and(header(CONTENT_ENCODING, "gzip"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let _g1 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}{}", server.uri(), OTLP_TRACES_PATH),
+        );
+        let result = send_telemetry_batch(&client, telemetry).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_send_telemetry_batch_no_content_encoding() {
+        let server = MockServer::start().await;
+        let client = test_client();
+        let telemetry = TelemetryData {
+            payload: b"test_payload_no_encoding".to_vec(),
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None,
+            ..Default::default()
+        };
+        Mock::given(method("POST"))
+            .and(path(OTLP_TRACES_PATH))
+            .and(body_bytes(telemetry.payload.clone()))
+            .and(header(CONTENT_TYPE, "application/x-protobuf"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let _g1 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}{}", server.uri(), OTLP_TRACES_PATH),
+        );
+        let result = send_telemetry_batch(&client, telemetry).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_send_telemetry_batch_server_error() {
+        let server = MockServer::start().await;
+        let client = test_client();
+        let telemetry = TelemetryData::default();
+        Mock::given(method("POST"))
+            .and(path(OTLP_TRACES_PATH))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Error"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let _g1 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}{}", server.uri(), OTLP_TRACES_PATH),
+        );
+        let result = send_telemetry_batch(&client, telemetry).await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("Status: 500"));
+        assert!(err_msg.contains("Internal Error"));
+    }
+}

--- a/packages/rust/serverless-otlp-forwarder-core/src/lib.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/lib.rs
@@ -1,0 +1,20 @@
+#![doc = include_str!("../README.md")]
+// In: packages/rust/serverless-otlp-forwarder-core/src/lib.rs
+
+pub mod telemetry;
+pub use telemetry::TelemetryData;
+
+pub mod span_compactor;
+pub use span_compactor::{compact_telemetry_payloads, SpanCompactionConfig};
+
+pub mod http_sender;
+pub use http_sender::{client_builder, send_telemetry_batch, HttpClient};
+
+#[cfg(feature = "instrumented-client")]
+pub use http_sender::instrumented::InstrumentedHttpClient;
+
+pub mod core_parser;
+pub use core_parser::EventParser;
+
+pub mod processor;
+pub use processor::process_event_batch;

--- a/packages/rust/serverless-otlp-forwarder-core/src/processor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/processor.rs
@@ -1,0 +1,358 @@
+use crate::core_parser::EventParser;
+use crate::http_sender::{send_telemetry_batch, HttpOtlpForwarderClient};
+use crate::span_compactor::{compact_telemetry_payloads, SpanCompactionConfig};
+use anyhow::Result;
+use tracing::{debug, error, info, instrument};
+
+/// Processes a batch of events from a specific AWS Lambda event source.
+///
+/// This function orchestrates the parsing, compaction, and sending of telemetry data.
+///
+/// # Type Parameters
+///
+/// * `E`: The type of the raw event input (e.g., `aws_lambda_events::event::cloudwatch_logs::LogsEvent`).
+/// * `P`: The type of the parser that implements `EventParser<EventInput = E>`.
+/// * `C`: The type of the HTTP client that implements `HttpOtlpForwarderClient`.
+///
+/// # Arguments
+///
+/// * `event_payload`: The raw event payload from AWS Lambda.
+/// * `parser`: An instance of the event parser for the specific event type.
+/// * `source_identifier`: A string identifying the source of the event (e.g., log group name, Kinesis stream name).
+/// * `http_client`: A reference to the HTTP client for making HTTP requests.
+/// * `compaction_config`: Configuration for span compaction.
+///
+#[instrument(name="processor/process_event_batch", skip_all, fields(source = %source_identifier))]
+pub async fn process_event_batch<
+    E,
+    P: EventParser<EventInput = E> + Sync + Send,
+    C: HttpOtlpForwarderClient,
+>(
+    event_payload: E,
+    parser: &P,
+    source_identifier: &str,
+    http_client: &C,
+    compaction_config: &SpanCompactionConfig,
+) -> Result<()> {
+    info!("Starting to process event batch.");
+
+    // 1. Parse the event payload
+    let telemetry_items = match parser.parse(event_payload, source_identifier) {
+        Ok(items) => items,
+        Err(e) => {
+            error!(error = %e, "Failed to parse event payload.");
+            return Err(e.context("Event parsing failed"));
+        }
+    };
+
+    if telemetry_items.is_empty() {
+        info!("No telemetry items to process after parsing.");
+        return Ok(());
+    }
+    debug!(
+        "Successfully parsed {} telemetry items.",
+        telemetry_items.len()
+    );
+
+    // 2. Compact the telemetry items into a single TelemetryData object
+    let compacted_telemetry = match compact_telemetry_payloads(telemetry_items, compaction_config) {
+        Ok(compacted) => compacted,
+        Err(e) => {
+            error!(error = %e, "Failed to compact telemetry items.");
+            return Err(e.context("Telemetry compaction failed"));
+        }
+    };
+    debug!("Successfully compacted telemetry items.");
+
+    // 3. Send the compacted telemetry batch
+    match send_telemetry_batch(http_client, compacted_telemetry).await {
+        Ok(_) => {
+            info!("Successfully sent telemetry batch.");
+            Ok(())
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to send telemetry batch.");
+            Err(e.context("Sending telemetry batch failed"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core_parser::EventParser;
+    use crate::telemetry::TelemetryData;
+    use anyhow::anyhow;
+    use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+    use prost::Message;
+    use reqwest::Client as ReqwestClient;
+    use sealed_test::prelude::*;
+    use std::env;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct EnvVarGuard {
+        name: String,
+        original_value: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        #[allow(dead_code)]
+        fn set(name: &str, value: &str) -> Self {
+            let original_value = env::var(name).ok();
+            env::set_var(name, value);
+            Self {
+                name: name.to_string(),
+                original_value,
+            }
+        }
+
+        #[allow(dead_code)]
+        fn remove(name: &str) -> Self {
+            let original_value = env::var(name).ok();
+            env::remove_var(name);
+            Self {
+                name: name.to_string(),
+                original_value,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(val) = &self.original_value {
+                env::set_var(&self.name, val);
+            } else {
+                env::remove_var(&self.name);
+            }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct MockEventInput {
+        records: Vec<String>,
+        produce_valid_otlp_for_compaction: bool,
+    }
+
+    struct MockSuccessfulParser;
+    impl EventParser for MockSuccessfulParser {
+        type EventInput = MockEventInput;
+        fn parse(
+            &self,
+            event_payload: Self::EventInput,
+            _source_identifier: &str,
+        ) -> Result<Vec<TelemetryData>> {
+            let items = event_payload
+                .records
+                .into_iter()
+                .enumerate()
+                .map(|(i, r)| {
+                    let payload_bytes = if event_payload.produce_valid_otlp_for_compaction {
+                        let request = ExportTraceServiceRequest {
+                            resource_spans: vec![
+                                opentelemetry_proto::tonic::trace::v1::ResourceSpans {
+                                    scope_spans: vec![
+                                        opentelemetry_proto::tonic::trace::v1::ScopeSpans {
+                                            spans: vec![
+                                                opentelemetry_proto::tonic::trace::v1::Span {
+                                                    name: format!("test-span-{r}-{i}"),
+                                                    ..Default::default()
+                                                },
+                                            ],
+                                            ..Default::default()
+                                        },
+                                    ],
+                                    ..Default::default()
+                                },
+                            ],
+                        };
+                        request.encode_to_vec()
+                    } else {
+                        r.into_bytes()
+                    };
+
+                    TelemetryData {
+                        payload: payload_bytes,
+                        source: "mock_source".to_string(),
+                        endpoint: "mock_endpoint".to_string(),
+                        content_type: "application/x-protobuf".to_string(),
+                        content_encoding: None,
+                    }
+                })
+                .collect();
+            Ok(items)
+        }
+    }
+
+    struct MockFailingParser;
+    impl EventParser for MockFailingParser {
+        type EventInput = MockEventInput;
+        fn parse(
+            &self,
+            _event_payload: Self::EventInput,
+            _source_identifier: &str,
+        ) -> Result<Vec<TelemetryData>> {
+            Err(anyhow!("Mock parser failed intentionally"))
+        }
+    }
+
+    struct MockEmptyParser;
+    impl EventParser for MockEmptyParser {
+        type EventInput = MockEventInput;
+        fn parse(
+            &self,
+            _event_payload: Self::EventInput,
+            _source_identifier: &str,
+        ) -> Result<Vec<TelemetryData>> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_process_event_batch_success() {
+        let server = MockServer::start().await;
+        let http_client = ReqwestClient::new();
+        let parser = MockSuccessfulParser;
+        let event = MockEventInput {
+            records: vec!["data1".to_string(), "data2".to_string()],
+            produce_valid_otlp_for_compaction: true,
+        };
+        let compaction_config = SpanCompactionConfig::default();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/traces"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _g = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}/v1/traces", server.uri()),
+        );
+
+        let result = process_event_batch(
+            event,
+            &parser,
+            "test_source",
+            &http_client,
+            &compaction_config,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "process_event_batch failed: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_process_event_batch_parser_fails() {
+        let http_client = ReqwestClient::new();
+        let parser = MockFailingParser;
+        let event = MockEventInput {
+            records: vec!["data1".to_string()],
+            produce_valid_otlp_for_compaction: false,
+        };
+        let compaction_config = SpanCompactionConfig::default();
+
+        let _g = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+        let result = process_event_batch(
+            event,
+            &parser,
+            "test_source",
+            &http_client,
+            &compaction_config,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Event parsing failed"));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_process_event_batch_empty_after_parsing() {
+        let http_client = ReqwestClient::new();
+        let parser = MockEmptyParser;
+        let event = MockEventInput {
+            records: vec![],
+            produce_valid_otlp_for_compaction: false,
+        };
+        let compaction_config = SpanCompactionConfig::default();
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+        let _g = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}/v1/traces", server.uri()),
+        );
+
+        let result = process_event_batch(
+            event,
+            &parser,
+            "test_source_empty_parse",
+            &http_client,
+            &compaction_config,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "Expected Ok for empty telemetry items, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_process_event_batch_sender_fails() {
+        let server = MockServer::start().await;
+        let http_client = ReqwestClient::new();
+        let parser = MockSuccessfulParser;
+        let event = MockEventInput {
+            records: vec!["data1".to_string()],
+            produce_valid_otlp_for_compaction: true,
+        };
+        let compaction_config = SpanCompactionConfig::default();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/traces"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _g = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}/v1/traces", server.uri()),
+        );
+
+        let result = process_event_batch(
+            event,
+            &parser,
+            "test_source",
+            &http_client,
+            &compaction_config,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Sending telemetry batch failed"));
+    }
+}

--- a/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
@@ -34,8 +34,6 @@ pub enum CompressionPreference {
 /// Configuration for span compaction
 #[derive(Debug, Clone)]
 pub struct SpanCompactionConfig {
-    /// Maximum size of a structurally compacted payload in bytes (before final compression)
-    pub max_payload_size: usize, // This check is not yet implemented, placeholder
     /// Compression preference for the final payload
     pub compression: CompressionPreference,
     /// GZIP compression level (0-9) if Gzip compression is used
@@ -86,7 +84,6 @@ impl Default for SpanCompactionConfig {
             .unwrap_or(default_compression_level);
 
         Self {
-            max_payload_size: 5_000_000, // 5MB
             compression: compression_preference,
             gzip_compression_level, // Use the determined level
         }
@@ -383,7 +380,6 @@ mod tests {
         let telemetry = create_test_telemetry_uncompressed(1, "s1");
         let config = SpanCompactionConfig {
             compression: CompressionPreference::Gzip,
-            max_payload_size: 5_000_000,
             gzip_compression_level: 9,
         };
         let result = compact_telemetry_payloads(vec![telemetry.clone()], &config).unwrap();
@@ -395,7 +391,6 @@ mod tests {
         let telemetry = create_test_telemetry_uncompressed(1, "s1");
         let config = SpanCompactionConfig {
             compression: CompressionPreference::None,
-            max_payload_size: 5_000_000,
             gzip_compression_level: 9,
         };
         let result = compact_telemetry_payloads(vec![telemetry.clone()], &config).unwrap();
@@ -409,7 +404,6 @@ mod tests {
         let telemetry2 = create_test_telemetry_uncompressed(3, "s2");
         let config = SpanCompactionConfig {
             compression: CompressionPreference::Gzip,
-            max_payload_size: 5_000_000,
             gzip_compression_level: 9,
         };
         let result = compact_telemetry_payloads(vec![telemetry1, telemetry2], &config).unwrap();
@@ -431,7 +425,6 @@ mod tests {
         let telemetry2 = create_test_telemetry_uncompressed(3, "s2");
         let config = SpanCompactionConfig {
             compression: CompressionPreference::None,
-            max_payload_size: 5_000_000,
             gzip_compression_level: 9,
         };
         let result = compact_telemetry_payloads(vec![telemetry1, telemetry2], &config).unwrap();
@@ -460,7 +453,6 @@ mod tests {
         };
         let config = SpanCompactionConfig {
             compression: CompressionPreference::None,
-            max_payload_size: 5_000_000,
             gzip_compression_level: 9,
         };
         let result =

--- a/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
@@ -1,0 +1,495 @@
+//! Module for compacting multiple OTLP span payloads into a single request
+
+use anyhow::Result; // Changed from LambdaError
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use prost::Message;
+use std::env;
+use tracing::{self, instrument}; // For reading environment variables
+
+use crate::telemetry::TelemetryData; // This should be correct once telemetry.rs is in the same crate
+
+/// Decodes a protobuf-serialized OTLP payload
+///
+/// This function assumes the payload is in binary protobuf format and not compressed.
+fn decode_otlp_payload(payload: &[u8]) -> Result<ExportTraceServiceRequest> {
+    // Changed from LambdaError
+    // Decode protobuf directly
+    ExportTraceServiceRequest::decode(payload)
+        .map_err(|e| anyhow::anyhow!("Failed to decode protobuf: {}", e)) // Changed from LambdaError
+}
+
+/// Encodes an OTLP request to binary protobuf format (uncompressed)
+fn encode_otlp_payload(request: &ExportTraceServiceRequest) -> Vec<u8> {
+    // Serialize to protobuf
+    request.encode_to_vec()
+}
+
+/// Enum to represent OTLP compression preference
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompressionPreference {
+    Gzip,
+    None,
+}
+
+/// Configuration for span compaction
+#[derive(Debug, Clone)]
+pub struct SpanCompactionConfig {
+    /// Maximum size of a structurally compacted payload in bytes (before final compression)
+    pub max_payload_size: usize, // This check is not yet implemented, placeholder
+    /// Compression preference for the final payload
+    pub compression: CompressionPreference,
+    /// GZIP compression level (0-9) if Gzip compression is used
+    pub gzip_compression_level: u32,
+}
+
+impl Default for SpanCompactionConfig {
+    fn default() -> Self {
+        let compression_preference = env::var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
+            .or_else(|_| env::var("OTEL_EXPORTER_OTLP_COMPRESSION"))
+            .ok()
+            .map_or(CompressionPreference::None, |val| { // Default to None if var is not set
+                match val.to_lowercase().as_str() {
+                    "gzip" => CompressionPreference::Gzip,
+                    "none" => CompressionPreference::None, // Explicitly none
+                    _ => { // Any other value, including empty string if var is set but empty, or invalid
+                        tracing::warn!(
+                            "Invalid or unrecognized value for OTEL_EXPORTER_OTLP_COMPRESSION: '{}'. Defaulting to no compression.", 
+                            val
+                        );
+                        CompressionPreference::None
+                    }
+                }
+            });
+
+        let default_compression_level = 9;
+        let gzip_compression_level = env::var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL")
+            .ok()
+            .and_then(|val_str| {
+                match val_str.parse::<u32>() {
+                    Ok(level) if (0..=9).contains(&level) => Some(level),
+                    Ok(_) => {
+                        tracing::warn!(
+                            "Invalid value for OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL: '{}'. Must be between 0 and 9. Defaulting to {}.",
+                            val_str, default_compression_level
+                        );
+                        None // Will cause fallback to default_compression_level
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "Failed to parse OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL: '{}'. Defaulting to {}.",
+                            val_str, default_compression_level
+                        );
+                        None // Will cause fallback to default_compression_level
+                    }
+                }
+            })
+            .unwrap_or(default_compression_level);
+
+        Self {
+            max_payload_size: 5_000_000, // 5MB
+            compression: compression_preference,
+            gzip_compression_level, // Use the determined level
+        }
+    }
+}
+
+/// Compacts multiple telemetry payloads into a single payload
+/// Since all log events in a single Lambda invocation come from the same log group,
+/// we can assume they all have the same metadata (source, endpoint, headers)
+#[instrument(name="span_compactor/compact_telemetry_payloads", skip_all, fields(compact_telemetry_payloads.records.count = batch.len() as i64, compression = ?config.compression))]
+pub fn compact_telemetry_payloads(
+    batch: Vec<TelemetryData>,
+    config: &SpanCompactionConfig,
+) -> Result<TelemetryData> {
+    // Changed from LambdaError
+    if batch.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Cannot compact an empty batch of telemetry data."
+        ));
+    }
+
+    // If only one item, just apply compression preference based on config and return
+    if batch.len() == 1 {
+        let mut telemetry_to_return = batch.into_iter().next().unwrap();
+        // Input TelemetryData.payload is expected to be uncompressed protobuf.
+        // TelemetryData.content_encoding is expected to be None.
+        match config.compression {
+            CompressionPreference::Gzip => {
+                // compress() method itself should be idempotent or handle already compressed state if necessary,
+                // but our contract is that input TelemetryData here is uncompressed.
+                telemetry_to_return
+                    .compress(config.gzip_compression_level)
+                    .map_err(|e| anyhow::anyhow!("Failed to compress single payload: {}", e))?;
+            }
+            CompressionPreference::None => {
+                // Ensure content_encoding is None. Payload is already uncompressed per contract.
+                telemetry_to_return.content_encoding = None;
+            }
+        }
+        return Ok(telemetry_to_return);
+    }
+
+    // Proceed with structural compaction for batch.len() > 1
+    let original_count = batch.len();
+    let mut decoded_requests = Vec::new();
+
+    // Get metadata from the first element before consuming the batch by value.
+    let first_item_source = batch[0].source.clone();
+    let first_item_endpoint = batch[0].endpoint.clone();
+
+    for telemetry_item in batch {
+        // Consume batch
+        match decode_otlp_payload(&telemetry_item.payload) {
+            Ok(request) => decoded_requests.push(request),
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to decode TelemetryData payload for compaction: {}. Skipping item.",
+                    e
+                );
+            }
+        }
+    }
+
+    if decoded_requests.is_empty() {
+        return Err(anyhow::anyhow!(
+            "All payloads in batch failed to decode for compaction"
+        ));
+    }
+
+    let mut merged_resource_spans = Vec::new();
+    for request in decoded_requests {
+        merged_resource_spans.extend(request.resource_spans);
+    }
+
+    let merged_request = ExportTraceServiceRequest {
+        resource_spans: merged_resource_spans,
+    };
+
+    let merged_payload = encode_otlp_payload(&merged_request);
+
+    let mut result_telemetry_data = TelemetryData {
+        source: first_item_source,     // Use cloned metadata
+        endpoint: first_item_endpoint, // Use cloned metadata
+        payload: merged_payload,
+        content_type: "application/x-protobuf".to_string(),
+        content_encoding: None, // Start as uncompressed before final compression decision
+    };
+
+    match config.compression {
+        CompressionPreference::Gzip => {
+            result_telemetry_data
+                .compress(config.gzip_compression_level)
+                .map_err(|e| anyhow::anyhow!("Failed to compress merged payload: {}", e))?;
+        }
+        CompressionPreference::None => {
+            // Ensure content_encoding is None (already set as default if not compressed)
+            result_telemetry_data.content_encoding = None;
+        }
+    }
+
+    tracing::info!(
+        "Compacted {} telemetry items into a single request. Final compression: {:?}.",
+        original_count,
+        result_telemetry_data.content_encoding
+    );
+    Ok(result_telemetry_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::telemetry::TelemetryData; // Ensure TelemetryData is in scope for tests
+    use flate2::read::GzDecoder;
+    use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
+    use serial_test::serial;
+    use std::io::Read; // For tests that modify environment variables
+
+    // Helper function to create a test ExportTraceServiceRequest with a specified number of spans
+    fn create_test_request(span_count: usize) -> ExportTraceServiceRequest {
+        let mut spans = Vec::new();
+        for i in 0..span_count {
+            spans.push(Span {
+                name: format!("test-span-{i}"),
+                ..Default::default()
+            });
+        }
+
+        ExportTraceServiceRequest {
+            resource_spans: vec![ResourceSpans {
+                scope_spans: vec![ScopeSpans {
+                    spans,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        }
+    }
+
+    // Helper function to create a test TelemetryData with a specified number of spans
+    fn create_test_telemetry_uncompressed(span_count: usize, source: &str) -> TelemetryData {
+        let request = create_test_request(span_count);
+        let payload = encode_otlp_payload(&request);
+
+        TelemetryData {
+            source: source.to_string(),
+            endpoint: "http://example.com/v1/traces".to_string(),
+            payload,
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None, // Uncompressed for testing
+        }
+    }
+
+    #[test]
+    fn test_decode_encode_roundtrip() {
+        // Create a simple request
+        let request = create_test_request(1);
+
+        // Encode it
+        let encoded = encode_otlp_payload(&request);
+
+        // Decode it back
+        let decoded = decode_otlp_payload(&encoded).unwrap();
+
+        // Verify resource_spans count is the same
+        assert_eq!(request.resource_spans.len(), decoded.resource_spans.len());
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_span_compaction_config_default_is_none_if_no_env_var() {
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.compression, CompressionPreference::None);
+        assert_eq!(config.gzip_compression_level, 9);
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_span_compaction_config_env_none_explicitly() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION", "none");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.compression, CompressionPreference::None);
+        assert_eq!(config.gzip_compression_level, 9); // Default level
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_span_compaction_config_env_gzip_explicitly() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.compression, CompressionPreference::Gzip);
+        assert_eq!(config.gzip_compression_level, 9); // Default level
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_span_compaction_config_env_traces_precedence_gzip() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", "gzip");
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION", "none"); // Should be ignored
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.compression, CompressionPreference::Gzip);
+        assert_eq!(config.gzip_compression_level, 9);
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_span_compaction_config_env_traces_precedence_none() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", "none");
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION", "gzip"); // Should be ignored
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.compression, CompressionPreference::None);
+        assert_eq!(config.gzip_compression_level, 9);
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_span_compaction_config_invalid_env_defaults_to_none() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION", "invalid_value");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.compression, CompressionPreference::None);
+        assert_eq!(config.gzip_compression_level, 9);
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_compression_level_env_var_valid() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL", "5");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.gzip_compression_level, 5);
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_compression_level_env_var_invalid_string() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL", "not_a_number");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.gzip_compression_level, 9); // Should default
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_compression_level_env_var_invalid_too_high() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL", "10");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.gzip_compression_level, 9); // Should default
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_compression_level_env_var_invalid_negative() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL", "-1");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.gzip_compression_level, 9); // Should default
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_compression_level_env_var_empty_string() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL", "");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.gzip_compression_level, 9); // Should default
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+    }
+
+    #[test]
+    #[serial] // Modifies env vars
+    fn test_compression_level_zero_is_valid() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL", "0");
+        let config = SpanCompactionConfig::default();
+        assert_eq!(config.gzip_compression_level, 0);
+        std::env::remove_var("OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL");
+    }
+
+    #[test]
+    fn test_compact_single_payload_with_gzip_preference() {
+        let telemetry = create_test_telemetry_uncompressed(1, "s1");
+        let config = SpanCompactionConfig {
+            compression: CompressionPreference::Gzip,
+            max_payload_size: 5_000_000,
+            gzip_compression_level: 9,
+        };
+        let result = compact_telemetry_payloads(vec![telemetry.clone()], &config).unwrap();
+        assert_eq!(result.content_encoding, Some("gzip".to_string()));
+    }
+
+    #[test]
+    fn test_compact_single_payload_with_none_preference() {
+        let telemetry = create_test_telemetry_uncompressed(1, "s1");
+        let config = SpanCompactionConfig {
+            compression: CompressionPreference::None,
+            max_payload_size: 5_000_000,
+            gzip_compression_level: 9,
+        };
+        let result = compact_telemetry_payloads(vec![telemetry.clone()], &config).unwrap();
+        assert_eq!(result.content_encoding, None);
+        assert_eq!(result.payload, telemetry.payload); // Payload should be unchanged if already uncompressed
+    }
+
+    #[test]
+    fn test_compact_multiple_payloads_with_gzip_preference() {
+        let telemetry1 = create_test_telemetry_uncompressed(2, "s1");
+        let telemetry2 = create_test_telemetry_uncompressed(3, "s2");
+        let config = SpanCompactionConfig {
+            compression: CompressionPreference::Gzip,
+            max_payload_size: 5_000_000,
+            gzip_compression_level: 9,
+        };
+        let result = compact_telemetry_payloads(vec![telemetry1, telemetry2], &config).unwrap();
+        assert_eq!(result.content_encoding, Some("gzip".to_string()));
+        let mut decoder = GzDecoder::new(&result.payload[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+        let decoded_request = ExportTraceServiceRequest::decode(decompressed.as_slice()).unwrap();
+        assert_eq!(
+            decoded_request.resource_spans[0].scope_spans[0].spans.len()
+                + decoded_request.resource_spans[1].scope_spans[0].spans.len(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_compact_multiple_payloads_with_none_preference() {
+        let telemetry1 = create_test_telemetry_uncompressed(2, "s1");
+        let telemetry2 = create_test_telemetry_uncompressed(3, "s2");
+        let config = SpanCompactionConfig {
+            compression: CompressionPreference::None,
+            max_payload_size: 5_000_000,
+            gzip_compression_level: 9,
+        };
+        let result = compact_telemetry_payloads(vec![telemetry1, telemetry2], &config).unwrap();
+        assert_eq!(result.content_encoding, None);
+        let decoded_request = ExportTraceServiceRequest::decode(result.payload.as_slice()).unwrap();
+        assert_eq!(
+            decoded_request.resource_spans[0].scope_spans[0].spans.len()
+                + decoded_request.resource_spans[1].scope_spans[0].spans.len(),
+            5
+        );
+    }
+
+    #[test]
+    fn test_compact_empty_batch_returns_error() {
+        let config = SpanCompactionConfig::default();
+        let result = compact_telemetry_payloads(Vec::new(), &config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compact_with_one_decode_failure() {
+        let telemetry_good = create_test_telemetry_uncompressed(1, "s1");
+        let telemetry_bad_payload = TelemetryData {
+            payload: vec![0, 1, 2], // Invalid protobuf
+            ..create_test_telemetry_uncompressed(0, "s2")
+        };
+        let config = SpanCompactionConfig {
+            compression: CompressionPreference::None,
+            max_payload_size: 5_000_000,
+            gzip_compression_level: 9,
+        };
+        let result =
+            compact_telemetry_payloads(vec![telemetry_good, telemetry_bad_payload], &config)
+                .unwrap();
+        // Should compact the good one, skipping the bad one
+        let decoded_request = ExportTraceServiceRequest::decode(result.payload.as_slice()).unwrap();
+        assert_eq!(
+            decoded_request.resource_spans[0].scope_spans[0].spans.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_compact_all_decode_failures() {
+        let telemetry_bad1 = TelemetryData {
+            payload: vec![1],
+            ..create_test_telemetry_uncompressed(0, "s1")
+        };
+        let telemetry_bad2 = TelemetryData {
+            payload: vec![2],
+            ..create_test_telemetry_uncompressed(0, "s2")
+        };
+        let config = SpanCompactionConfig::default();
+        let result = compact_telemetry_payloads(vec![telemetry_bad1, telemetry_bad2], &config);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("All payloads in batch failed to decode"));
+    }
+}

--- a/packages/rust/serverless-otlp-forwarder-core/src/telemetry.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/telemetry.rs
@@ -1,0 +1,336 @@
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose, Engine};
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
+use otlp_stdout_span_exporter::ExporterOutput;
+use prost::Message;
+use serde_json::Value;
+use std::io::{Read, Write};
+use tracing;
+/// Core structure representing telemetry data to be forwarded
+#[derive(Clone, Debug)]
+pub struct TelemetryData {
+    /// Source of the telemetry data (e.g., service name or log group)
+    pub source: String,
+    /// Target endpoint for the telemetry data
+    pub endpoint: String,
+    /// The actual payload bytes
+    pub payload: Vec<u8>,
+    /// Content type of the payload
+    pub content_type: String,
+    /// Optional content encoding (e.g., gzip)
+    pub content_encoding: Option<String>,
+}
+
+impl Default for TelemetryData {
+    fn default() -> Self {
+        Self {
+            source: "unknown".to_string(),
+            // Default endpoint to localhost for the collector extension model
+            endpoint: "http://localhost:4318/v1/traces".to_string(),
+            payload: Vec::new(),
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None, // No compression by default
+        }
+    }
+}
+
+impl TelemetryData {
+    /// Converts payload data to binary protobuf format (uncompressed)
+    ///
+    /// This method ensures that all telemetry data is in a consistent format
+    /// before it reaches the span compactor, which simplifies compaction logic.
+    ///
+    /// # Arguments
+    ///
+    /// * `payload` - The raw payload bytes
+    /// * `content_type` - The content type of the payload
+    /// * `content_encoding` - The optional content encoding of the payload
+    ///
+    /// # Returns
+    ///
+    /// The binary protobuf payload
+    fn convert_to_protobuf(
+        payload: Vec<u8>,
+        content_type: &str,
+        content_encoding: Option<&str>,
+    ) -> Result<Vec<u8>> {
+        tracing::debug!(
+            "Converting payload from {}/{:?} to protobuf",
+            content_type,
+            content_encoding
+        );
+
+        // First, decompress if needed
+        let decompressed = if content_encoding == Some("gzip") {
+            tracing::debug!("Decompressing gzipped payload");
+            let mut decoder = GzDecoder::new(&payload[..]);
+            let mut decompressed = Vec::new();
+            decoder
+                .read_to_end(&mut decompressed)
+                .context("Failed to decompress payload")?;
+            decompressed
+        } else {
+            payload
+        };
+
+        // Then convert to protobuf based on content type
+        match content_type {
+            "application/x-protobuf" => {
+                // Already protobuf, no conversion needed
+                tracing::debug!("Payload already in protobuf format");
+                Ok(decompressed)
+            }
+            "application/json" => {
+                // Convert JSON to protobuf
+                tracing::debug!("Converting JSON to protobuf");
+                Self::convert_json_to_protobuf(&decompressed)
+            }
+            _ => {
+                // Unknown format, log warning and return as-is
+                tracing::warn!("Unknown content type: {}, keeping as is", content_type);
+                Ok(decompressed)
+            }
+        }
+    }
+
+    /// Converts JSON to protobuf using the OTLP schema
+    ///
+    /// Since the JSON schema matches the OTLP protobuf schema, we can directly
+    /// deserialize the JSON into the protobuf structure and then serialize it back
+    /// to binary protobuf format.
+    fn convert_json_to_protobuf(json_bytes: &[u8]) -> Result<Vec<u8>> {
+        // Parse the JSON into an ExportTraceServiceRequest
+        let request: ExportTraceServiceRequest = serde_json::from_slice(json_bytes)
+            .context("Failed to parse JSON as ExportTraceServiceRequest")?;
+
+        // Serialize to protobuf binary format
+        let protobuf_bytes = request.encode_to_vec();
+
+        tracing::debug!(
+            "Successfully converted JSON to protobuf (size: {} bytes)",
+            protobuf_bytes.len()
+        );
+
+        Ok(protobuf_bytes)
+    }
+
+    /// Applies gzip compression to the payload
+    ///
+    /// This should only be called on the final compacted payload
+    /// to avoid unnecessary compression/decompression cycles.
+    pub fn compress(&mut self, compression_level: u32) -> Result<()> {
+        // Only compress if not already compressed
+        if self.content_encoding != Some("gzip".to_string()) {
+            tracing::debug!("Compressing payload with level {}", compression_level);
+
+            let mut encoder = GzEncoder::new(Vec::new(), Compression::new(compression_level));
+            encoder
+                .write_all(&self.payload)
+                .context("Failed to compress payload")?;
+
+            self.payload = encoder.finish().context("Failed to finish compression")?;
+
+            self.content_encoding = Some("gzip".to_string());
+
+            tracing::debug!(
+                "Compressed payload from {} to {} bytes",
+                self.payload.len(), // This was a slight bug, should be original length if we want to show reduction
+                self.payload.len()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Creates a TelemetryData instance from a LogRecord
+    pub fn from_log_record(record: ExporterOutput) -> Result<Self> {
+        // Decode base64 payload
+        let raw_payload = if record.base64 {
+            general_purpose::STANDARD
+                .decode(&record.payload)
+                .context("Failed to decode base64 payload")?
+        } else {
+            record.payload.as_bytes().to_vec()
+        };
+
+        // Convert to uncompressed protobuf format
+        let protobuf_payload = Self::convert_to_protobuf(
+            raw_payload,
+            &record.content_type,
+            Some(&record.content_encoding),
+        )?;
+
+        Ok(Self {
+            source: record.source.clone(),
+            endpoint: record.endpoint.to_string(),
+            payload: protobuf_payload,
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None, // Decompressed at this stage
+        })
+    }
+
+    /// Creates a TelemetryData instance from a raw span (as serialized JSON)
+    pub fn from_raw_span(span: Value, log_group: &str) -> Result<Self> {
+        // Serialize the span data
+        let json_string =
+            serde_json::to_string(&span).context("Failed to serialize span data to JSON string")?;
+
+        let raw_payload = json_string.as_bytes().to_vec();
+
+        // Convert to protobuf format (uncompressed)
+        let protobuf_payload = Self::convert_to_protobuf(raw_payload, "application/json", None)?;
+
+        Ok(Self {
+            source: log_group.to_string(),
+            // Default endpoint to localhost for the collector extension model
+            endpoint: "http://localhost:4318/v1/traces".to_string(),
+            payload: protobuf_payload,
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None, // No compression at this stage
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose, Engine};
+    use flate2::{write::GzEncoder, Compression};
+    use otlp_stdout_span_exporter::ExporterOutput;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use std::io::Write; // Added missing import for tests
+
+    // Helper function to create gzipped, base64-encoded protobuf data
+    fn create_test_payload() -> String {
+        // Create a minimal valid OTLP protobuf payload
+        let request = ExportTraceServiceRequest {
+            resource_spans: vec![],
+        };
+
+        // Convert to protobuf bytes
+        let proto_bytes = request.encode_to_vec();
+
+        // Compress with gzip
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&proto_bytes).unwrap();
+        let compressed_bytes = encoder.finish().unwrap();
+
+        // Base64 encode
+        general_purpose::STANDARD.encode(compressed_bytes)
+    }
+
+    #[test]
+    fn test_from_log_record() {
+        let record = ExporterOutput {
+            version: "test".to_string(),
+            source: "test-service".to_string(),
+            endpoint: "http://example.com".to_string(),
+            method: "POST".to_string(),
+            payload: create_test_payload(),
+            headers: Some(HashMap::new()),
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: "gzip".to_string(),
+            base64: true,
+            level: Some("info".to_string()),
+        };
+
+        let telemetry = TelemetryData::from_log_record(record).unwrap();
+        assert_eq!(telemetry.source, "test-service");
+        assert_eq!(telemetry.endpoint, "http://example.com");
+        assert_eq!(telemetry.content_type, "application/x-protobuf");
+        // Since we're decompressing at from_log_record level, it should be None
+        assert_eq!(telemetry.content_encoding, None);
+    }
+
+    #[test]
+    fn test_from_raw_span() {
+        // Create a valid OTLP JSON structure
+        let span = json!({
+            "resourceSpans": []
+        });
+
+        let telemetry = TelemetryData::from_raw_span(span, "aws/spans").unwrap();
+        assert_eq!(telemetry.source, "aws/spans");
+        assert_eq!(telemetry.content_type, "application/x-protobuf");
+        assert_eq!(telemetry.content_encoding, None); // No compression at this stage
+    }
+
+    #[test]
+    fn test_compress() {
+        // Create a telemetry object with uncompressed data
+        let mut telemetry = TelemetryData {
+            source: "test".to_string(),
+            endpoint: "http://example.com".to_string(),
+            payload: vec![1, 2, 3, 4, 5],
+            content_type: "application/x-protobuf".to_string(),
+            content_encoding: None,
+        };
+
+        // Compress it
+        telemetry.compress(6).unwrap();
+
+        // Verify it's now compressed
+        assert_eq!(telemetry.content_encoding, Some("gzip".to_string()));
+
+        // Decompress to verify the data is intact
+        let mut decoder = GzDecoder::new(&telemetry.payload[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+
+        assert_eq!(decompressed, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_convert_to_protobuf_already_protobuf() {
+        // Test that protobuf data is not modified
+        let original_payload = vec![1, 2, 3, 4];
+        let converted = TelemetryData::convert_to_protobuf(
+            original_payload.clone(),
+            "application/x-protobuf",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(converted, original_payload);
+    }
+
+    #[test]
+    fn test_convert_to_protobuf_from_json() {
+        // Create a minimal valid OTLP JSON payload
+        let json_data = json!({
+            "resourceSpans": []
+        });
+        let json_bytes = serde_json::to_vec(&json_data).unwrap();
+
+        let converted =
+            TelemetryData::convert_to_protobuf(json_bytes, "application/json", None).unwrap();
+
+        // Verify we can decode it as an ExportTraceServiceRequest
+        let request = ExportTraceServiceRequest::decode(converted.as_slice()).unwrap();
+        assert_eq!(request.resource_spans.len(), 0);
+    }
+
+    #[test]
+    fn test_convert_to_protobuf_from_gzipped_json() {
+        // Create a minimal valid OTLP JSON payload
+        let json_data = json!({
+            "resourceSpans": []
+        });
+        let json_bytes = serde_json::to_vec(&json_data).unwrap();
+
+        // Compress it
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&json_bytes).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let converted =
+            TelemetryData::convert_to_protobuf(compressed, "application/json", Some("gzip"))
+                .unwrap();
+
+        // Verify we can decode it as an ExportTraceServiceRequest
+        let request = ExportTraceServiceRequest::decode(converted.as_slice()).unwrap();
+        assert_eq!(request.resource_spans.len(), 0);
+    }
+}

--- a/packages/rust/serverless-otlp-forwarder-core/src/telemetry.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/telemetry.rs
@@ -124,6 +124,7 @@ impl TelemetryData {
         if self.content_encoding != Some("gzip".to_string()) {
             tracing::debug!("Compressing payload with level {}", compression_level);
 
+            let original_size = self.payload.len();
             let mut encoder = GzEncoder::new(Vec::new(), Compression::new(compression_level));
             encoder
                 .write_all(&self.payload)
@@ -135,7 +136,7 @@ impl TelemetryData {
 
             tracing::debug!(
                 "Compressed payload from {} to {} bytes",
-                self.payload.len(), // This was a slight bug, should be original length if we want to show reduction
+                original_size,
                 self.payload.len()
             );
         }


### PR DESCRIPTION
This pull request introduces the `serverless-otlp-forwarder-core` Rust package, along with its associated CI/CD workflow, metadata, and documentation. The changes establish a foundation for publishing, testing, and maintaining the package, which is designed to facilitate serverless telemetry forwarding on AWS Lambda. Key updates include the addition of a GitHub Actions workflow for automated testing and publishing, comprehensive package metadata, and a publishing checklist.

### CI/CD Workflow Setup:
- [`.github/workflows/publish-rust-serverless-otlp-forwarder-core.yml`](diffhunk://#diff-852742a4526c647e85682b6bf3953a3ffd9d8ca23c4e7791bf1f12e0f2f46c21R1-R111): Added a GitHub Actions workflow to automate testing, quality checks, and publishing of the `serverless-otlp-forwarder-core` crate. Includes multi-architecture support (x64 and arm64) and integration with crates.io.

### Package Metadata:
- [`packages/rust/serverless-otlp-forwarder-core/Cargo.toml`](diffhunk://#diff-0d65a7e4f9d9a7025e8f3307492d96e2ae6d69c20728b4603995e79daa07956bR1-R54): Defined package metadata, including name, version, dependencies, and feature flags. Added workspace dependencies for streamlined development and publishing.

### Documentation:
- [`packages/rust/serverless-otlp-forwarder-core/CHANGELOG.md`](diffhunk://#diff-a8c4eca54f7256dffaee36b2c1cb89a2e71869048be4e199ce68a11f8ddeb847R1-R24): Created a changelog documenting the initial release and notable features, adhering to semantic versioning and Keep a Changelog format.
- [`packages/rust/serverless-otlp-forwarder-core/PUBLISHING.md`](diffhunk://#diff-34b6ed08eb21e9be0623b27a03a3e56c7e4b0a740ee34f56d42ce968985dceacR1-R107): Added a detailed publishing checklist to ensure quality and consistency during release cycles, covering Cargo.toml, documentation, code quality, and Git checks.