### PR TITLE
Codex/fix cli release gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
  "opentelemetry-aws",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "otlp-stdout-span-exporter 0.17.0",
  "pin-project",
  "rand 0.9.1",
  "reqwest 0.12.20",
@@ -2454,7 +2454,7 @@ dependencies = [
  "lambda_runtime",
  "opentelemetry",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter 0.17.1",
  "rand 0.9.1",
  "serde_json",
  "tokio",
@@ -2562,7 +2562,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "livetrace"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2582,7 +2582,7 @@ dependencies = [
  "indexmap 2.10.0",
  "indicatif",
  "opentelemetry-proto",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter 0.17.1",
  "prost",
  "regex",
  "reqwest 0.12.20",
@@ -2974,7 +2974,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter 0.17.1",
  "prost",
  "rand 0.9.1",
  "serde",
@@ -2999,7 +2999,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter 0.17.1",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-tracing",
@@ -3025,7 +3025,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter 0.17.1",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-tracing",
@@ -3035,27 +3035,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "otlp-stdout-span-exporter"
-version = "0.17.0"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bon",
- "doc-comment",
- "flate2",
- "log",
- "nix",
- "opentelemetry",
- "opentelemetry-proto",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "serial_test",
- "tokio",
 ]
 
 [[package]]
@@ -3077,6 +3056,27 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "otlp-stdout-span-exporter"
+version = "0.17.1"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bon",
+ "doc-comment",
+ "flate2",
+ "log",
+ "nix",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -4311,7 +4311,7 @@ dependencies = [
  "lambda-otel-lite",
  "lambda_runtime",
  "opentelemetry-proto",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter 0.17.1",
  "prost",
  "reqwest 0.12.20",
  "reqwest 0.13.2",
@@ -4459,7 +4459,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "startled"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ otlp-sigv4-client = { version = "0.13.0", path = "packages/rust/otlp-sigv4-clien
 lambda-lw-http-router = { version = "0.6.0", path = "packages/rust/lambda-lw-http-router" }
 lambda-lw-http-router-core = { version = "0.6.0", path = "packages/rust/lambda-lw-http-router/router-core" }
 lambda-lw-http-router-macro = { version = "0.6.0", path = "packages/rust/lambda-lw-http-router/router-macro" }
-otlp-stdout-span-exporter = { version = "0.17.0", path = "packages/rust/otlp-stdout-span-exporter" }
+otlp-stdout-span-exporter = { version = "0.17.1", path = "packages/rust/otlp-stdout-span-exporter" }
 lambda-otel-lite = { version = "0.19.0", path = "packages/rust/lambda-otel-lite" }
 otlp-stdout-logs-processor = { path = "forwarders/otlp-stdout-logs-processor/processor" }
 serverless-otlp-forwarder-core = { version = "0.2.0", path = "packages/rust/serverless-otlp-forwarder-core" }

--- a/cli/livetrace/CHANGELOG.md
+++ b/cli/livetrace/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-01
+
+### Fixed
+- Updated test fixtures for the current OpenTelemetry proto `Resource` shape by setting `entity_refs`.
+- Restored the CLI release-quality gate on the current workspace dependency set.
+
 ## [0.2.1] - 2025-05-18
 
 ### Changed
@@ -52,6 +58,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated copyright year in LICENSE to 2025.
 
 ## [Unreleased]
-
-### Added
-- Initial project setup.

--- a/cli/livetrace/Cargo.toml
+++ b/cli/livetrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livetrace"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/livetrace/RELEASE_NOTES.md
+++ b/cli/livetrace/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## livetrace v0.2.2 - 2026-04-01
+
+This patch release restores `livetrace` compatibility with the current OpenTelemetry workspace and keeps the CLI release gate green on current Rust/Clippy tooling.
+
+### Fixes
+
+* **OpenTelemetry proto compatibility:** Updated test fixtures to include the current `Resource.entity_refs` field required by the generated proto types.
+* **Release readiness:** Revalidated `fmt`, `clippy`, `test`, and `build` for the CLI against the current workspace dependency graph.
+
 ## livetrace v0.2.1 - 2025-05-18
 
 This minor release of `livetrace` introduces a new screenshot of the `livetrace` CLI in action.
@@ -43,4 +52,3 @@ This release of `livetrace` introduces powerful new filtering and log fetching c
     *   Added `regex` crate to support the new `--grep` feature.
 
 For a detailed list of all individual changes, bug fixes, and commits, please see the [CHANGELOG.md](https://github.com/dev7a/serverless-otlp-forwarder/blob/main/cli/livetrace/CHANGELOG.md).
-

--- a/cli/livetrace/src/processing.rs
+++ b/cli/livetrace/src/processing.rs
@@ -311,6 +311,7 @@ mod tests {
                         }),
                     }],
                     dropped_attributes_count: 0,
+                    entity_refs: vec![],
                 }),
                 scope_spans: vec![ScopeSpans {
                     // ... add scope/spans if needed for specific tests
@@ -545,6 +546,7 @@ mod tests {
                         }),
                     }],
                     dropped_attributes_count: 0,
