### PR TITLE
release: rust/serverless-otlp-forwarder-core v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "serverless-otlp-forwarder-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4323,6 +4323,7 @@ dependencies = [
  "serial_test",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "url",
  "wiremock",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lambda-lw-http-router-macro = { version = "0.6.0", path = "packages/rust/lambda-
 otlp-stdout-span-exporter = { version = "0.17.1", path = "packages/rust/otlp-stdout-span-exporter" }
 lambda-otel-lite = { version = "0.19.0", path = "packages/rust/lambda-otel-lite" }
 otlp-stdout-logs-processor = { path = "forwarders/otlp-stdout-logs-processor/processor" }
-serverless-otlp-forwarder-core = { version = "0.2.0", path = "packages/rust/serverless-otlp-forwarder-core" }
+serverless-otlp-forwarder-core = { version = "0.2.1", path = "packages/rust/serverless-otlp-forwarder-core" }
 
 # Runtime and async
 tokio = { version = "1.45.1", features = ["full"] }

--- a/packages/rust/serverless-otlp-forwarder-core/CHANGELOG.md
+++ b/packages/rust/serverless-otlp-forwarder-core/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-04-23
+
+### Changed
+- Removed sensitive values from emitted tracing and logging across the HTTP sender, processor, telemetry conversion, and span compaction paths
+- Replaced high-cardinality log messages with static event names plus allowlisted fields such as counts, status codes, sizes, compression settings, and timeout metadata
+- Sanitized non-success OTLP export errors so they report the HTTP status without including raw response bodies
+
 ## [0.2.0] - 2026-03-30
 
 ### Changed

--- a/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
+++ b/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serverless-otlp-forwarder-core"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -46,6 +46,7 @@ reqwest-tracing = { workspace = true, optional = true }
 wiremock = { workspace = true }
 sealed_test = { workspace = true }
 serial_test = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # for doctests
 aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }

--- a/packages/rust/serverless-otlp-forwarder-core/README.md
+++ b/packages/rust/serverless-otlp-forwarder-core/README.md
@@ -146,7 +146,7 @@ cargo add serverless-otlp-forwarder-core
 - **`instrumented-client`**: Enables the `InstrumentedHttpClient` for advanced middleware support
   ```toml
   [dependencies]
-  serverless-otlp-forwarder-core = { version = "0.2.0", features = ["instrumented-client"] }
+  serverless-otlp-forwarder-core = { version = "0.2.1", features = ["instrumented-client"] }
   ```
 
 ## Usage Example
