### PR TITLE
fix: unblock core crate publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,7 +4308,6 @@ dependencies = [
  "bytes",
  "flate2",
  "http 1.3.1",
- "lambda-otel-lite",
  "lambda_runtime",
  "opentelemetry-proto",
  "otlp-stdout-span-exporter 0.17.1",

--- a/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
+++ b/packages/rust/serverless-otlp-forwarder-core/Cargo.toml
@@ -50,7 +50,6 @@ tracing-subscriber = { workspace = true }
 
 # for doctests
 aws_lambda_events = { workspace = true, features = ["cloudwatch_logs"] }
-lambda-otel-lite = { workspace = true }
 lambda_runtime = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary
- remove the unused `lambda-otel-lite` dev-dependency from `serverless-otlp-forwarder-core`
- refresh `Cargo.lock` so the crate publish graph no longer pulls incompatible `otlp-stdout-span-exporter` versions

## CI failure
- failed job: https://github.com/dev7a/serverless-otlp-forwarder/actions/runs/24867678292/job/72807403999
- root cause: `cargo publish` resolved `serverless-otlp-forwarder-core v0.2.1` with `otlp-stdout-span-exporter ^0.17.1`, while the unused `lambda-otel-lite v0.19.0` dev dependency pulled the published crate graph locked to `otlp-stdout-span-exporter 0.17.0`

## Verification
- `cargo package -p serverless-otlp-forwarder-core --allow-dirty`
- `cargo fmt --package serverless-otlp-forwarder-core --check`
- `cargo clippy -p serverless-otlp-forwarder-core -- -D warnings`
- `cargo test -p serverless-otlp-forwarder-core`

No workflow files were changed.