+                    entity_refs: vec![],
                 }),
                 scope_spans: vec![ScopeSpans {
                     ..Default::default()

--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-04-01
+
+### Fixed
+- Updated the Lambda invocation path to satisfy current Clippy checks without changing proxy invocation behavior.
+- Restored the CLI release-quality gate on current workspace dependencies and Rust toolchains.
+
 ## [0.9.0] - 2025-06-28
 
 ### Added
@@ -217,4 +223,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated `startled` CLI version from 0.1.0 to 0.1.1 in `Cargo.toml`.
-

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+# Release Notes for startled v0.9.1
+
+This patch release restores the `startled` release-quality gate on the current workspace and Rust toolchain without changing user-facing benchmark behavior.
+
+### Fixes
+
+* **Clippy compatibility:** Simplified the Lambda proxy invocation branch to satisfy current Clippy checks while preserving existing runtime behavior.
+* **Release readiness:** Revalidated `fmt`, `clippy`, `test`, and `build` for the CLI with the current dependency set.
+
+---
+
 # Release Notes for startled v0.9.0
 
 This release introduces significant updates to the `startled` CLI tool, focusing on the addition of a production-ready proxy Lambda function for enhanced benchmarking capabilities, improved documentation, and better security configurations. It also includes updates to versioning, new files for the proxy application, and enhancements to error handling in the proxy function's implementation.

--- a/cli/startled/src/lambda.rs
+++ b/cli/startled/src/lambda.rs
@@ -113,63 +113,34 @@ pub async fn invoke_function(
         .and_then(|value| value.to_str().ok())
         .map(|s| s.to_string());
 
-    let result = if client_metrics_mode {
+    let (target_function, invoke_payload) = if client_metrics_mode {
         if let Some(proxy) = proxy_function {
             let proxy_request = ProxyRequest {
                 target: function_name.to_string(),
                 payload: final_payload,
             };
-            let req_builder = req
-                .function_name(proxy)
-                .payload(Blob::new(serde_json::to_vec(&proxy_request)?));
-            if let Some(header_value) = xray_header_value.clone() {
-                req_builder
-                    .customize()
-                    .mutate_request(move |http_req| {
-                        http_req
-                            .headers_mut()
-                            .insert("X-Amzn-Trace-Id", header_value.clone());
-                    })
-                    .send()
-                    .await
-            } else {
-                req_builder.send().await
-            }
+            (proxy, Blob::new(serde_json::to_vec(&proxy_request)?))
         } else {
-            let req_builder = req
-                .function_name(function_name)
-                .payload(Blob::new(final_payload.to_string()));
-            if let Some(header_value) = xray_header_value {
-                req_builder
-                    .customize()
-                    .mutate_request(move |http_req| {
-                        http_req
-                            .headers_mut()
-                            .insert("X-Amzn-Trace-Id", header_value.clone());
-                    })
-                    .send()
-                    .await
-            } else {
-                req_builder.send().await
-            }
+            (function_name, Blob::new(final_payload.to_string()))
         }
     } else {
-        let req_builder = req
-            .function_name(function_name)
-            .payload(Blob::new(final_payload.to_string()));
-        if let Some(header_value) = xray_header_value {
-            req_builder
-                .customize()
-                .mutate_request(move |http_req| {
-                    http_req
-                        .headers_mut()
-                        .insert("X-Amzn-Trace-Id", header_value.clone());
-                })
-                .send()
-                .await
-        } else {
-            req_builder.send().await
-        }
+        (function_name, Blob::new(final_payload.to_string()))
+    };
+
+    let req_builder = req.function_name(target_function).payload(invoke_payload);
+
+    let result = if let Some(header_value) = xray_header_value {
+        req_builder
+            .customize()
+            .mutate_request(move |http_req| {
+                http_req
+                    .headers_mut()
+                    .insert("X-Amzn-Trace-Id", header_value.clone());
+            })
+            .send()
+            .await
+    } else {
+        req_builder.send().await
     };
 
     match result {

--- a/cli/startled/src/lambda.rs
+++ b/cli/startled/src/lambda.rs
@@ -113,27 +113,45 @@ pub async fn invoke_function(
         .and_then(|value| value.to_str().ok())
         .map(|s| s.to_string());
 
-    let result = if client_metrics_mode && proxy_function.is_some() {
-        let proxy = proxy_function.unwrap();
-        let proxy_request = ProxyRequest {
-            target: function_name.to_string(),
-            payload: final_payload,
-        };
-        let req_builder = req
-            .function_name(proxy)
-            .payload(Blob::new(serde_json::to_vec(&proxy_request)?));
-        if let Some(header_value) = xray_header_value.clone() {
-            req_builder
-                .customize()
-                .mutate_request(move |http_req| {
-                    http_req
-                        .headers_mut()
-                        .insert("X-Amzn-Trace-Id", header_value.clone());
-                })
-                .send()
-                .await
+    let result = if client_metrics_mode {
+        if let Some(proxy) = proxy_function {
+            let proxy_request = ProxyRequest {
+                target: function_name.to_string(),
+                payload: final_payload,
+            };
+            let req_builder = req
+                .function_name(proxy)
+                .payload(Blob::new(serde_json::to_vec(&proxy_request)?));
+            if let Some(header_value) = xray_header_value.clone() {
+                req_builder
+                    .customize()
+                    .mutate_request(move |http_req| {
+                        http_req
+                            .headers_mut()
+                            .insert("X-Amzn-Trace-Id", header_value.clone());
+                    })
+                    .send()
+                    .await
+            } else {
+                req_builder.send().await
+            }
         } else {
-            req_builder.send().await
+            let req_builder = req
+                .function_name(function_name)
+                .payload(Blob::new(final_payload.to_string()));
+            if let Some(header_value) = xray_header_value {
+                req_builder
+                    .customize()
+                    .mutate_request(move |http_req| {
+                        http_req
+                            .headers_mut()
+                            .insert("X-Amzn-Trace-Id", header_value.clone());
+                    })
+                    .send()
+                    .await
+            } else {
+                req_builder.send().await
+            }
         }
     } else {
         let req_builder = req

--- a/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
+++ b/packages/rust/otlp-stdout-span-exporter/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.1] - 2026-04-01
+
+### Fixed
+- Replaced a Clippy-triggering `map_or` pattern with `is_none_or` without changing header-serialization behavior.
+- Restored downstream workspace lint compatibility for crates that depend on the local exporter during release checks.
+
 ## [0.17.0] - 2026-03-29
 
 ### Changed

--- a/packages/rust/otlp-stdout-span-exporter/Cargo.toml
+++ b/packages/rust/otlp-stdout-span-exporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otlp-stdout-span-exporter"
-version = "0.17.0"
+version = "0.17.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/otlp-stdout-span-exporter/src/lib.rs
+++ b/packages/rust/otlp-stdout-span-exporter/src/lib.rs
@@ -400,7 +400,7 @@ pub struct ExporterOutput {
 impl ExporterOutput {
     /// Helper function for serde to skip serializing empty headers
     fn is_headers_empty(headers: &Option<HashMap<String, String>>) -> bool {
-        headers.as_ref().map_or(true, |h| h.is_empty())
+        headers.as_ref().is_none_or(|h| h.is_empty())
     }
 }
 


### PR DESCRIPTION
This pull request includes patch releases for the `livetrace`, `startled`, and `otlp-stdout-span-exporter` Rust crates, focusing on restoring compatibility with the latest OpenTelemetry proto definitions, Rust toolchains, and workspace dependencies. The updates primarily address Clippy and linting issues, update test fixtures, and ensure the release-quality gates remain green across the workspace. No user-facing behavior is changed.

**Livetrace CLI updates:**

- Bumped `livetrace` version to `0.2.2`, updated changelog and release notes to reflect restored compatibility with current OpenTelemetry proto types and workspace dependencies. [[1]](diffhunk://#diff-0aa1c491fa74752e81c4b4c0962df8b0e2b65edf4f706a1a9e9bed1187c221beL3-R3) [[2]](diffhunk://#diff-c451b7e6fddedec09135853b8dcba814a2a3f6235787c31db7de9b2549b95f4bR8-R13) [[3]](diffhunk://#diff-ceeee9da25ae0bf4961997f809eb82a40f12b42b4f749d8ad3e0f12481a426e7R1-R9)
- Updated test fixtures in `processing.rs` to set the `entity_refs` field on `Resource` to match current proto requirements. [[1]](diffhunk://#diff-bbc94d1fe7c3886a727404d488646a074ed8fdee2d63f3d371482e562a9f134cR314) [[2]](diffhunk://#diff-bbc94d1fe7c3886a727404d488646a074ed8fdee2d63f3d371482e562a9f134cR549)

**Startled CLI updates:**

- Bumped `startled` version to `0.9.1` and updated changelog and release notes to document restored release-quality gate and Clippy fixes. [[1]](diffhunk://#diff-112c3857fa8d5706869ef8ba5fdaee05097cf93d95f849ab39a4c1457fafa30bL3-R3) [[2]](diffhunk://#diff-bd0cb949bb67fcfa38060059b5016cdb217ed459714094210b87496f0714b453R8-R13) [[3]](diffhunk://#diff-355350d3a7fa2003a39ec9494c944acb48edffadf500b4cd0b27e322927cf8eaR1-R11)
- Refactored the Lambda invocation logic in `lambda.rs` to satisfy Clippy by simplifying the proxy invocation branch, without changing runtime behavior. [[1]](diffhunk://#diff-d315a245e8cb6187b6ac3de02389dbf4bd36ccab2c46487e898ff2390ba4a600L116-R117) [[2]](diffhunk://#diff-d315a245e8cb6187b6ac3de02389dbf4bd36ccab2c46487e898ff2390ba4a600R155-R172)

**Otlp-stdout-span-exporter crate updates:**

- Bumped `otlp-stdout-span-exporter` version to `0.17.1`, updated changelog, and fixed a Clippy warning by replacing a `map_or` pattern with `is_none_or` in header serialization logic. [[1]](diffhunk://#diff-139d37c5c8f0270080968f69d2217b6dc710f974739d4ef4f2b7410ce95f9ee6L3-R3) [[2]](diffhunk://#diff-51c986c5bb8e2e0e9f9c5ecc6f5ac74d2f94a63485f77b241081dc12820081ffR8-R13) [[3]](diffhunk://#diff-5e5a6c2c01507f300be15a04a7ce487666ff70869d5bffba3cd94bd4a1973040L403-R403)
- Updated the workspace dependency in the root `Cargo.toml` to use the new version.