@@ -252,7 +252,7 @@ For more advanced use cases requiring request tracing and observability of the f
 ```toml
 # Cargo.toml
 [dependencies]
-serverless-otlp-forwarder-core = { version = "0.2.0", features = ["instrumented-client"] }
+serverless-otlp-forwarder-core = { version = "0.2.1", features = ["instrumented-client"] }
 reqwest-middleware = "0.3"
 reqwest-tracing = "0.5"
 ```

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -363,7 +363,7 @@ pub async fn send_telemetry_batch(
     Span::current().record("otlp.payload.size_bytes", payload_bytes.len() as u64);
 
     debug!(
-        timeout_ms = timeout.as_millis(),
+        timeout_ms = timeout.as_millis() as u64,
         header_count = headers.len() as u64,
         payload_size_bytes = payload_bytes.len() as u64,
         "Sending telemetry batch"

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -190,7 +190,8 @@ fn resolve_otlp_endpoint() -> Result<Url> {
                 endpoint_source = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
                 "Using configured OTLP endpoint"
             );
-            return Url::parse(&traces_endpoint).context("Invalid OTLP traces endpoint URL");
+            return Url::parse(&traces_endpoint)
+                .context("Invalid URL in OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
         }
     }
 
@@ -200,7 +201,8 @@ fn resolve_otlp_endpoint() -> Result<Url> {
                 endpoint_source = "OTEL_EXPORTER_OTLP_ENDPOINT",
                 "Using configured OTLP endpoint"
             );
-            let mut url = Url::parse(&generic_endpoint).context("Invalid OTLP endpoint URL")?;
+            let mut url = Url::parse(&generic_endpoint)
+                .context("Invalid URL in OTEL_EXPORTER_OTLP_ENDPOINT")?;
 
             let current_path = url.path();
             if !current_path.ends_with(OTLP_TRACES_PATH) {
@@ -861,6 +863,32 @@ mod tests {
 
     #[tokio::test]
     #[sealed_test]
+    async fn test_resolve_otlp_endpoint_traces_invalid_mentions_source_only() {
+        let invalid_endpoint = "not a url with a secret token";
+        let _g1 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", invalid_endpoint);
+        let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_ENDPOINT");
+
+        let err_msg = resolve_otlp_endpoint().unwrap_err().to_string();
+
+        assert!(err_msg.contains("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"));
+        assert!(!err_msg.contains(invalid_endpoint));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    async fn test_resolve_otlp_endpoint_generic_invalid_mentions_source_only() {
+        let invalid_endpoint = "not a url with a secret token";
+        let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+        let _g2 = EnvVarGuard::set("OTEL_EXPORTER_OTLP_ENDPOINT", invalid_endpoint);
+
+        let err_msg = resolve_otlp_endpoint().unwrap_err().to_string();
+
+        assert!(err_msg.contains("OTEL_EXPORTER_OTLP_ENDPOINT"));
+        assert!(!err_msg.contains(invalid_endpoint));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
     async fn test_resolve_otlp_timeout_default() {
         let _g1 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT");
         let _g2 = EnvVarGuard::remove("OTEL_EXPORTER_OTLP_TIMEOUT");
@@ -1059,7 +1087,7 @@ mod tests {
         assert!(!err_msg.contains("Internal Error"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     #[sealed_test]
     #[serial]
     async fn test_send_telemetry_batch_error_logs_exclude_sensitive_values() {

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -51,7 +51,6 @@ impl HttpForwarderResponse {
 async fn read_error_body_if_needed<F, E>(status: StatusCode, read_body: F) -> String
 where
     F: Future<Output = std::result::Result<String, E>>,
-    E: std::fmt::Display,
 {
     if status.is_success() {
         return String::new();
@@ -72,7 +71,6 @@ where
 async fn drain_success_body<F, E>(status: StatusCode, drain_body: F)
 where
     F: Future<Output = std::result::Result<(), E>>,
-    E: std::fmt::Display,
 {
     if drain_body.await.is_err() {
         warn!(
@@ -374,12 +372,12 @@ pub async fn send_telemetry_batch(
         .await
     {
         Ok(resp) => resp,
-        Err(e) => {
+        Err(_) => {
             Span::current().record("otel.status_code", "ERROR");
             Span::current().record("error", true);
             Span::current().record("error.kind", "transport");
             warn!("OTLP HTTP post_telemetry failed");
-            return Err(e.context("OTLP export request failed"));
+            return Err(anyhow::anyhow!("OTLP export request failed"));
         }
     };
 
@@ -941,21 +939,10 @@ mod tests {
             "Expected send_telemetry_batch to fail due to timeout"
         );
         let err = result.unwrap_err();
+        let err_msg = err.to_string();
 
-        let is_timeout_error = err.chain().any(|cause| {
-            if let Some(req_err) = cause.downcast_ref::<reqwest::Error>() {
-                req_err.is_timeout()
-            } else {
-                cause.to_string().to_lowercase().contains("timeout")
-                    || cause.to_string().to_lowercase().contains("timed out")
-            }
-        });
-        assert!(
-            is_timeout_error,
-            "Error was not a timeout error. Actual error: {:?}\nCause chain: {:#?}",
-            err,
-            err.chain().collect::<Vec<_>>()
-        );
+        assert_eq!(err_msg, "OTLP export request failed");
+        assert!(!err_msg.contains(&server.uri()));
     }
 
     #[tokio::test]

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -59,10 +59,9 @@ where
 
     match read_body.await {
         Ok(body) => body,
-        Err(err) => {
+        Err(_) => {
             warn!(
-                status = %status,
-                error = %err,
+                status = status.as_u16(),
                 "Failed to read OTLP error response body"
             );
             String::new()
@@ -75,17 +74,16 @@ where
     F: Future<Output = std::result::Result<(), E>>,
     E: std::fmt::Display,
 {
-    if let Err(err) = drain_body.await {
+    if drain_body.await.is_err() {
         warn!(
-            status = %status,
-            error = %err,
+            status = status.as_u16(),
             "Failed to drain OTLP success response body"
         );
     }
 }
 
 /// Parses OTLP headers from a comma-separated key=value string.
-fn parse_otlp_headers(headers_str: &str) -> Result<HeaderMap> {
+fn parse_otlp_headers(headers_str: &str, header_source: &'static str) -> Result<HeaderMap> {
     let mut headers = HeaderMap::new();
     if headers_str.is_empty() {
         return Ok(headers);
@@ -100,7 +98,11 @@ fn parse_otlp_headers(headers_str: &str) -> Result<HeaderMap> {
                 let key = key_str.trim();
                 let value = value_str.trim();
                 if key.is_empty() {
-                    warn!("Empty header key found in OTLP headers string part: '{}' from full string: '{}'", pair_str, headers_str);
+                    warn!(
+                        header_source,
+                        invalid_header_reason = "empty_key",
+                        "Skipping invalid OTLP header"
+                    );
                     continue;
                 }
                 match HeaderName::from_str(key) {
@@ -108,20 +110,29 @@ fn parse_otlp_headers(headers_str: &str) -> Result<HeaderMap> {
                         Ok(header_value) => {
                             headers.append(header_name, header_value);
                         }
-                        Err(e) => {
+                        Err(_) => {
                             warn!(
-                                "Invalid header value '{}' for key '{}': {}. Skipping header.",
-                                value, key, e
+                                header_source,
+                                invalid_header_reason = "invalid_value",
+                                "Skipping invalid OTLP header"
                             );
                         }
                     },
-                    Err(e) => {
-                        warn!("Invalid header name '{}': {}. Skipping header.", key, e);
+                    Err(_) => {
+                        warn!(
+                            header_source,
+                            invalid_header_reason = "invalid_name",
+                            "Skipping invalid OTLP header"
+                        );
                     }
                 }
             }
             None => {
-                warn!("Malformed header pair (missing '='): '{}' in OTLP headers string: '{}'. Skipping.", pair_str, headers_str);
+                warn!(
+                    header_source,
+                    invalid_header_reason = "missing_equals",
+                    "Skipping invalid OTLP header"
+                );
             }
         }
     }
@@ -136,8 +147,15 @@ fn resolve_otlp_headers() -> Result<HeaderMap> {
 
     match traces_headers_var {
         Ok(headers_str) if !headers_str.is_empty() => {
-            debug!("Using OTEL_EXPORTER_OTLP_TRACES_HEADERS: {}", headers_str);
-            return parse_otlp_headers(&headers_str);
+            debug!(
+                header_source = "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+                configured_header_parts_count = headers_str
+                    .split(',')
+                    .filter(|part| !part.trim().is_empty())
+                    .count() as u64,
+                "Using configured OTLP headers"
+            );
+            return parse_otlp_headers(&headers_str, "OTEL_EXPORTER_OTLP_TRACES_HEADERS");
         }
         _ => { // Fall through if TRACES_HEADERS is not set or empty
         }
@@ -145,8 +163,15 @@ fn resolve_otlp_headers() -> Result<HeaderMap> {
 
     match generic_headers_var {
         Ok(headers_str) if !headers_str.is_empty() => {
-            debug!("Using OTEL_EXPORTER_OTLP_HEADERS: {}", headers_str);
-            return parse_otlp_headers(&headers_str);
+            debug!(
+                header_source = "OTEL_EXPORTER_OTLP_HEADERS",
+                configured_header_parts_count = headers_str
+                    .split(',')
+                    .filter(|part| !part.trim().is_empty())
+                    .count() as u64,
+                "Using configured OTLP headers"
+            );
+            return parse_otlp_headers(&headers_str, "OTEL_EXPORTER_OTLP_HEADERS");
         }
         _ => { // Fall through if HEADERS is not set or empty
         }
@@ -164,21 +189,20 @@ fn resolve_otlp_endpoint() -> Result<Url> {
     if let Ok(traces_endpoint) = env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") {
         if !traces_endpoint.is_empty() {
             debug!(
-                "Using OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: {}",
-                traces_endpoint
+                endpoint_source = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "Using configured OTLP endpoint"
             );
-            return Url::parse(&traces_endpoint).with_context(|| {
-                format!("Invalid URL from OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: {traces_endpoint}")
-            });
+            return Url::parse(&traces_endpoint).context("Invalid OTLP traces endpoint URL");
         }
     }
 
     if let Ok(generic_endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT") {
         if !generic_endpoint.is_empty() {
-            debug!("Using OTEL_EXPORTER_OTLP_ENDPOINT: {}", generic_endpoint);
-            let mut url = Url::parse(&generic_endpoint).with_context(|| {
-                format!("Invalid URL from OTEL_EXPORTER_OTLP_ENDPOINT: {generic_endpoint}")
-            })?;
+            debug!(
+                endpoint_source = "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "Using configured OTLP endpoint"
+            );
+            let mut url = Url::parse(&generic_endpoint).context("Invalid OTLP endpoint URL")?;
 
             let current_path = url.path();
             if !current_path.ends_with(OTLP_TRACES_PATH) {
@@ -193,16 +217,15 @@ fn resolve_otlp_endpoint() -> Result<Url> {
         }
     }
 
-    debug!("Using default OTLP endpoint: {}", DEFAULT_OTLP_ENDPOINT);
-    Url::parse(DEFAULT_OTLP_ENDPOINT)
-        .with_context(|| format!("Failed to parse default OTLP endpoint: {DEFAULT_OTLP_ENDPOINT}"))
+    debug!(endpoint_source = "default", "Using default OTLP endpoint");
+    Url::parse(DEFAULT_OTLP_ENDPOINT).context("Failed to parse default OTLP endpoint URL")
 }
 
 /// Parses an OTLP timeout string (expected to be milliseconds) into a Duration.
 fn parse_otlp_timeout_millis(duration_ms_str: &str) -> Result<Duration> {
-    let millis = duration_ms_str.parse::<u64>().with_context(|| {
-        format!("Invalid OTLP timeout value: '{duration_ms_str}'. Expected integer milliseconds.")
-    })?;
+    let millis = duration_ms_str
+        .parse::<u64>()
+        .context("Invalid OTLP timeout value")?;
     Ok(Duration::from_millis(millis))
 }
 
@@ -213,36 +236,36 @@ fn resolve_otlp_timeout() -> Duration {
     let generic_timeout_var = env::var("OTEL_EXPORTER_OTLP_TIMEOUT");
 
     let timeout_str_to_parse = match traces_timeout_var {
-        Ok(val) if !val.is_empty() => {
-            debug!("Using OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: {}", val);
-            Some(val)
-        }
+        Ok(val) if !val.is_empty() => Some(("OTEL_EXPORTER_OTLP_TRACES_TIMEOUT", val)),
         _ => match generic_timeout_var {
-            Ok(val) if !val.is_empty() => {
-                debug!("Using OTEL_EXPORTER_OTLP_TIMEOUT: {}", val);
-                Some(val)
-            }
+            Ok(val) if !val.is_empty() => Some(("OTEL_EXPORTER_OTLP_TIMEOUT", val)),
             _ => None,
         },
     };
 
-    if let Some(s) = timeout_str_to_parse {
-        match parse_otlp_timeout_millis(&s) {
+    if let Some((timeout_source, timeout_value)) = timeout_str_to_parse {
+        match parse_otlp_timeout_millis(&timeout_value) {
             Ok(duration) => {
-                debug!("Parsed OTLP export timeout duration: {:?}", duration);
+                debug!(
+                    timeout_source,
+                    timeout_ms = duration.as_millis() as u64,
+                    "Using configured OTLP export timeout"
+                );
                 return duration;
             }
-            Err(e) => {
+            Err(_) => {
                 warn!(
-                    "Failed to parse OTLP timeout value '{}': {}. Using default timeout.",
-                    s, e
+                    timeout_source,
+                    timeout_ms = DEFAULT_OTLP_EXPORT_TIMEOUT.as_millis() as u64,
+                    "Failed to parse OTLP export timeout; using default"
                 );
             }
         }
     }
     debug!(
-        "Using default OTLP export timeout: {:?}",
-        DEFAULT_OTLP_EXPORT_TIMEOUT
+        timeout_source = "default",
+        timeout_ms = DEFAULT_OTLP_EXPORT_TIMEOUT.as_millis() as u64,
+        "Using default OTLP export timeout"
     );
     DEFAULT_OTLP_EXPORT_TIMEOUT
 }
@@ -293,19 +316,30 @@ pub type HttpClient = Arc<dyn HttpOtlpForwarderClient + Send + Sync>;
 
 /// Sends a batch of OTLP telemetry data.
 /// The TelemetryData payload is assumed to be a compacted, possibly compressed, OTLP protobuf batch.
-#[instrument(name="http_sender/send_telemetry_batch", skip_all, fields(
-    otel.kind = "client",
-    http.method = "POST",
-    http.url = %telemetry_data.endpoint,
-    http.status_code
-    // error details will be added on error
-))]
+#[instrument(
+    name = "http_sender/send_telemetry_batch",
+    skip_all,
+    fields(
+        otel.kind = "client",
+        http.method = "POST",
+        http.status_code,
+        otel.status_code,
+        error,
+        error.kind,
+        otlp.headers.count,
+        otlp.payload.size_bytes,
+        otlp.timeout_ms,
+        otlp.request_content_type = %telemetry_data.content_type,
+        otlp.request_content_encoding = %telemetry_data.content_encoding.as_deref().unwrap_or("none"),
+        otlp.response_error_body_present,
+        otlp.response_error_body_size_bytes
+    )
+)]
 pub async fn send_telemetry_batch(
     client: &impl HttpOtlpForwarderClient,
     telemetry_data: TelemetryData,
 ) -> Result<()> {
     let resolved_target_url = resolve_otlp_endpoint()?;
-    Span::current().record("http.url", resolved_target_url.as_str());
     let timeout = resolve_otlp_timeout();
 
     let mut headers = resolve_otlp_headers()?;
@@ -324,14 +358,15 @@ pub async fn send_telemetry_batch(
     }
 
     let payload_bytes = Bytes::from(telemetry_data.payload); // Convert Vec<u8> to Bytes
+    Span::current().record("otlp.timeout_ms", timeout.as_millis() as u64);
+    Span::current().record("otlp.headers.count", headers.len() as u64);
+    Span::current().record("otlp.payload.size_bytes", payload_bytes.len() as u64);
 
     debug!(
-        name = "sending telemetry batch",
-        target_url = %resolved_target_url,
         timeout_ms = timeout.as_millis(),
-        headers = ?headers,
-        payload_size_bytes = payload_bytes.len(), // Use length of Bytes
-        "Request details"
+        header_count = headers.len() as u64,
+        payload_size_bytes = payload_bytes.len() as u64,
+        "Sending telemetry batch"
     );
 
     let response = match client
@@ -342,9 +377,9 @@ pub async fn send_telemetry_batch(
         Err(e) => {
             Span::current().record("otel.status_code", "ERROR");
             Span::current().record("error", true);
-            Span::current().record("error.message", e.to_string());
-            warn!(target_url = %resolved_target_url, error = %e, "OTLP HTTP post_telemetry failed");
-            return Err(e);
+            Span::current().record("error.kind", "transport");
+            warn!("OTLP HTTP post_telemetry failed");
+            return Err(e.context("OTLP export request failed"));
         }
     };
 
@@ -353,23 +388,32 @@ pub async fn send_telemetry_batch(
 
     if !status.is_success() {
         Span::current().record("otel.status_code", "ERROR");
+        Span::current().record("error", true);
+        Span::current().record("error.kind", "non_success_status");
         let error_body = response.into_body();
-        Span::current().record("error.message", error_body.clone());
+        Span::current().record("otlp.response_error_body_present", !error_body.is_empty());
+        Span::current().record(
+            "otlp.response_error_body_size_bytes",
+            error_body.len() as u64,
+        );
         warn!(
-            target_url = %resolved_target_url,
-            status = %status,
-            response_body = %error_body,
+            status = status.as_u16(),
+            response_error_body_present = !error_body.is_empty(),
+            response_error_body_size_bytes = error_body.len() as u64,
             "OTLP export failed with non-success status"
         );
         return Err(anyhow::anyhow!(
-            "OTLP export failed to {}. Status: {}. Body: {}",
-            resolved_target_url,
-            status,
-            error_body
+            "OTLP export failed with status {}",
+            status.as_u16()
         ));
     }
 
-    debug!(target_url = %resolved_target_url, status = %status, "Telemetry batch sent successfully");
+    Span::current().record("otel.status_code", "OK");
+    Span::current().record("error", false);
+    debug!(
+        status = status.as_u16(),
+        "Telemetry batch sent successfully"
+    );
     Ok(())
 }
 
@@ -474,9 +518,21 @@ mod tests {
     use anyhow::anyhow;
     use reqwest::Client as ReqwestClient;
     use sealed_test::prelude::*;
+    use serial_test::serial;
+    use std::collections::BTreeMap;
+    use std::fmt::Debug;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration as StdDuration;
+    use tracing::{
+        field::{Field, Visit},
+        Event, Subscriber,
+    };
+    use tracing_subscriber::{
+        layer::{Context, Layer},
+        prelude::*,
+        registry::Registry,
+    };
     use wiremock::matchers::{body_bytes, header, method, path};
     use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 
@@ -522,9 +578,74 @@ mod tests {
         ReqwestClient::new()
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct CapturedEvent {
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Debug, Default)]
+    struct EventFieldVisitor {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for EventFieldVisitor {
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct EventCaptureLayer {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl EventCaptureLayer {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn events(&self) -> Arc<Mutex<Vec<CapturedEvent>>> {
+            Arc::clone(&self.events)
+        }
+    }
+
+    impl<S> Layer<S> for EventCaptureLayer
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = EventFieldVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                fields: visitor.fields,
+            });
+        }
+    }
+
     #[tokio::test]
     async fn test_parse_otlp_headers_empty() {
-        let headers = parse_otlp_headers("").unwrap();
+        let headers = parse_otlp_headers("", "test").unwrap();
         assert!(headers.is_empty());
     }
 
@@ -594,13 +715,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_otlp_headers_single() {
-        let headers = parse_otlp_headers("key1=value1").unwrap();
+        let headers = parse_otlp_headers("key1=value1", "test").unwrap();
         assert_eq!(headers.get("key1").unwrap(), "value1");
     }
 
     #[tokio::test]
     async fn test_parse_otlp_headers_multiple() {
-        let headers = parse_otlp_headers("key1=value1,key2=value2, key3 = value3 ").unwrap();
+        let headers =
+            parse_otlp_headers("key1=value1,key2=value2, key3 = value3 ", "test").unwrap();
         assert_eq!(headers.get("key1").unwrap(), "value1");
         assert_eq!(headers.get("key2").unwrap(), "value2");
         assert_eq!(headers.get("key3").unwrap(), "value3");
@@ -608,7 +730,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_otlp_headers_invalid_pair() {
-        let headers = parse_otlp_headers("key1=value1,invalid,key2=value2").unwrap();
+        let headers = parse_otlp_headers("key1=value1,invalid,key2=value2", "test").unwrap();
         assert_eq!(headers.get("key1").unwrap(), "value1");
         assert_eq!(headers.get("key2").unwrap(), "value2");
         assert!(headers.get("invalid").is_none());
@@ -617,7 +739,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_otlp_headers_empty_key_value() {
-        let headers = parse_otlp_headers("key1=, =value2 , key3=value3").unwrap();
+        let headers = parse_otlp_headers("key1=, =value2 , key3=value3", "test").unwrap();
         assert_eq!(headers.get("key1").unwrap(), "");
         assert_eq!(headers.get("key3").unwrap(), "value3");
         assert_eq!(headers.len(), 2);
@@ -946,7 +1068,66 @@ mod tests {
         let result = send_telemetry_batch(&client, telemetry).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("Status: 500"));
-        assert!(err_msg.contains("Internal Error"));
+        assert!(err_msg.contains("status 500"));
+        assert!(!err_msg.contains("Internal Error"));
+    }
+
+    #[tokio::test]
+    #[sealed_test]
+    #[serial]
+    async fn test_send_telemetry_batch_error_logs_exclude_sensitive_values() {
+        let server = MockServer::start().await;
+        let client = test_client();
+        let telemetry = TelemetryData::default();
+        let capture_layer = EventCaptureLayer::new();
+        let captured_events = capture_layer.events();
+        let subscriber = Registry::default().with(capture_layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        Mock::given(method("POST"))
+            .and(path(OTLP_TRACES_PATH))
+            .respond_with(ResponseTemplate::new(500).set_body_string("Internal Error"))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let _g1 = EnvVarGuard::set(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            &format!("{}{}", server.uri(), OTLP_TRACES_PATH),
+        );
+
+        let result = send_telemetry_batch(&client, telemetry).await;
+        assert!(result.is_err());
+
+        let events = captured_events.lock().unwrap();
+        let failure_event = events
+            .iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message == "OTLP export failed with non-success status")
+            })
+            .expect("expected non-success OTLP export warning");
+
+        assert_eq!(
+            failure_event.fields.get("status").map(String::as_str),
+            Some("500")
+        );
+        assert_eq!(
+            failure_event
+                .fields
+                .get("response_error_body_present")
+                .map(String::as_str),
+            Some("true")
+        );
+        assert!(failure_event
+            .fields
+            .values()
+            .all(|value| !value.contains("Internal Error")));
+        assert!(failure_event
+            .fields
+            .values()
+            .all(|value| !value.contains(&server.uri())));
     }
 }

--- a/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/http_sender.rs
@@ -515,24 +515,15 @@ pub mod client_builder {
 mod tests {
     use super::*;
     use crate::telemetry::TelemetryData;
+    use crate::tracing_capture::EventCaptureLayer;
     use anyhow::anyhow;
     use reqwest::Client as ReqwestClient;
     use sealed_test::prelude::*;
     use serial_test::serial;
-    use std::collections::BTreeMap;
-    use std::fmt::Debug;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
     use std::time::Duration as StdDuration;
-    use tracing::{
-        field::{Field, Visit},
-        Event, Subscriber,
-    };
-    use tracing_subscriber::{
-        layer::{Context, Layer},
-        prelude::*,
-        registry::Registry,
-    };
+    use tracing_subscriber::{prelude::*, registry::Registry};
     use wiremock::matchers::{body_bytes, header, method, path};
     use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 
@@ -576,71 +567,6 @@ mod tests {
 
     fn test_client() -> ReqwestClient {
         ReqwestClient::new()
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    struct CapturedEvent {
-        fields: BTreeMap<String, String>,
-    }
-
-    #[derive(Debug, Default)]
-    struct EventFieldVisitor {
-        fields: BTreeMap<String, String>,
-    }
-
-    impl Visit for EventFieldVisitor {
-        fn record_i64(&mut self, field: &Field, value: i64) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_u64(&mut self, field: &Field, value: u64) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_bool(&mut self, field: &Field, value: bool) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_str(&mut self, field: &Field, value: &str) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
-            self.fields
-                .insert(field.name().to_string(), format!("{value:?}"));
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct EventCaptureLayer {
-        events: Arc<Mutex<Vec<CapturedEvent>>>,
-    }
-
-    impl EventCaptureLayer {
-        fn new() -> Self {
-            Self::default()
-        }
-
-        fn events(&self) -> Arc<Mutex<Vec<CapturedEvent>>> {
-            Arc::clone(&self.events)
-        }
-    }
-
-    impl<S> Layer<S> for EventCaptureLayer
-    where
-        S: Subscriber,
-    {
-        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-            let mut visitor = EventFieldVisitor::default();
-            event.record(&mut visitor);
-            self.events.lock().unwrap().push(CapturedEvent {
-                fields: visitor.fields,
-            });
-        }
     }
 
     #[tokio::test]

--- a/packages/rust/serverless-otlp-forwarder-core/src/lib.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/lib.rs
@@ -4,6 +4,9 @@
 pub mod telemetry;
 pub use telemetry::TelemetryData;
 
+#[cfg(test)]
+pub(crate) mod tracing_capture;
+
 pub mod span_compactor;
 pub use span_compactor::{compact_telemetry_payloads, SpanCompactionConfig};
 

--- a/packages/rust/serverless-otlp-forwarder-core/src/processor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/processor.rs
@@ -39,9 +39,9 @@ pub async fn process_event_batch<
     // 1. Parse the event payload
     let telemetry_items = match parser.parse(event_payload, source_identifier) {
         Ok(items) => items,
-        Err(e) => {
+        Err(_) => {
             error!("Failed to parse event payload.");
-            return Err(e.context("Event parsing failed"));
+            return Err(anyhow::anyhow!("Event parsing failed"));
         }
     };
 
@@ -271,11 +271,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Event parsing failed"));
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert_eq!(err_msg, "Event parsing failed");
+        assert!(!err_msg.contains("Mock parser failed intentionally"));
     }
 
     #[tokio::test]

--- a/packages/rust/serverless-otlp-forwarder-core/src/processor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/processor.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, instrument};
 /// * `http_client`: A reference to the HTTP client for making HTTP requests.
 /// * `compaction_config`: Configuration for span compaction.
 ///
-#[instrument(name="processor/process_event_batch", skip_all, fields(source = %source_identifier))]
+#[instrument(name = "processor/process_event_batch", skip_all)]
 pub async fn process_event_batch<
     E,
     P: EventParser<EventInput = E> + Sync + Send,
@@ -40,7 +40,7 @@ pub async fn process_event_batch<
     let telemetry_items = match parser.parse(event_payload, source_identifier) {
         Ok(items) => items,
         Err(e) => {
-            error!(error = %e, "Failed to parse event payload.");
+            error!("Failed to parse event payload.");
             return Err(e.context("Event parsing failed"));
         }
     };
@@ -50,19 +50,19 @@ pub async fn process_event_batch<
         return Ok(());
     }
     debug!(
-        "Successfully parsed {} telemetry items.",
-        telemetry_items.len()
+        telemetry_items_count = telemetry_items.len() as i64,
+        "Parsed telemetry items"
     );
 
     // 2. Compact the telemetry items into a single TelemetryData object
     let compacted_telemetry = match compact_telemetry_payloads(telemetry_items, compaction_config) {
         Ok(compacted) => compacted,
         Err(e) => {
-            error!(error = %e, "Failed to compact telemetry items.");
+            error!("Failed to compact telemetry items.");
             return Err(e.context("Telemetry compaction failed"));
         }
     };
-    debug!("Successfully compacted telemetry items.");
+    debug!("Compacted telemetry items.");
 
     // 3. Send the compacted telemetry batch
     match send_telemetry_batch(http_client, compacted_telemetry).await {
@@ -71,7 +71,7 @@ pub async fn process_event_batch<
             Ok(())
         }
         Err(e) => {
-            error!(error = %e, "Failed to send telemetry batch.");
+            error!("Failed to send telemetry batch.");
             Err(e.context("Sending telemetry batch failed"))
         }
     }

--- a/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
@@ -4,6 +4,7 @@ use anyhow::Result; // Changed from LambdaError
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use prost::Message;
 use std::env;
+use std::fmt;
 use tracing::{self, instrument}; // For reading environment variables
 
 use crate::telemetry::TelemetryData; // This should be correct once telemetry.rs is in the same crate
@@ -15,7 +16,7 @@ fn decode_otlp_payload(payload: &[u8]) -> Result<ExportTraceServiceRequest> {
     // Changed from LambdaError
     // Decode protobuf directly
     ExportTraceServiceRequest::decode(payload)
-        .map_err(|e| anyhow::anyhow!("Failed to decode protobuf: {}", e)) // Changed from LambdaError
+        .map_err(|_| anyhow::anyhow!("Failed to decode protobuf payload")) // Changed from LambdaError
 }
 
 /// Encodes an OTLP request to binary protobuf format (uncompressed)
@@ -31,6 +32,21 @@ pub enum CompressionPreference {
     None,
 }
 
+impl CompressionPreference {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Gzip => "gzip",
+            Self::None => "none",
+        }
+    }
+}
+
+impl fmt::Display for CompressionPreference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Configuration for span compaction
 #[derive(Debug, Clone)]
 pub struct SpanCompactionConfig {
@@ -42,17 +58,23 @@ pub struct SpanCompactionConfig {
 
 impl Default for SpanCompactionConfig {
     fn default() -> Self {
-        let compression_preference = env::var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
-            .or_else(|_| env::var("OTEL_EXPORTER_OTLP_COMPRESSION"))
-            .ok()
-            .map_or(CompressionPreference::None, |val| { // Default to None if var is not set
+        let compression_setting = env::var("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION")
+            .map(|val| ("OTEL_EXPORTER_OTLP_TRACES_COMPRESSION", val))
+            .or_else(|_| {
+                env::var("OTEL_EXPORTER_OTLP_COMPRESSION")
+                    .map(|val| ("OTEL_EXPORTER_OTLP_COMPRESSION", val))
+            })
+            .ok();
+
+        let compression_preference =
+            compression_setting.map_or(CompressionPreference::None, |(env_var, val)| {
                 match val.to_lowercase().as_str() {
                     "gzip" => CompressionPreference::Gzip,
                     "none" => CompressionPreference::None, // Explicitly none
-                    _ => { // Any other value, including empty string if var is set but empty, or invalid
+                    _ => {
                         tracing::warn!(
-                            "Invalid or unrecognized value for OTEL_EXPORTER_OTLP_COMPRESSION: '{}'. Defaulting to no compression.", 
-                            val
+                            env_var,
+                            "Invalid OTLP compression setting; defaulting to no compression"
                         );
                         CompressionPreference::None
                     }
@@ -67,15 +89,17 @@ impl Default for SpanCompactionConfig {
                     Ok(level) if (0..=9).contains(&level) => Some(level),
                     Ok(_) => {
                         tracing::warn!(
-                            "Invalid value for OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL: '{}'. Must be between 0 and 9. Defaulting to {}.",
-                            val_str, default_compression_level
+                            env_var = "OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL",
+                            default_compression_level,
+                            "Invalid OTLP compression level; defaulting to configured fallback"
                         );
                         None // Will cause fallback to default_compression_level
                     }
                     Err(_) => {
                         tracing::warn!(
-                            "Failed to parse OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL: '{}'. Defaulting to {}.",
-                            val_str, default_compression_level
+                            env_var = "OTEL_EXPORTER_OTLP_COMPRESSION_LEVEL",
+                            default_compression_level,
+                            "Failed to parse OTLP compression level; defaulting to configured fallback"
                         );
                         None // Will cause fallback to default_compression_level
                     }
@@ -93,7 +117,14 @@ impl Default for SpanCompactionConfig {
 /// Compacts multiple telemetry payloads into a single payload
 /// Since all log events in a single Lambda invocation come from the same log group,
 /// we can assume they all have the same metadata (source, endpoint, headers)
-#[instrument(name="span_compactor/compact_telemetry_payloads", skip_all, fields(compact_telemetry_payloads.records.count = batch.len() as i64, compression = ?config.compression))]
+#[instrument(
+    name = "span_compactor/compact_telemetry_payloads",
+    skip_all,
+    fields(
+        compact_telemetry_payloads.records.count = batch.len() as i64,
+        requested_compression = %config.compression
+    )
+)]
 pub fn compact_telemetry_payloads(
     batch: Vec<TelemetryData>,
     config: &SpanCompactionConfig,
@@ -116,7 +147,7 @@ pub fn compact_telemetry_payloads(
                 // but our contract is that input TelemetryData here is uncompressed.
                 telemetry_to_return
                     .compress(config.gzip_compression_level)
-                    .map_err(|e| anyhow::anyhow!("Failed to compress single payload: {}", e))?;
+                    .map_err(|_| anyhow::anyhow!("Failed to compress single payload"))?;
             }
             CompressionPreference::None => {
                 // Ensure content_encoding is None. Payload is already uncompressed per contract.
@@ -138,11 +169,8 @@ pub fn compact_telemetry_payloads(
         // Consume batch
         match decode_otlp_payload(&telemetry_item.payload) {
             Ok(request) => decoded_requests.push(request),
-            Err(e) => {
-                tracing::warn!(
-                    "Failed to decode TelemetryData payload for compaction: {}. Skipping item.",
-                    e
-                );
+            Err(_) => {
+                tracing::warn!("Failed to decode telemetry payload for compaction; skipping item");
             }
         }
     }
@@ -176,7 +204,7 @@ pub fn compact_telemetry_payloads(
         CompressionPreference::Gzip => {
             result_telemetry_data
                 .compress(config.gzip_compression_level)
-                .map_err(|e| anyhow::anyhow!("Failed to compress merged payload: {}", e))?;
+                .map_err(|_| anyhow::anyhow!("Failed to compress merged payload"))?;
         }
         CompressionPreference::None => {
             // Ensure content_encoding is None (already set as default if not compressed)
@@ -185,9 +213,12 @@ pub fn compact_telemetry_payloads(
     }
 
     tracing::info!(
-        "Compacted {} telemetry items into a single request. Final compression: {:?}.",
-        original_count,
-        result_telemetry_data.content_encoding
+        compact_telemetry_payloads.records.count = original_count as i64,
+        compression = result_telemetry_data
+            .content_encoding
+            .as_deref()
+            .unwrap_or("none"),
+        "Compacted telemetry items"
     );
     Ok(result_telemetry_data)
 }
@@ -199,7 +230,84 @@ mod tests {
     use flate2::read::GzDecoder;
     use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
     use serial_test::serial;
+    use std::collections::BTreeMap;
+    use std::fmt::Debug;
     use std::io::Read; // For tests that modify environment variables
+    use std::sync::{Arc, Mutex};
+    use tracing::{
+        field::{Field, Visit},
+        Event, Subscriber,
+    };
+    use tracing_subscriber::{
+        layer::{Context, Layer},
+        prelude::*,
+        registry::Registry,
+    };
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct CapturedEvent {
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Debug, Default)]
+    struct EventFieldVisitor {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for EventFieldVisitor {
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct EventCaptureLayer {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl EventCaptureLayer {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn events(&self) -> Arc<Mutex<Vec<CapturedEvent>>> {
+            Arc::clone(&self.events)
+        }
+    }
+
+    impl<S> Layer<S> for EventCaptureLayer
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = EventFieldVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().unwrap().push(CapturedEvent {
+                fields: visitor.fields,
+            });
+        }
+    }
 
     // Helper function to create a test ExportTraceServiceRequest with a specified number of spans
     fn create_test_request(span_count: usize) -> ExportTraceServiceRequest {
@@ -435,6 +543,57 @@ mod tests {
                 + decoded_request.resource_spans[1].scope_spans[0].spans.len(),
             5
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_compaction_emits_low_cardinality_event() {
+        let telemetry1 = create_test_telemetry_uncompressed(2, "s1");
+        let telemetry2 = create_test_telemetry_uncompressed(3, "s2");
+        let config = SpanCompactionConfig {
+            compression: CompressionPreference::Gzip,
+            gzip_compression_level: 9,
+        };
+        let capture_layer = EventCaptureLayer::new();
+        let captured_events = capture_layer.events();
+        let subscriber = Registry::default().with(capture_layer);
+
+        let result = tracing::subscriber::with_default(subscriber, || {
+            compact_telemetry_payloads(vec![telemetry1, telemetry2], &config)
+        })
+        .unwrap();
+
+        assert_eq!(result.content_encoding.as_deref(), Some("gzip"));
+
+        let events = captured_events.lock().unwrap();
+        let compaction_event = events
+            .iter()
+            .find(|event| {
+                event
+                    .fields
+                    .get("message")
+                    .is_some_and(|message| message.contains("Compacted telemetry items"))
+            })
+            .unwrap_or_else(|| panic!("expected compaction event to be emitted, got {events:#?}"));
+
+        assert_eq!(
+            compaction_event
+                .fields
+                .get("compact_telemetry_payloads.records.count")
+                .map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(
+            compaction_event
+                .fields
+                .get("compression")
+                .map(String::as_str),
+            Some("gzip")
+        );
+        assert!(compaction_event
+            .fields
+            .values()
+            .all(|value| !value.contains("Some(")));
     }
 
     #[test]

--- a/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/span_compactor.rs
@@ -227,87 +227,12 @@ pub fn compact_telemetry_payloads(
 mod tests {
     use super::*;
     use crate::telemetry::TelemetryData; // Ensure TelemetryData is in scope for tests
+    use crate::tracing_capture::EventCaptureLayer;
     use flate2::read::GzDecoder;
     use opentelemetry_proto::tonic::trace::v1::{ResourceSpans, ScopeSpans, Span};
     use serial_test::serial;
-    use std::collections::BTreeMap;
-    use std::fmt::Debug;
     use std::io::Read; // For tests that modify environment variables
-    use std::sync::{Arc, Mutex};
-    use tracing::{
-        field::{Field, Visit},
-        Event, Subscriber,
-    };
-    use tracing_subscriber::{
-        layer::{Context, Layer},
-        prelude::*,
-        registry::Registry,
-    };
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    struct CapturedEvent {
-        fields: BTreeMap<String, String>,
-    }
-
-    #[derive(Debug, Default)]
-    struct EventFieldVisitor {
-        fields: BTreeMap<String, String>,
-    }
-
-    impl Visit for EventFieldVisitor {
-        fn record_i64(&mut self, field: &Field, value: i64) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_u64(&mut self, field: &Field, value: u64) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_bool(&mut self, field: &Field, value: bool) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_str(&mut self, field: &Field, value: &str) {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
-
-        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
-            self.fields
-                .insert(field.name().to_string(), format!("{value:?}"));
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct EventCaptureLayer {
-        events: Arc<Mutex<Vec<CapturedEvent>>>,
-    }
-
-    impl EventCaptureLayer {
-        fn new() -> Self {
-            Self::default()
-        }
-
-        fn events(&self) -> Arc<Mutex<Vec<CapturedEvent>>> {
-            Arc::clone(&self.events)
-        }
-    }
-
-    impl<S> Layer<S> for EventCaptureLayer
-    where
-        S: Subscriber,
-    {
-        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-            let mut visitor = EventFieldVisitor::default();
-            event.record(&mut visitor);
-            self.events.lock().unwrap().push(CapturedEvent {
-                fields: visitor.fields,
-            });
-        }
-    }
+    use tracing_subscriber::{prelude::*, registry::Registry};
 
     // Helper function to create a test ExportTraceServiceRequest with a specified number of spans
     fn create_test_request(span_count: usize) -> ExportTraceServiceRequest {

--- a/packages/rust/serverless-otlp-forwarder-core/src/telemetry.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/telemetry.rs
@@ -56,9 +56,9 @@ impl TelemetryData {
         content_encoding: Option<&str>,
     ) -> Result<Vec<u8>> {
         tracing::debug!(
-            "Converting payload from {}/{:?} to protobuf",
-            content_type,
-            content_encoding
+            content_type = %content_type,
+            content_encoding = %content_encoding.unwrap_or("none"),
+            "Converting payload to protobuf"
         );
 
         // First, decompress if needed
@@ -88,7 +88,10 @@ impl TelemetryData {
             }
             _ => {
                 // Unknown format, log warning and return as-is
-                tracing::warn!("Unknown content type: {}, keeping as is", content_type);
+                tracing::warn!(
+                    content_type = %content_type,
+                    "Unknown content type; keeping payload as is"
+                );
                 Ok(decompressed)
             }
         }
@@ -108,8 +111,8 @@ impl TelemetryData {
         let protobuf_bytes = request.encode_to_vec();
 
         tracing::debug!(
-            "Successfully converted JSON to protobuf (size: {} bytes)",
-            protobuf_bytes.len()
+            payload_size_bytes = protobuf_bytes.len() as u64,
+            "Converted JSON to protobuf"
         );
 
         Ok(protobuf_bytes)
@@ -122,7 +125,7 @@ impl TelemetryData {
     pub fn compress(&mut self, compression_level: u32) -> Result<()> {
         // Only compress if not already compressed
         if self.content_encoding != Some("gzip".to_string()) {
-            tracing::debug!("Compressing payload with level {}", compression_level);
+            tracing::debug!(compression_level, "Compressing payload");
 
             let original_size = self.payload.len();
             let mut encoder = GzEncoder::new(Vec::new(), Compression::new(compression_level));
@@ -135,9 +138,9 @@ impl TelemetryData {
             self.content_encoding = Some("gzip".to_string());
 
             tracing::debug!(
-                "Compressed payload from {} to {} bytes",
-                original_size,
-                self.payload.len()
+                original_size_bytes = original_size as u64,
+                compressed_size_bytes = self.payload.len() as u64,
+                "Compressed payload"
             );
         }
 

--- a/packages/rust/serverless-otlp-forwarder-core/src/tracing_capture.rs
+++ b/packages/rust/serverless-otlp-forwarder-core/src/tracing_capture.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+use tracing::{
+    field::{Field, Visit},
+    Event, Subscriber,
+};
+use tracing_subscriber::layer::{Context, Layer};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CapturedEvent {
+    pub(crate) fields: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default)]
+struct EventFieldVisitor {
+    fields: BTreeMap<String, String>,
+}
+
+impl Visit for EventFieldVisitor {
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct EventCaptureLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl EventCaptureLayer {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn events(&self) -> Arc<Mutex<Vec<CapturedEvent>>> {
+        Arc::clone(&self.events)
+    }
+}
+
+impl<S> Layer<S> for EventCaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = EventFieldVisitor::default();
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(CapturedEvent {
+            fields: visitor.fields,
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize emitted tracing/logging in serverless-otlp-forwarder-core so raw headers, URLs, response bodies, source identifiers, and upstream error strings are not emitted
- replace high-cardinality messages with static event names plus allowlisted fields such as counts, status codes, sizes, compression, and timeout metadata
- bump serverless-otlp-forwarder-core to 0.2.1 and update the workspace dependency, crate README examples, and changelog

## Testing
- cargo fmt --package serverless-otlp-forwarder-core --check
- cargo clippy -p serverless-otlp-forwarder-core -- -D warnings
- cargo test -p serverless-otlp-forwarder-core