### PR TITLE
release: packages/rust/lambda-otel-lite v0.17.0

### DIFF
--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2025-07-19
+
+### Added
+- **Custom Sampler Support**: Added comprehensive sampler configuration capabilities
+  - `with_sampler()` method for custom `ShouldSample` trait implementations
+  - `with_named_sampler()` method for convenient access to common sampler types
+  - Environment variable support via `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`
+  - Support for `always_on`, `always_off`, `trace_id_ratio`, and `parent_based` named samplers
+  - Integration with OpenTelemetry's built-in sampler types (`Sampler::AlwaysOn`, `Sampler::AlwaysOff`, etc.)
+  - Added sampler environment variable constants to the constants module
+  - Comprehensive documentation with examples for custom sampler implementations
+  - Added sampler example demonstrating different sampling strategies
+
 ## [0.16.0] - 2025-06-29
 
 ### Added

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ exclude = ["examples/"]
 
 [dependencies]
 # pin to specific version for publishing
-otlp-stdout-span-exporter = { workspace = true }
+otlp-stdout-span-exporter = "0.16.0"
 
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true

--- a/packages/rust/lambda-otel-lite/README.md
+++ b/packages/rust/lambda-otel-lite/README.md
@@ -416,6 +416,124 @@ opentelemetry-aws = "0.16.0"
 
 The XrayIdGenerator formats trace IDs in a way that's compatible with AWS X-Ray, using a timestamp in the first part of the trace ID. This allows X-Ray to display and organize traces correctly, and enables correlation between OpenTelemetry traces and traces from other services that use X-Ray.
 
+### Custom configuration with sampler:
+
+```rust, no_run
+use lambda_otel_lite::{init_telemetry, TelemetryConfig};
+use opentelemetry_sdk::trace::Sampler;
+use lambda_runtime::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let config = TelemetryConfig::builder()
+        // Sample all traces
+        .with_sampler(Sampler::AlwaysOn)
+        .build();
+
+    let (_, completion_handler) = init_telemetry(config).await?;
+
+    // Use the tracer and completion handler as usual
+    
+    Ok(())
+}
+```
+
+You can also use named samplers for convenience:
+
+```rust, no_run
+use lambda_otel_lite::{init_telemetry, TelemetryConfig};
+use lambda_runtime::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let config = TelemetryConfig::builder()
+        // Sample all traces
+        .with_named_sampler("always_on")
+        // Or sample 10% of traces
+        // .with_named_sampler("trace_id_ratio")
+        .build();
+
+    let (_, completion_handler) = init_telemetry(config).await?;
+
+    // Use the tracer and completion handler as usual
+    
+    Ok(())
+}
+```
+
+Available named samplers:
+- `"always_on"`: Sample all traces
+- `"always_off"`: Sample no traces
+- `"trace_id_ratio"`: Sample based on trace ID ratio (uses `OTEL_TRACES_SAMPLER_ARG` environment variable for ratio)
+- `"parent_based"`: Sample based on parent span sampling decision
+
+You can also implement custom samplers by implementing the `ShouldSample` trait:
+
+```rust, no_run
+use lambda_otel_lite::{init_telemetry, TelemetryConfig};
+use opentelemetry::{
+    trace::{SamplingDecision, SamplingResult, SpanKind, TraceId, TraceContextExt},
+    Context, KeyValue,
+};
+use opentelemetry_sdk::trace::{Sampler, ShouldSample};
+use lambda_runtime::Error;
+
+#[derive(Debug, Clone)]
+struct CustomLambdaSampler {
+    base_sampler: Box<dyn ShouldSample>,
+}
+
+impl ShouldSample for CustomLambdaSampler {
+    fn should_sample(
+        &self,
+        parent_context: Option<&Context>,
+        trace_id: TraceId,
+        name: &str,
+        kind: &SpanKind,
+        attributes: &[KeyValue],
+        links: &[opentelemetry::trace::Link],
+    ) -> SamplingResult {
+        // Simple example: sample all spans with "error" in the name
+        if name.contains("error") {
+            return SamplingResult {
+                decision: SamplingDecision::RecordAndSample,
+                attributes: vec![KeyValue::new("sampler.type", "error_sampler")],
+                trace_state: opentelemetry::trace::TraceState::default(),
+            };
+        }
+
+        // Use base sampler for normal spans
+        self.base_sampler.should_sample(
+            parent_context,
+            trace_id,
+            name,
+            kind,
+            attributes,
+            links,
+        )
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let config = TelemetryConfig::builder()
+        .with_sampler(CustomLambdaSampler {
+            base_sampler: Box::new(Sampler::TraceIdRatioBased(0.1)),
+        })
+        .build();
+
+    let (_, completion_handler) = init_telemetry(config).await?;
+
+    // Use the tracer and completion handler as usual
+    
+    Ok(())
+}
+```
+
+Samplers can also be configured via environment variables:
+- `OTEL_TRACES_SAMPLER`: Sampler type (`always_on`, `always_off`, `trace_id_ratio`, `parent_based`)
+- `OTEL_TRACES_SAMPLER_ARG`: Sampler argument (e.g., ratio for `trace_id_ratio` sampler)
+
 ### Using the Tower Layer
 You can "wrap" your handler in the `OtelTracingLayer` using the `ServiceBuilder` from the `tower` crate:
 
