### PR TITLE
release: bump CLI patch versions for lockfile refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "livetrace"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -4400,9 +4400,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slug"
@@ -4459,7 +4459,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "startled"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/cli/livetrace/CHANGELOG.md
+++ b/cli/livetrace/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-04-01
+
+### Fixed
+- Refreshed the packaged workspace lockfile to replace yanked `slab 0.4.10` with `slab 0.4.12`.
+- Removes the yanked dependency warning during publish verification and `cargo install --locked`.
+
 ## [0.2.2] - 2026-04-01
 
 ### Fixed

--- a/cli/livetrace/Cargo.toml
+++ b/cli/livetrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "livetrace"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/livetrace/RELEASE_NOTES.md
+++ b/cli/livetrace/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+## livetrace v0.2.3 - 2026-04-01
+
+This patch release refreshes the packaged lockfile used for `cargo publish` and `cargo install --locked` so it no longer references the yanked `slab 0.4.10` release.
+
+### Fixes
+
+* **Lockfile refresh:** Updated the packaged workspace lockfile to use `slab 0.4.12`.
+* **Cleaner publish/install path:** Removes the yanked-package warning during publish verification and locked installs.
+
 ## livetrace v0.2.2 - 2026-04-01
 
 This patch release restores `livetrace` compatibility with the current OpenTelemetry workspace and keeps the CLI release gate green on current Rust/Clippy tooling.

--- a/cli/startled/CHANGELOG.md
+++ b/cli/startled/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2026-04-01
+
+### Fixed
+- Refreshed the packaged workspace lockfile to replace yanked `slab 0.4.10` with `slab 0.4.12`.
+- Removes the yanked dependency warning during publish verification and `cargo install --locked`.
+
 ## [0.9.1] - 2026-04-01
 
 ### Fixed

--- a/cli/startled/Cargo.toml
+++ b/cli/startled/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "startled"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/cli/startled/RELEASE_NOTES.md
+++ b/cli/startled/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+# Release Notes for startled v0.9.2
+
+This patch release refreshes the packaged lockfile used for `cargo publish` and `cargo install --locked` so it no longer references the yanked `slab 0.4.10` release.
+
+### Fixes
+
+* **Lockfile refresh:** Updated the packaged workspace lockfile to use `slab 0.4.12`.
+* **Cleaner publish/install path:** Removes the yanked-package warning during publish verification and locked installs.
+
+---
+
 # Release Notes for startled v0.9.1
 
 This patch release restores the `startled` release-quality gate on the current workspace and Rust toolchain without changing user-facing benchmark behavior.


### PR DESCRIPTION
This pull request updates both the `livetrace` and `startled` CLI packages to address a yanked dependency and improve the reliability of publishing and installing these crates. The main focus is on refreshing the workspace lockfile to replace the yanked `slab 0.4.10` dependency with the stable `slab 0.4.12` release, which removes warnings during publish verification and locked installs. Both packages have their versions bumped to reflect these maintenance fixes.

**Dependency and Release Maintenance:**

* Refreshed the packaged workspace lockfile for both `livetrace` and `startled` to use `slab 0.4.12` instead of the yanked `slab 0.4.10`, resolving yanked-package warnings during `cargo publish` and `cargo install --locked`. [[1]](diffhunk://#diff-c451b7e6fddedec09135853b8dcba814a2a3f6235787c31db7de9b2549b95f4bR8-R13) [[2]](diffhunk://#diff-bd0cb949bb67fcfa38060059b5016cdb217ed459714094210b87496f0714b453R8-R13) [[3]](diffhunk://#diff-ceeee9da25ae0bf4961997f809eb82a40f12b42b4f749d8ad3e0f12481a426e7R1-R9) [[4]](diffhunk://#diff-355350d3a7fa2003a39ec9494c944acb48edffadf500b4cd0b27e322927cf8eaR1-R11)
* Bumped the version of `livetrace` to `0.2.3` and `startled` to `0.9.2` to reflect the lockfile and dependency fixes. [[1]](diffhunk://#diff-0aa1c491fa74752e81c4b4c0962df8b0e2b65edf4f706a1a9e9bed1187c221beL3-R3) [[2]](diffhunk://#diff-112c3857fa8d5706869ef8ba5fdaee05097cf93d95f849ab39a4c1457fafa30bL3-R3)