### PR TITLE
release: rust/lambda-otel-lite v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "lambda-otel-lite"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "aws_lambda_events",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
  "opentelemetry-aws",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.0",
+ "otlp-stdout-span-exporter",
  "pin-project",
  "rand 0.9.1",
  "reqwest 0.12.20",
@@ -2454,7 +2454,7 @@ dependencies = [
  "lambda_runtime",
  "opentelemetry",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.1",
+ "otlp-stdout-span-exporter",
  "rand 0.9.1",
  "serde_json",
  "tokio",
@@ -2582,7 +2582,7 @@ dependencies = [
  "indexmap 2.10.0",
  "indicatif",
  "opentelemetry-proto",
- "otlp-stdout-span-exporter 0.17.1",
+ "otlp-stdout-span-exporter",
  "prost",
  "regex",
  "reqwest 0.12.20",
@@ -2974,7 +2974,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.1",
+ "otlp-stdout-span-exporter",
  "prost",
  "rand 0.9.1",
  "serde",
@@ -2999,7 +2999,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.1",
+ "otlp-stdout-span-exporter",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-tracing",
@@ -3025,7 +3025,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "otlp-stdout-span-exporter 0.17.1",
+ "otlp-stdout-span-exporter",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-tracing",
@@ -3035,28 +3035,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "otlp-stdout-span-exporter"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dfe96600efcd63f3110103c11f91e8200d9d707079cf052c17c17d2ce5594d9"
-dependencies = [
- "async-trait",
- "base64 0.22.1",
- "bon",
- "doc-comment",
- "flate2",
- "log",
- "nix",
- "opentelemetry",
- "opentelemetry-proto",
- "opentelemetry_sdk",
- "prost",
- "serde",
- "serde_json",
- "tokio",
 ]
 
 [[package]]
@@ -4310,7 +4288,7 @@ dependencies = [
  "http 1.3.1",
  "lambda_runtime",
  "opentelemetry-proto",
- "otlp-stdout-span-exporter 0.17.1",
+ "otlp-stdout-span-exporter",
  "prost",
  "reqwest 0.12.20",
  "reqwest 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lambda-lw-http-router = { version = "0.6.0", path = "packages/rust/lambda-lw-htt
 lambda-lw-http-router-core = { version = "0.6.0", path = "packages/rust/lambda-lw-http-router/router-core" }
 lambda-lw-http-router-macro = { version = "0.6.0", path = "packages/rust/lambda-lw-http-router/router-macro" }
 otlp-stdout-span-exporter = { version = "0.17.1", path = "packages/rust/otlp-stdout-span-exporter" }
-lambda-otel-lite = { version = "0.19.0", path = "packages/rust/lambda-otel-lite" }
+lambda-otel-lite = { version = "0.19.1", path = "packages/rust/lambda-otel-lite" }
 otlp-stdout-logs-processor = { path = "forwarders/otlp-stdout-logs-processor/processor" }
 serverless-otlp-forwarder-core = { version = "0.2.1", path = "packages/rust/serverless-otlp-forwarder-core" }
 

--- a/packages/rust/lambda-otel-lite/CHANGELOG.md
+++ b/packages/rust/lambda-otel-lite/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-04-24
+
+### Changed
+- Updated `otlp-stdout-span-exporter` to `0.17.1` through the workspace dependency.
+
 ## [0.19.0] - 2026-03-30
 
 ### Changed

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -14,8 +14,7 @@ categories = ["development-tools::debugging", "web-programming::http-server"]
 exclude = ["examples/"]
 
 [dependencies]
-# pin to specific version for publishing
-otlp-stdout-span-exporter = "0.17.0"
+otlp-stdout-span-exporter.workspace = true
 
 opentelemetry = { version = "0.31.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }

--- a/packages/rust/lambda-otel-lite/Cargo.toml
+++ b/packages/rust/lambda-otel-lite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lambda-otel-lite"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/packages/rust/lambda-otel-lite/PUBLISHING.md
+++ b/packages/rust/lambda-otel-lite/PUBLISHING.md
@@ -13,7 +13,7 @@ Before publishing a new version of `lambda-otel-lite`, ensure all these items ar
 - [ ] `homepage` URL is valid
 - [ ] `documentation` URL is specified
 - [ ] Dependencies are up-to-date and correct
-- [ ] Validate that otlp-stdout-span-exporter is not just using the workspace version, but is pinned to the last version
+- [ ] Validate that `otlp-stdout-span-exporter` resolves to the intended published version, either as an explicit version or via a workspace dependency that includes `version`
 - [ ] No extraneous dependencies
 - [ ] Development dependencies are in `[dev-dependencies]`
 - [ ] Feature flags are correctly defined
@@ -101,4 +101,4 @@ Before publishing a new version of `lambda-otel-lite`, ensure all these items ar
 - Consider running `cargo audit` for security vulnerabilities
 - Use `cargo clippy` with all relevant feature combinations
 - Remember to update any related documentation or examples in the main repository
-- Consider testing on different architectures (x86_64, aarch64) 
+- Consider testing on different architectures (x86_64, aarch64)


### PR DESCRIPTION
## Summary
- bump `lambda-otel-lite` to `0.19.1`
- resolve `otlp-stdout-span-exporter` through the workspace at `0.17.1`
- prune the stale registry `otlp-stdout-span-exporter 0.17.0` lockfile entry
- update the changelog and publishing checklist for the workspace-version publish pattern

## Why
`lambda-otel-lite` was the only remaining manifest edge requesting `otlp-stdout-span-exporter 0.17.0`. The package now resolves the exporter through the workspace dependency, and Cargo normalizes that to an explicit `0.17.1` registry dependency during packaging.

## Verification
- `cargo metadata --format-version 1 --no-deps`
- `cargo check -p lambda-otel-lite --all-targets`
- `cargo fmt --package lambda-otel-lite --check`
- `cargo clippy -p lambda-otel-lite -- -D warnings`
- `cargo package -p lambda-otel-lite --allow-dirty`
- `cargo test -p lambda-otel-lite`

Packaged manifest check: `target/package/lambda-otel-lite-0.19.1/Cargo.toml` normalizes `otlp-stdout-span-exporter` to `version = "0.17.1"`.