@@ -970,6 +1088,15 @@ Resource attributes from environment variables are only included in the resource
 ### Export Configuration
 
 - `OTLP_STDOUT_SPAN_EXPORTER_COMPRESSION_LEVEL`: GZIP compression level (0-9, default: 6)
+
+### Sampling Configuration
+
+- `OTEL_TRACES_SAMPLER`: Sampler type for OpenTelemetry traces
+  - `"always_on"`: Sample all traces (default)
+  - `"always_off"`: Sample no traces
+  - `"trace_id_ratio"`: Sample based on trace ID ratio
+  - `"parent_based"`: Sample based on parent span sampling decision
+- `OTEL_TRACES_SAMPLER_ARG`: Sampler argument (e.g., ratio for `trace_id_ratio` sampler, default: 1.0)
 
 ### Logging and Debug
 - `RUST_LOG` or `AWS_LAMBDA_LOG_LEVEL`: Configure log levels

--- a/packages/rust/lambda-otel-lite/examples/sampler/main.rs
+++ b/packages/rust/lambda-otel-lite/examples/sampler/main.rs
@@ -1,0 +1,57 @@
+use lambda_otel_lite::{init_telemetry, TelemetryConfig};
+use lambda_runtime::{service_fn, Error, LambdaEvent, Runtime};
+use opentelemetry::trace::{TraceContextExt, Tracer};
+use opentelemetry_sdk::trace::Sampler;
+use serde_json::Value;
+
+async fn handler(_event: LambdaEvent<Value>) -> Result<Value, Error> {
+    // Get the global tracer
+    let tracer = opentelemetry::global::tracer("sampler-example");
+
+    // Create some spans to demonstrate sampling
+    tracer.in_span("normal-operation", |cx| {
+        cx.span()
+            .set_attribute(opentelemetry::KeyValue::new("operation.type", "normal"));
+        // Simulate some work
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    });
+
+    tracer.in_span("error-operation", |cx| {
+        cx.span()
+            .set_attribute(opentelemetry::KeyValue::new("operation.type", "error"));
+        // Simulate some work
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    });
+
+    Ok(serde_json::json!({
+        "message": "Sampler example completed",
+        "sampled_spans": "Check your telemetry backend to see which spans were sampled"
+    }))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Initialize telemetry with custom sampler
+    let config = TelemetryConfig::builder()
+        // Example 1: Sample all traces
+        .with_sampler(Sampler::AlwaysOn)
+        // Example 2: Sample 50% of traces
+        // .with_sampler(Sampler::TraceIdRatioBased(0.5))
+        // Example 3: Sample no traces
+        // .with_sampler(Sampler::AlwaysOff)
+        // Example 4: Parent-based sampling
+        // .with_sampler(Sampler::ParentBased(Box::new(Sampler::AlwaysOn)))
+        .build();
+
+    let (_, completion_handler) = init_telemetry(config).await?;
+
+    let handler = service_fn(handler);
+
+    // Run the Lambda runtime
+    Runtime::new(handler).run().await?;
+
+    // Complete telemetry processing
+    completion_handler.complete();
+
+    Ok(())
+}

--- a/packages/rust/lambda-otel-lite/src/constants.rs
+++ b/packages/rust/lambda-otel-lite/src/constants.rs
@@ -30,6 +30,13 @@ pub mod env_vars {
     /// Controls whether to enable the fmt layer for logging regardless of code settings.
     /// Set to "true" to force enable logging output.
     pub const ENABLE_FMT_LAYER: &str = "LAMBDA_TRACING_ENABLE_FMT_LAYER";
+
+    /// Sampler type for OpenTelemetry traces.
+    /// Valid values: always_on, always_off, trace_id_ratio, parent_based
+    pub const TRACES_SAMPLER: &str = "OTEL_TRACES_SAMPLER";
+
+    /// Sampler argument (e.g., ratio for trace_id_ratio sampler).
+    pub const TRACES_SAMPLER_ARG: &str = "OTEL_TRACES_SAMPLER_ARG";
 }
 
 /// Default values for configuration parameters.


### PR DESCRIPTION
This pull request introduces a new version (`0.17.0`) of the `lambda-otel-lite` package, with a focus on adding extensive support for custom trace sampling configurations. The changes include new methods for configuring samplers, environment variable support, examples, and tests to validate these features. Additionally, documentation and examples have been updated to reflect these enhancements.

### Key Changes:

#### New Features for Sampling Configuration:
* Added `with_sampler()` and `with_named_sampler()` methods to the `TelemetryConfigBuilder` for custom and named sampler configurations, respectively. Supported samplers include `always_on`, `always_off`, `trace_id_ratio`, and `parent_based`. [[1]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6R428-R503) [[2]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6R662-R690)
* Introduced environment variable support for configuring samplers via `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`. [[1]](diffhunk://#diff-12ef7660237b8592ada3c92cfb4992335f23fb3492c8681cd775630d1835dbfdR33-R39) [[2]](diffhunk://#diff-12e540601f25150dea6d8f3d1da7dd92b2e7b1c8100696849434ddb1d5ec32f6R662-R690)
* Updated the `constants` module to include new sampler-related constants.

#### Documentation and Examples:
* Enhanced the `README.md` with detailed examples and explanations for using custom and named samplers, including code snippets for various sampling strategies. [[1]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aR419-R536) [[2]](diffhunk://#diff-1c26ba0d854aa5ea68e0f15ae91f4cad8300defcce057be8cecb5f54be8d612aR1092-R1100)
* Added a new example (`examples/sampler/main.rs`) demonstrating the use of different samplers in practice.

#### Tests:
* Added unit tests to validate the functionality of custom and named samplers, as well as environment variable-based sampler configuration.

#### Version and Dependency Updates:
* Updated the package version to `0.17.0` in `Cargo.toml`.
* Pinned the `otlp-stdout-span-exporter` dependency to version `0.16.0` for publishing.

#### Minor Code Refinements:
* Improved formatting and consistency in existing code and examples. [[1]](diffhunk://#diff-22064b0d8d0691fe75a244b7ddb3e3e7449e2f1d839494f3ad22c4dec305f18cL6-R6) [[2]](diffhunk://#diff-22064b0d8d0691fe75a244b7ddb3e3e7449e2f1d839494f3ad22c4dec305f18cL172-R186) [[3]](diffhunk://#diff-22064b0d8d0691fe75a244b7ddb3e3e7449e2f1d839494f3ad22c4dec305f18cL208-R212)

These changes collectively enhance the flexibility and usability of the `lambda-otel-lite` package for trace sampling, making it easier to configure and integrate with OpenTelemetry.